### PR TITLE
Use bootstrap-sass official from GitHub

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,7 +3,7 @@
 var EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 var app = new EmberApp({
-  emberCliFontAwesome: { includeFontAwesomeAssets: false }
+  emberCliFontAwesome: { includeFontAwesomeAssets: false },
 });
 
 app.import('bower_components/nouislider/src/jquery.nouislider.css');

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "nouislider": "~7.0.9",
     "font-awesome": "~4.2.0",
     "pretender": "0.3.1",
-    "JavaScript-MD5": "~1.1.0"
+    "JavaScript-MD5": "~1.1.0",
+    "bootstrap-sass": "twbs/bootstrap-sass#3.3.1"
   },
   "resolutions": {
     "ember-data": "1.0.0-beta.11",

--- a/lib/bootstrap-sass/index.js
+++ b/lib/bootstrap-sass/index.js
@@ -1,0 +1,29 @@
+var path = require('path');
+
+module.exports = {
+  name: "bootstrap-sass",
+  included: function included(app) {
+    if (!app.options.sassOptions) {
+      app.options.sassOptions = {
+        includePaths: []
+      }
+    }
+
+    app.options.sassOptions.includePaths.push(
+      'bower_components/bootstrap-sass/assets/stylesheets'
+    )
+
+    app.import("bower_components/bootstrap-sass/assets/fonts/bootstrap/glyphicons-halflings-regular.eot", { destDir: "fonts/bootstrap" });
+    app.import("bower_components/bootstrap-sass/assets/fonts/bootstrap/glyphicons-halflings-regular.svg", { destDir: "fonts/bootstrap" });
+    app.import("bower_components/bootstrap-sass/assets/fonts/bootstrap/glyphicons-halflings-regular.ttf", { destDir: "fonts/bootstrap" });
+    app.import("bower_components/bootstrap-sass/assets/fonts/bootstrap/glyphicons-halflings-regular.woff", { destDir: "fonts/bootstrap" });
+
+  },
+  treeFor: function(name){
+    if (name === 'styles') {
+      return this.treeGenerator(
+        path.join(__dirname, '../../bower_components/bootstrap-sass/assets/stylesheets')
+      );
+    }
+  }
+};

--- a/lib/bootstrap-sass/package.json
+++ b/lib/bootstrap-sass/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bootstrap-sass",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "broccoli-sass": "^0.3.3",
     "ember-cli": "0.1.2",
-    "ember-cli-bootstrap-sass": "^0.2.8",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-font-awesome": "0.0.4",
     "ember-cli-gravatar": "^1.2.1",
@@ -37,5 +36,10 @@
     "express": "^4.8.5",
     "glob": "^4.0.5",
     "torii": "^0.2.2"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/bootstrap-sass"
+    ]
   }
 }


### PR DESCRIPTION
@bantic for you to review/merge.

It turns out ember-cli-bootstrap-sass has some ugly Ember code it wants to import. The code does crazy stuff, like want to do client-side compilation of templates. Yuck.

This uses an in-repo-addon to manage the sass instead, and directly references Twitter's repo for bootstrap on GitHub

/cc @sandersonet 
