### PR TITLE
Use query param to define plan

### DIFF
--- a/app/components/app-setup-description/component.js
+++ b/app/components/app-setup-description/component.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  isDevelopment: Ember.computed.equal('plan', 'development'),
+  isPlatform: Ember.computed.equal('plan', 'platform')
+});

--- a/app/components/app-setup-description/template.hbs
+++ b/app/components/app-setup-description/template.hbs
@@ -1,0 +1,54 @@
+{{#if isDevelopment}}
+  <div class="welcome-info">
+    <section class="welcome-section">
+      <h2>Your First Development App</h2>
+
+      <p>
+        Aptible Development environments are deployed into a shared environment that is perfect for staging and development.  There is no upfront cost, just pay for the resources you use.
+      </p>
+    </section>
+
+    <section class="welcome-section">
+      <h4>Create an app to run your code</h4>
+
+      <p>
+        Aptible is language- and framework-agnostic. If it runs on Linux, it runs on Aptible.
+      </p>
+    </section>
+
+    <section class="welcome-section">
+      <h4>Create a database for your app</h4>
+
+      <p>
+        Databases are further isolated in a private subnet, addressable only from within the network, and accessible only to the account's own apps, or via authenticated tunnel.
+      </p>
+    </section>
+  </div>
+{{/if}}
+
+{{#if isPlatform}}
+  <div class="welcome-info">
+    <section class="welcome-section">
+      <h2>Your own PHI-ready environment</h2>
+      <p>
+        Each Aptible Platform Environment's resources are deployed into an isolated network of dedicated instances. Access to and from applications is strictly controlled and logged for auditing.
+      </p>
+    </section>
+
+    <section class="welcome-section">
+      <h4>Create an app to run your code</h4>
+
+      <p>
+        Aptible is language- and framework-agnostic. If it runs on Linux, it runs on Aptible.
+      </p>
+    </section>
+
+    <section class="welcome-section">
+      <h4>Create a database to store PHI</h4>
+
+      <p>
+        Databases are further isolated in a private subnet, addressable only from within the network, and accessible only to the account's own apps, or via authenticated tunnel.
+      </p>
+    </section>
+  </div>
+{{/if}}

--- a/app/components/pricing-page-header/template.hbs
+++ b/app/components/pricing-page-header/template.hbs
@@ -1,5 +1,5 @@
 {{#if isDevelopment}}
-  <h1>Add a Payment Method to Your<br /> Pay-as-you-go Development Plan</h1>
+  <h1>Add a Payment Method to Your Pay-as-you-go Development Plan</h1>
 {{/if}}
 {{#if isPlatform}}
   <h1>Add a Payment Method to Your PHI-ready Platform Plan</h1>

--- a/app/mixins/routes/signup.js
+++ b/app/mixins/routes/signup.js
@@ -5,6 +5,7 @@ export default Ember.Mixin.create({
   actions: {
     signup: function(user, organization){
       let {email, password} = user.getProperties('email', 'password');
+      let plan = this.get('controller.plan') || 'development';
 
       user.save().then(() => {
         let credentials = buildCredentials(email, password);
@@ -14,7 +15,7 @@ export default Ember.Mixin.create({
         if (organization) {
           // standard signup flow, create organization at the same time
           return organization.save().then(() => {
-            this.transitionTo('welcome.first-app');
+            this.transitionTo('welcome.first-app', { queryParams: { plan: plan }});
           });
         } else {
           // accepting invitation, redirect to accept page

--- a/app/signup/index/controller.js
+++ b/app/signup/index/controller.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 import SignupControllerMixin from "diesel/mixins/controllers/signup";
 
-export default Ember.Controller.extend(SignupControllerMixin);
+export default Ember.Controller.extend(SignupControllerMixin, {
+  queryParams: ['plan'],
+  plan: null
+});

--- a/app/signup/index/route.js
+++ b/app/signup/index/route.js
@@ -3,6 +3,9 @@ import DisallowAuthenticated from "diesel/mixins/routes/disallow-authenticated";
 import SignupRouteMixin from "diesel/mixins/routes/signup";
 
 export default Ember.Route.extend(DisallowAuthenticated, SignupRouteMixin, {
+  queryParams: {
+    plan: { }
+  },
   setupController: function(controller){
     let user = this.store.createRecord('user');
     let organization = this.store.createRecord('organization');

--- a/app/styles/specific_resources/databases.scss
+++ b/app/styles/specific_resources/databases.scss
@@ -28,6 +28,7 @@
 
 
 .select-options-container {
+  margin-bottom: -10px;
   $option-margin: 10px;
 
   &.row {

--- a/app/styles/specific_resources/welcome.scss
+++ b/app/styles/specific_resources/welcome.scss
@@ -1,12 +1,13 @@
 .container.focus {
   .page-header {
     margin: 50px 0;
+    padding: 0;
 
     h1 {
+      text-transform: capitalize;
       line-height: 39px;
       font-size: 26px;
       margin: 0 auto;
-      max-width: 500px;
     }
   }
 }

--- a/app/welcome/controller.js
+++ b/app/welcome/controller.js
@@ -1,0 +1,8 @@
+import Ember from "ember";
+
+export default Ember.Controller.extend({
+  queryParams: ['plan'],
+  plan: null,
+  planBinding: 'model.plan'
+});
+

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>Create Your Production Environment</h1>
+  <h1>Create Your Aptible {{model.plan}} Environment</h1>
 </div>
 
 <div class="signup-form create-first-app">
@@ -104,30 +104,13 @@
     </div>
 
     <div class="col-xs-5">
-      <div class="welcome-info">
-        <section class="welcome-section">
-          <h2>Your own private environment</h2>
-          <p>
-            Each Aptible Production Account's resources are deployed into an isolated network of dedicated instances. Access to and from applications is strictly controlled and logged for auditing.
-          </p>
-        </section>
+      {{app-setup-description plan=model.plan}}
+    </div>
+  </div>
 
-        <section class="welcome-section">
-          <h4>Create an app to run your code</h4>
-
-          <p>
-            Aptible is language- and framework-agnostic. If it runs on Linux, it runs on Aptible.
-          </p>
-        </section>
-
-        <section class="welcome-section">
-          <h4>Create a database to store PHI</h4>
-
-          <p>
-            Databases are further isolated in a private subnet, addressable only from within the network, and accessible only to the account's own apps, or via authenticated tunnel.
-          </p>
-        </section>
-      </div>
+  <div class="row">
+    <div class="col-xs-10 col-xs-offset-1">
+      {{change-plan value=model.plan}}
     </div>
   </div>
 

--- a/app/welcome/payment-info/route.js
+++ b/app/welcome/payment-info/route.js
@@ -3,14 +3,6 @@ import { createStripeToken } from '../../utils/stripe';
 import { provisionDatabases } from '../../models/database';
 
 export default Ember.Route.extend({
-  model: function() {
-    return {
-      // TODO: should come from the link they click
-      // on the sales site to visit the signup flow
-      plan: 'development'
-    };
-  },
-
   setupController: function(controller, model) {
     controller.set('model', model);
     var firstApp = this.modelFor('welcome');
@@ -47,7 +39,7 @@ export default Ember.Route.extend({
         saveProgress.set('currentStep', 2);
         organization = result.organizations.objectAt(0);
         var subscription = store.createRecord('subscription', {
-          plan: model.plan,
+          plan: welcomeModel.plan,
           stripeToken: result.stripeResponse.id,
           organization: organization
         });

--- a/app/welcome/payment-info/template.hbs
+++ b/app/welcome/payment-info/template.hbs
@@ -1,5 +1,5 @@
 {{#save-progress progress=saveProgress progressMessage="Provisioning your new environment..."}}
-  {{pricing-page-header plan=model.plan}}
+  {{pricing-page-header plan=firstApp.plan}}
   <div class="signup-form payment-information">
     <div class="row">
       <div class="col-xs-5 col-xs-offset-1">
@@ -44,14 +44,14 @@
       </div>
       <div class="col-xs-5">
         <div class="welcome-info">
-          {{plan-description app=firstApp plan=model.plan}}
+          {{plan-description app=firstApp plan=firstApp.plan}}
         </div>
       </div>
     </div>
 
     <div class="row">
       <div class="col-xs-10 col-xs-offset-1">
-        {{change-plan value=model.plan}}
+        {{change-plan value=firstApp.plan}}
       </div>
     </div>
 

--- a/app/welcome/route.js
+++ b/app/welcome/route.js
@@ -7,6 +7,9 @@ export function resetDBData(model){
 }
 
 export default Ember.Route.extend({
+  queryParams: {
+    plan: { }
+  },
   beforeModel: function(){
     if(this.session.get('isAuthenticated')) {
       return this.store.find('stack').then((stacks) => {
@@ -19,11 +22,18 @@ export default Ember.Route.extend({
     }
   },
 
-  model: function(){
-    return this.store.find('organization').then(function(organizations){
+  model: function(params){
+    return this.store.find('organization').then((organizations) => {
       let stackHandle = organizations.objectAt(0).get('name').dasherize();
+      let plan = params.plan || 'development';
+
+      if(plan === 'production') {
+        plan = 'platform';
+      }
+
       let model = {
-        stackHandle
+        stackHandle,
+        plan
       };
       resetDBData(model);
       return model;

--- a/tests/acceptance/signup/index-test.js
+++ b/tests/acceptance/signup/index-test.js
@@ -63,6 +63,57 @@ test('Creating an account directs to welcome wizard', function() {
   });
 });
 
+test('Signing up with a platform plan shows platform copy', function() {
+  // for loading information on the welcome.first-app screen
+  stubStacks({}, []);
+  stubOrganizations();
+  url = `${url}?plan=platform`;
+
+  stubRequest('post', '/organizations', function(request){
+    let params = this.json(request);
+    equal(params.name, userInput.organization, 'correct organization is passed');
+    return this.success({
+      id: 'my-organization',
+      name: userInput.organization
+    });
+  });
+
+  doSignupSteps(url, userInput, {clickButton:false});
+  fillInput('organization', userInput.organization);
+  clickButton('Create account');
+
+  andThen(function() {
+    equal(currentPath(), 'welcome.first-app', 'directs to first app');
+    ok(find(':contains(Create Your Aptible platform Environment)'));
+    ok(find(':contains(Create a database to store PHI)'));
+  });
+});
+
+test('Signing up with no plan shows development copy', function() {
+  // for loading information on the welcome.first-app screen
+  stubStacks({}, []);
+  stubOrganizations();
+
+  stubRequest('post', '/organizations', function(request){
+    let params = this.json(request);
+    equal(params.name, userInput.organization, 'correct organization is passed');
+    return this.success({
+      id: 'my-organization',
+      name: userInput.organization
+    });
+  });
+
+  doSignupSteps(url, userInput, {clickButton:false});
+  fillInput('organization', userInput.organization);
+  clickButton('Create account');
+
+  andThen(function() {
+    equal(currentPath(), 'welcome.first-app', 'directs to first app');
+    ok(find(':contains(Create Your Aptible development Environment)'));
+    ok(find(':contains(Create a database for your app)'));
+  });
+});
+
 test(`visiting ${url} and signing up with too-short organization name shows error`, function() {
   let tooShortOrganizationName = 'ba';
 

--- a/tests/unit/components/app-setup-description-test.js
+++ b/tests/unit/components/app-setup-description-test.js
@@ -1,0 +1,21 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+import Ember from 'ember';
+
+moduleForComponent('app-setup-description', 'AppSetupDescriptionComponent', {
+});
+
+test('it renders', function() {
+  expect(2);
+
+  // creates the component instance
+  var component = this.subject({});
+  equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.render();
+  equal(component._state, 'inDOM');
+});


### PR DESCRIPTION
This PR enables a query string param to be used to define the default plan when signing up.  If no plan is provided, a development plan is assumed.  The plan is used to determine which feature copy should appear and ultimately which plan the user will be signed up and charged for.

The query param is bound to the signup model, so toggling the plan in the UI will also update the query param.

@mixonic If you have time for a review, we would greatly appreciate it.

@samyount This fixes the issue of seeing production copy for development signup flow. Please review the copy included in this pull request and let me know if you see any issues. 