### PR TITLE
Add Ember-Data model for app, database

### DIFF
--- a/app/app/model.js
+++ b/app/app/model.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  handle: DS.attr('string')
+});

--- a/app/application/adapter.js
+++ b/app/application/adapter.js
@@ -1,0 +1,13 @@
+import config from "../config/environment";
+import HalAdapter from "ember-data-hal-9000/adapter";
+
+export var auth = {};
+
+export default HalAdapter.extend({
+  host: config.apiBaseUri,
+  headers: function(){
+    return {
+      'Authorization': 'Bearer ' + auth.token
+    };
+  }.property().volatile()
+});

--- a/app/application/serializer.js
+++ b/app/application/serializer.js
@@ -1,0 +1,3 @@
+import HalSerializer from "ember-data-hal-9000/serializer";
+
+export default HalSerializer.extend();

--- a/app/apps/index/route.js
+++ b/app/apps/index/route.js
@@ -2,9 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   model: function(){
-    return [
-      {handle:'app1', id: 'app1'},
-      {handle:'app2', id: 'app2'}
-    ];
+    return this.store.find('app');
   }
 });

--- a/app/aptible/torii-adapter.js
+++ b/app/aptible/torii-adapter.js
@@ -3,6 +3,7 @@ import storage from '../utils/storage';
 import config from "../config/environment";
 import ajax from "../utils/ajax";
 import JWT from '../utils/jwt';
