### PR TITLE
Provide actual created_at date for user traits

### DIFF
--- a/app/aptible/torii-adapter.js
+++ b/app/aptible/torii-adapter.js
@@ -90,7 +90,8 @@ export default Ember.Object.extend({
     this.get('analytics').identify(user.get('id'), {
       email: email,
       id: user.get('id'),
-      name: user.get('name')
+      name: user.get('name'),
+      createdAt: user.get('createdAt')
     });
   }
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -8,6 +8,7 @@ export default DS.Model.extend({
   username: DS.attr('string'),
   password: DS.attr('string'),
   verified: DS.attr('boolean'),
+  createdAt: DS.attr('date'),
 
   // used when changing a user's password. Set as an `attr` so that it
   // will be sent to the API

--- a/app/services/analytics.js
+++ b/app/services/analytics.js
@@ -131,5 +131,4 @@ export default Ember.Service.extend({
       window.analytics.page(name, Ember.run.bind(null, resolve));
     });
   }
-
 });


### PR DESCRIPTION
Intercom is currently defaulting all user's created_at attributes to the day they first were identified in intercom.  For most users, this isn't actually when their account was created, but instead when they migrated from dashboard => diesel.  This fix will sync up the intercom created_at attribute to match the user's actual created_at.