+import { auth } from '../application/adapter';
 
 export default Ember.Object.extend({
   fetch: function(){
@@ -17,6 +18,7 @@ export default Ember.Object.extend({
         throw new Error('Token not found');
       }
     }).then(function(token){
+      auth.token = token;
       var jwt = JWT.create({token:token});
       return jwt.get('payload');
     }).then(function(payload){
@@ -27,6 +29,7 @@ export default Ember.Object.extend({
         }
       });
     }).catch(function(e){
+      delete auth.token;
       storage.remove(config.authTokenKey);
       throw e;
     });
@@ -34,6 +37,7 @@ export default Ember.Object.extend({
 
   open: function(tokenResponse){
     return new Ember.RSVP.Promise(function(resolve){
+      auth.token = tokenResponse.access_token;
       storage.write(config.authTokenKey, tokenResponse.access_token);
       resolve();
     });

--- a/app/database/model.js
+++ b/app/database/model.js
@@ -1,0 +1,4 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+});

--- a/config/environment.js
+++ b/config/environment.js
@@ -55,6 +55,8 @@ module.exports = function(environment) {
     ENV.APP.rootElement = '#ember-testing';
 
     ENV.authTokenKey = '_aptible_authToken-test';
+
+    delete ENV.apiBaseUri;
   }
 
   if (environment === 'production') {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.1.0",
     "ember-data": "1.0.0-beta.10",
+    "ember-data-hal-9000": "git://github.com/201-created/ember-data-hal-9000#f8f00635d33a39b38689e4ccb5f44dc4b56744f4",
     "ember-export-application-global": "^1.0.0",
     "express": "^4.8.5",
     "glob": "^4.0.5",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -48,7 +48,8 @@
     "signIn",
     "signInAndVisit",
     "equalElementText",
-    "elementTextContains"
+    "elementTextContains",
+    "stubApps"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/apps-test.js
+++ b/tests/acceptance/apps-test.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import Pretender from 'pretender';
 
-var App;
+var App, server;
 
 module('Acceptance: Apps', {
   setup: function() {
@@ -9,6 +10,9 @@ module('Acceptance: Apps', {
   },
   teardown: function() {
     Ember.run(App, 'destroy');
+    if (server) {
+      server.shutdown();
+    }
   }
 });
 
@@ -21,6 +25,9 @@ test('visiting /apps when not signed in', function() {
 });
 
 test('visiting /apps', function() {
+  server = new Pretender(function(){
+    stubApps(this);
+  });
   signInAndVisit('/apps');
 
   andThen(function() {
@@ -29,6 +36,9 @@ test('visiting /apps', function() {
 });
 
 test('visiting /apps shows list of apps', function() {
+  server = new Pretender(function(){
+    stubApps(this);
+  });
   signInAndVisit('/apps');
 
   andThen(function() {
@@ -38,6 +48,9 @@ test('visiting /apps shows list of apps', function() {
 });
 
 test('visiting /apps then clicking on an app visits the app', function() {
+  server = new Pretender(function(){
+    stubApps(this);
+  });
   signInAndVisit('/apps');
   click('.app-link');
   andThen(function(){
@@ -46,6 +59,9 @@ test('visiting /apps then clicking on an app visits the app', function() {
 });
 
 test('visiting /apps/my-app shows the app', function() {
+  server = new Pretender(function(){
+    stubApps(this);
+  });
   signInAndVisit('/apps/my-app');
   andThen(function() {
     equal(currentPath(), 'apps.show', 'show page is visited');

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -62,6 +62,7 @@ test('logging in with correct credentials', function() {
   var password = 'correct';
 
   server = new Pretender(function(){
+    stubApps(this);
     this.post('/tokens', function(request){
       var params = JSON.parse(request.requestBody);
       equal(params.username, email, 'correct email is passed');

--- a/tests/helpers/aptible-helpers.js
+++ b/tests/helpers/aptible-helpers.js
@@ -23,3 +23,26 @@ Ember.Test.registerHelper('elementTextContains', function(app, node, expectedTex
   ok( nodeText.indexOf(expectedText) !== -1,
       "Element's text did not match expected value, was: '"+nodeText+"'" );
 });
+
+Ember.Test.registerHelper('stubApps', function(app, server){
+  server.get('/apps', function(request){
+    return [200, {}, {
+      _links: {},
+      _embedded: {
+        apps: [{
+          _links: {
+            self: { href: '...' }
+          },
+          id: 1,
+          handle: 'my-app'
+        }, {
+          _links: {
+            self: { href: '...' }
+          },
+          id: 2,
+          handle: 'my-app-2'
+        }]
+      }
+    }];
+  });
+});

--- a/tests/unit/models/app-test.js
+++ b/tests/unit/models/app-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('app', 'App', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function() {
+  var model = this.subject();
+  // var store = this.store();
+  ok(!!model);
+});

--- a/tests/unit/models/database-test.js
+++ b/tests/unit/models/database-test.js
@@ -1,0 +1,15 @@
+import {
+  moduleForModel,
+  test
+} from 'ember-qunit';
+
+moduleForModel('database', 'Database', {
+  // Specify the other units that are required for this test.
+  needs: []
+});
+
+test('it exists', function() {
+  var model = this.subject();
+  // var store = this.store();
+  ok(!!model);
+});

--- a/tests/unit/torii-adapters/aptible-test.js
+++ b/tests/unit/torii-adapters/aptible-test.js
@@ -4,6 +4,8 @@ import {
 } from 'ember-qunit';
 import config from "../../../config/environment";
 
+import { auth } from '../../../application/adapter';
+
 import storage from '../../../utils/storage';
 
 var originalWrite, originalRead;
@@ -29,10 +31,13 @@ test('adapter stores the auth token in storage', function(){
     wroteVal = val;
   };
 
+  ok(!auth.token, 'precond - no auth.token');
+
   adapter.open({ access_token: token }).then(function(){
     ok(true, 'session is opened with an auth_token');
     equal(wroteKey, config.authTokenKey, 'writes to config.authTokenKey');
     equal(wroteVal, token, 'writes token value');
+    equal(auth.token, token, 'sets token on auth');
   }, function(e){
     ok(false, "Unexpected error: "+e);
   });


### PR DESCRIPTION
Introduce Ember-Data and list apps, databases on their pages. Since Aptible's API is fairly strict about HAL, we've kicked off the adapter as a stand-alone library:

https://github.com/201-created/ember-data-hal-9000
