### PR TITLE
Billing plan

### DIFF
--- a/app/organization/billing/index/route.js
+++ b/app/organization/billing/index/route.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  redirect() {
+    this.transitionTo('organization.billing.plan');
+  }
+});

--- a/app/organization/billing/plan/route.js
+++ b/app/organization/billing/plan/route.js
@@ -45,7 +45,7 @@ export default Ember.Route.extend({
                      Ember.get(e, 'responseJSON.message'));
       organization.rollback();
     }).finally(() => {
-      this.controller.set('isUpgrading', false);
+      controller.set('isUpgrading', false);
     });
   },
 

--- a/app/organization/billing/plan/route.js
+++ b/app/organization/billing/plan/route.js
@@ -1,0 +1,52 @@
+import Ember from 'ember';
+import { UPGRADE_PLAN_REQUEST_EVENT } from 'diesel/models/organization';
+
+export default Ember.Route.extend({
+  analytics: Ember.inject.service(),
+  confirmationModal: Ember.inject.service(),
+
+  actions: {
+    upgrade(planType) {
+      this.get('confirmationModal').open({
+        partial: 'confirmation-modals/upgrade-plan',
+        onConfirm: () => this._upgradePlan(planType)
+      });
+    },
+
+    requestUpgrade() {
+      this._trackUpgradeRequest();
+
+      this.get('confirmationModal').open({
+        partial: 'confirmation-modals/request-plan-upgrade'
+      });
+    }
+  },
+
+  _trackUpgradeRequest() {
+      const organization = this.modelFor('organization');
+      const eventName = UPGRADE_PLAN_REQUEST_EVENT;
+      const eventAttributes = {
+        organization_id: organization.get('id'),
+        organization_name: organization.get('name')
+      };
+
+      this.get('analytics').track(eventName, eventAttributes);
+  },
+
+  _upgradePlan(planType) {
+    const organization = this.modelFor('organization');
+    const controller = this.controller;
+    organization.set('plan', planType);
+
+    controller.set('error', null);
+    controller.set('isUpgrading', true);
+    organization.save().catch((e) => {
+      controller.set('error',
+                     Ember.get(e, 'responseJSON.message'));
+      organization.rollback();
+    }).finally(() => {
+      this.controller.set('isUpgrading', false);
+    });
+  },
+
+});

--- a/app/organization/billing/plan/template.hbs
+++ b/app/organization/billing/plan/template.hbs
@@ -1,0 +1,154 @@
+{{#if error}}
+  {{#bs-alert alert="danger"}}
+    {{error}}
+  {{/bs-alert}}
+{{/if}}
+
+<div class="resource-list-grid">
+  <div class="row">
+    <div class="col-xs-4">
+      <div class='panel plan-panel {{if (eq model.plan "development") "active"}}'>
+        <div class="panel-heading"><h5>Development</h5></div>
+        <div class="panel-heading">
+          <div class='plan-cost'>
+            <span class='plan-cost-amount'>$0</span> per month
+          </div>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            Ideal for staging or development
+          </p>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            No commitment, pay month-to-month
+          </p>
+        </div>
+        <div class="panel-body">
+          <div class="plan-include">
+            0 Containers Included
+            <div class="plan-include-subheader">
+              $0.08/hour per container
+            </div>
+          </div>
+
+          <div class="plan-include">
+            0 GB Disk Storage Included
+            <div class="plan-include-subheader">
+              $0.0005/hour per GB
+            </div>
+          </div>
+
+          <div class="plan-include">
+            0 Domains Included
+            <div class="plan-include-subheader">
+              $0.005/hour per domain
+            </div>
+          </div>
+
+          {{#if (eq model.plan "development")}}
+            <button class='btn plan-btn current' disabled>
+              {{fa-icon "check" classNames="success"}}
+              Current Plan
+            </button>
+          {{else}}
+            <button class='btn plan-btn' disabled>Contact Support to downgrade</button>
+          {{/if}}
+        </div>
+      </div>
+    </div>
+
+    <div class="col-xs-4">
+      <div class='panel plan-panel {{if (eq model.plan "platform") "active"}}'>
+        <div class="panel-heading"><h5>Platform</h5></div>
+        <div class="panel-heading">
+          <div class='plan-cost'>
+            <span class='plan-cost-amount'>$499</span> per month
+          </div>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            HIPAA-compliant/PHI-ready private cloud
+          </p>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            Signed Business Associate Agreement
+          </p>
+        </div>
+        <div class="panel-body">
+          <div class="plan-include">
+            6 Containers Included
+            <div class="plan-include-subheader">
+              $0.08/hour per container
+            </div>
+          </div>
+
+          <div class="plan-include">
+            1024 GB Disk Storage Included
+            <div class="plan-include-subheader">
+              $0.0005/hour per GB
+            </div>
+          </div>
+
+          <div class="plan-include">
+            4 Domains Included
+            <div class="plan-include-subheader">
+              $0.05/hour per domain
+            </div>
+          </div>
+
+          {{#if isUpgrading}}
+            <button class='btn plan-btn' disabled>Upgrading...</button>
+          {{else}}
+            {{#if (eq model.plan "platform")}}
+              <button class='btn plan-btn current' disabled>
+                {{fa-icon "check" classNames="success"}}
+                Current Plan
+              </button>
+            {{else}}
+              <button class='btn plan-btn btn-primary' {{action 'upgrade' 'platform'}}>Upgrade to Platform</button>
+            {{/if}}
+          {{/if}}
+        </div>
+      </div>
+    </div>
+
+    <div class="col-xs-4">
+      <div class='panel plan-panel'>
+        <div class="panel-heading"><h5>HIPAA Compliance</h5></div>
+        <div class="panel-heading">
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            HIPAA-compliant/PHI-ready private cloud
+          </p>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            Signed Business Associate Agreement
+          </p>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            Managed HIPAA Compliance
+          </p>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            Dedicated HIPAA specialist
+          </p>
+          <p>
+            {{fa-icon "check" classNames="primary"}}
+            Risk, Policy, Security, Training Compliance Engines
+            and much more
+          </p>
+        </div>
+        <div class="panel-body">
+          <div class="plan-hero">
+            <div>
+              Contact us about managed HIPAA compliance
+            </div>
+          </div>
+          <button class="btn plan-btn btn-primary" {{action 'requestUpgrade'}}>
+            Ask about our HIPAA compliant plans
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+

--- a/app/organization/billing/template.hbs
+++ b/app/organization/billing/template.hbs
@@ -1,0 +1,12 @@
+<div class="layout-container">
+  <ul class='nav nav-pills resource-navigation'>
+    {{#activating-item currentWhen="organization.billing.plan" tagName="li"}}
+      {{link-to "Plan" "organization.billing.plan"}}
+    {{/activating-item}}
+    {{#activating-item currentWhen="organization.billing.payment-method" tagName="li"}}
+      {{link-to "Payment Method" "organization.billing.payment-method"}}
+    {{/activating-item}}
+  </ul>
+</div>
+
+{{outlet}}

--- a/app/organization/roles/index/controller.js
+++ b/app/organization/roles/index/controller.js
@@ -1,8 +1,7 @@
 import Ember from "ember";
 
 export default Ember.Controller.extend({
-
-  confirmationModalService: Ember.inject.service('confirmation-modal'),
+  confirmationModal: Ember.inject.service(),
 
   actions: {
     inviteTo(role) {
@@ -10,7 +9,7 @@ export default Ember.Controller.extend({
       this.transitionToRoute('organization.invite', organization, {queryParams: {role}});
     },
     delete(role) {
-      this.get('confirmationModalService').open({
+      this.get('confirmationModal').open({
         partial: 'confirmation-modals/delete-role',
         model: role,
         onConfirm: () => {

--- a/app/router.js
+++ b/app/router.js
@@ -82,6 +82,10 @@ export default Router.map(function() {
       this.route('environments', function() {
         this.route('new');
       });
+      this.route("billing", {}, function() {
+        this.route('plan');
+        this.route('payment-method');
+      });
     });
 
     this.route('settings', {

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,5 +1,7 @@
 @import "bower_components/aptible-sass/dist/styles/aptible";
 
+@import "billing-plans";
+
 @import "components/activate-notice";
 @import "components/button-with-confirmation";
 @import "components/change-plan";
@@ -27,4 +29,3 @@
 @import "components/verification-code-reset";
 @import "components/vhost-panel";
 @import "components/welcome";
-

--- a/app/styles/billing-plans.scss
+++ b/app/styles/billing-plans.scss
@@ -51,7 +51,7 @@
   .plan-btn {
     width: 100%;
 
-    &[disabled] {
+    &:disabled {
       color: #FFF;
     }
 

--- a/app/styles/billing-plans.scss
+++ b/app/styles/billing-plans.scss
@@ -1,0 +1,65 @@
+.plan-panel {
+  color: $color-light;
+
+  &.active {
+    border: 1px solid $color-bright-blue;
+  }
+
+  .panel-heading h5 {
+    text-align: center;
+  }
+
+  &.active .panel-heading h5 {
+    color: #0D0D0D;
+  }
+
+  .plan-cost {
+    margin: 5px 0;
+  }
+
+  .plan-hero {
+    /* flexbox */
+    align-items: center;
+    display: flex;
+    justify-content: center;
+
+    color: #0D0D0D;
+    height: 110px;
+    font-size: 18px;
+    font-weight: $weight-normal;
+    text-align: center;
+  }
+
+  .plan-cost-amount {
+    color: #0D0D0D;
+    font-size: 28px;
+    font-weight: $weight-normal;
+    margin: 2px;
+    vertical-align: middle;
+  }
+
+  .plan-include {
+    color: #0D0D0D;
+    margin-bottom: 1.5em;
+  }
+
+  .plan-include-subheader {
+    color: $color-light;
+    font-size: smaller;
+  }
+
+  .plan-btn {
+    width: 100%;
+
+    &[disabled] {
+      color: #FFF;
+    }
+
+    &.current {
+      opacity: 1;
+      background-color: #FFF;
+      color: $color-success;
+      border: 2px solid $color-success;
+    }
+  }
+}

--- a/app/templates/confirmation-modals/request-plan-upgrade.hbs
+++ b/app/templates/confirmation-modals/request-plan-upgrade.hbs
@@ -1,0 +1,18 @@
+{{#login-box}}
+  <div class="row">
+    <div class="col-xs-6 col-xs-offset-3">
+      <div class="panel panel-focused upgrade-request-modal-panel">
+        <div class="panel-heading">
+          <h3>Upgrade Request Completed</h3>
+        </div>
+        <div class="panel-body">
+          <p>
+          Your request has been sent to your Aptible account manager. Our team will contact you soon with details.
+          </p>
+
+          <button class="btn btn-primary btn-block btn-lg" {{action "confirm"}}>Ok</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{/login-box}}

--- a/app/templates/confirmation-modals/upgrade-plan.hbs
+++ b/app/templates/confirmation-modals/upgrade-plan.hbs
@@ -1,0 +1,24 @@
+{{#login-box}}
+  <div class="row">
+    <div class="col-xs-6 col-xs-offset-3">
+      <div class="panel panel-focused">
+        <div class="panel-heading">
+          <h3>Upgrade to Platform</h3>
+        </div>
+        <div class="panel-body">
+          <p>
+            Once you upgrade, an Aptible Account Manager will contact you with
+            instructions for signing a Business Associate Agreement and using
+            your new PHI-ready environment.
+          </p>
+          <p>
+            Your account will be billed immediately when you upgrade.
+          </p>
+
+          <button class="btn btn-default btn-block btn-lg" {{action "cancel"}}>Cancel</button>
+          <button class="btn btn-primary btn-block btn-lg" {{action "confirm"}}>Confirm Upgrade</button>
+        </div>
+      </div>
+    </div>
+  </div>
+{{/login-box}}

--- a/app/templates/sidebars/organization.hbs
+++ b/app/templates/sidebars/organization.hbs
@@ -21,8 +21,10 @@
       {{/if}}
     {{/aptible-ability}}
 
-    {{#activating-item currentWhen="organization.billing" tagName="li"}}
-      {{link-to "Billing" "organization.billing"}}
-    {{/activating-item}}
+    {{#if features.organizationBillingSettings}}
+      {{#activating-item currentWhen="organization.billing" tagName="li"}}
+        {{link-to "Billing" "organization.billing"}}
+      {{/activating-item}}
+    {{/if}}
   </ul>
 </nav>

--- a/app/templates/sidebars/organization.hbs
+++ b/app/templates/sidebars/organization.hbs
@@ -20,5 +20,9 @@
         {{/activating-item}}
       {{/if}}
     {{/aptible-ability}}
+
+    {{#activating-item currentWhen="organization.billing" tagName="li"}}
+      {{link-to "Billing" "organization.billing"}}
+    {{/activating-item}}
   </ul>
 </nav>

--- a/config/environment.js
+++ b/config/environment.js
@@ -61,7 +61,8 @@ module.exports = function(environment) {
     featureFlags: {
       'organization-settings': true,
       'price-estimator': true,
-      'notifications': false
+      'notifications': false,
+      'organization-billing-settings': true
     }
 
   };
@@ -125,6 +126,7 @@ module.exports = function(environment) {
     ENV.featureFlags['organization-settings'] = true;
     ENV.featureFlags['price-estimator'] = false;
     ENV.featureFlags['notifications'] = true;
+    ENV.featureFlags['organization-billing-settings'] = false;
   }
 
   return ENV;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "broccoli-sass": "^0.2.4",
     "ember-cli": "0.2.5",
     "ember-cli-app-version": "0.3.3",
-    "ember-cli-aptible-shared": "0.0.6",
+    "ember-cli-aptible-shared": "0.0.7",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",

--- a/tests/acceptance/organization/billing-test.js
+++ b/tests/acceptance/organization/billing-test.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'diesel/tests/helpers/start-app';
+import { stubRequest } from 'ember-cli-fake-server';
+
+let application;
+
+// FIXME this is hardcoded to match the value for signIn in
+// aptible-helpers
+const organizationId = 'o1';
+
+const billingUrl = `/organizations/${organizationId}/billing`;
+const url = billingUrl;
+const aptibleSettingsUrl = `/organizations/${organizationId}`;
+const planUrl = `${billingUrl}/plan`;
+const paymentMethodUrl = `${billingUrl}/payment-method`;
+
+function expectNav(assert, tabName) {
+  const tab = find(`.nav li:contains(${tabName})`);
+  assert.ok(tab.length, `Finds nav containing "${tabName}"`);
+}
+
+module('Acceptance: Organizations: Billing', {
+  beforeEach: function() {
+    application = startApp();
+    stubOrganization();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test(`visiting ${url} requires authentication`, () => {
+  expectRequiresAuthentication(url);
+});
+
+test(`visiting ${aptibleSettingsUrl} shows link to billing`, () => {
+  signInAndVisit(aptibleSettingsUrl);
+  andThen(() => {
+    expectLink(billingUrl);
+  });
+});
+
+test(`visiting ${billingUrl} redirects to /plan`, (assert) => {
+  signInAndVisit(billingUrl);
+  andThen(() => {
+    assert.equal(currentPath(), 'dashboard.organization.billing.plan');
+    expectLink(billingUrl);
+  });
+});
+
+test(`visiting ${url} shows "Plan" tab`, (assert) => {
+  signInAndVisit(url);
+  andThen(() => {
+    expectNav(assert, 'Plan');
+    expectLink(planUrl);
+  });
+});
+
+test(`visiting ${url} shows "Payment Method" tab`, (assert) => {
+  signInAndVisit(url);
+  andThen(() => {
+    expectNav(assert, 'Payment Method');
+    expectLink(paymentMethodUrl);
+  });
+});

--- a/tests/acceptance/organization/billing/plan-test.js
+++ b/tests/acceptance/organization/billing/plan-test.js
@@ -1,0 +1,193 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'diesel/tests/helpers/start-app';
+import { stubRequest } from 'ember-cli-fake-server';
+import { didTrackEventWith } from 'diesel/tests/helpers/mock-analytics';
+import { UPGRADE_PLAN_REQUEST_EVENT } from 'diesel/models/organization';
+
+let application;
+
+// FIXME this is hardcoded to match the value for signIn in
+// aptible-helpers
+const organizationId = 'o1';
+
+const planUrl = `/organizations/${organizationId}/billing/plan`;
+const url = planUrl;
+const apiOrganizationUrl = `/organizations/${organizationId}`;
+const activePanelClass = 'active';
+const askAboutHIPAAButtonName = 'Ask about our HIPAA compliant plans';
+
+module('Acceptance: Organizations: Billing: Plan', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test(`visiting ${url} requires authentication`, () => {
+  stubOrganization();
+  expectRequiresAuthentication(url);
+});
+
+function expectDisplayedPlanType(assert, planType){
+  let $planType = findPlanPanel(assert, planType);
+  assert.ok($planType.length, `Finds plan type "${planType}"`);
+}
+
+function findPlanPanel(assert, planType){
+  return find(`.panel .panel-heading:contains(${planType})`).parent('.panel');
+}
+
+test(`shows 3 plan types: development, platform and HIPAA Compliance`, (assert) => {
+  stubOrganization();
+  signInAndVisit(url);
+
+  andThen(() => {
+    expectDisplayedPlanType(assert, 'Development');
+    expectDisplayedPlanType(assert, 'Platform');
+    expectDisplayedPlanType(assert, 'HIPAA Compliance');
+    expectButton(askAboutHIPAAButtonName);
+  });
+});
+
+test(`on plan "development": highlights the current plan, shows upgrade button`, (assert) => {
+  let plan = 'development';
+  stubOrganization({plan});
+  signInAndVisit(url);
+
+  andThen(() => {
+    let panel = findPlanPanel(assert, 'Development');
+    assert.ok(panel.hasClass(activePanelClass),
+              'panel "Development" is active');
+
+    expectButton('Current Plan', {context:panel});
+
+    let otherPanel = findPlanPanel(assert, 'Platform');
+    assert.ok(!otherPanel.hasClass(activePanelClass),
+              'platform panel is not active');
+
+    expectButton('Upgrade to Platform', {context:otherPanel});
+  });
+});
+
+test(`on plan "platform": highlights the current plan, shows "contact support to downgrade" button`, (assert) => {
+  let plan = 'platform';
+  stubOrganization({plan});
+  signInAndVisit(url);
+
+  andThen(() => {
+    let panel = findPlanPanel(assert, 'Platform');
+    assert.ok(panel.hasClass(activePanelClass),
+              'panel "Platform" is active');
+
+    expectButton('Current Plan', {context:panel});
+
+    let otherPanel = findPlanPanel(assert, 'Development');
+    assert.ok(!otherPanel.hasClass(activePanelClass),
+              'Development panel is not active');
+
+    expectButton('Contact Support to downgrade', {context:otherPanel});
+  });
+});
+
+test(`on plan "development": clicking the upgrade platform shows modal`, (assert) => {
+  let panel;
+  let plan = 'development';
+  stubOrganization({plan});
+
+  signInAndVisit(url);
+
+  clickButton('Upgrade to Platform');
+
+  andThen(() => {
+    expectButton('Confirm Upgrade');
+  });
+});
+
+test(`on plan "development": clicking the upgrade platform updates organization's plan`, (assert) => {
+  assert.expect(5);
+
+  let plan = 'development';
+  stubOrganization({plan});
+
+  stubRequest('put', apiOrganizationUrl, (request) => {
+    assert.ok(true, 'updates organization');
+    assert.equal(request.json().plan, 'platform');
+
+    Ember.run.next(() => {
+      let panel = findPlanPanel(assert, 'Platform');
+      expectButton('Upgrading...', {context:panel});
+    });
+
+    request.noContent();
+  });
+
+  signInAndVisit(url);
+
+  andThen(() => {
+    let panel = findPlanPanel(assert, 'Platform');
+    assert.ok(!panel.hasClass(activePanelClass),
+              'precond - panel is not active before upgrading');
+  });
+
+  clickButton('Upgrade to Platform');
+  clickButton('Confirm Upgrade'); // <-- modal
+
+  andThen(() => {
+    let panel = findPlanPanel(assert, 'Platform');
+    assert.ok(panel.hasClass(activePanelClass),
+              'panel is active after upgrading');
+  });
+});
+
+test(`clicking "${askAboutHIPAAButtonName}" triggers a tracking event, shows modal`, (assert) => {
+  let organizationName = 'the organization';
+  stubOrganization({name: organizationName});
+  signInAndVisit(url);
+  clickButton(askAboutHIPAAButtonName);
+
+  andThen(() => {
+    assert.ok(didTrackEventWith(UPGRADE_PLAN_REQUEST_EVENT, 'organization_id', organizationId),
+              `tracked event "${UPGRADE_PLAN_REQUEST_EVENT}" with {organization_id: ${organizationId}}`);
+
+    assert.ok(didTrackEventWith(UPGRADE_PLAN_REQUEST_EVENT, 'organization_name', organizationName),
+              `tracked event "${UPGRADE_PLAN_REQUEST_EVENT}" with {organization_name: ${organizationName}}`);
+
+    let modal = find('.upgrade-request-modal-panel');
+    assert.ok(!!modal.length, 'upgrade request modal is displayed');
+  });
+});
+
+test('shows error message if the server has error', (assert) => {
+  let errorMessage = `Stripe error: This plan cannot be upgraded`;
+  let plan = 'development';
+  stubOrganization({plan});
+
+  stubRequest('put', apiOrganizationUrl, (request) => {
+    assert.ok(true, 'updates organization');
+
+    request.error(401, {
+      code: 401,
+      error: 'invalid_plan_upgrade',
+      message: errorMessage
+    });
+  });
+
+  signInAndVisit(url);
+  clickButton('Upgrade to Platform');
+  clickButton('Confirm Upgrade'); // <-- modal
+  andThen(() => {
+    let error = findWithAssert('.alert');
+    ok(error.text().indexOf(errorMessage) > -1, 'error message shown');
+
+    let panel = findPlanPanel(assert, 'Platform');
+    assert.ok(!panel.hasClass(activePanelClass),
+              'platform panel is not shown as active after failed upgrade');
+  });
+});

--- a/tests/helpers/mock-analytics.js
+++ b/tests/helpers/mock-analytics.js
@@ -1,4 +1,5 @@
 var oldAnalytics;
+let trackedEvents = [];
 
 export var mockAnalytics = {
  load: function(){},
@@ -18,6 +19,9 @@ export var mockAnalytics = {
        return {};
      }
    };
+ },
+ track(eventName, attributes={}) {
+   trackedEvents.push({eventName, attributes});
  }
 };
 
@@ -27,5 +31,17 @@ export function stubAnalytics(){
 }
 
 export function teardownAnalytics(){
+  trackedEvents = [];
   window.analytics = oldAnalytics;
+}
+
+export function didTrackEvent(eventName) {
+  return trackedEvents.filterBy('eventName', eventName).length > 0;
+}
+
+export function didTrackEventWith(eventName, key, value) {
+  let foundEvents = trackedEvents.filterBy('eventName', eventName);
+  return foundEvents.find((evt) => {
+    return evt.attributes[key] === value;
+  });
 }


### PR DESCRIPTION
Refs #291 

  * [x] add /organizations/:id/billing/plan route
  * [x] style the plan panels on plan page (can we use flexbox?)
  * [ ] ~~display billing overview header (plan name, payment method, invoice date, etc: http://take.ms/kNA55)~~
  * [x] wire the UI to update the organization's plan when requested
  * [x] display a confirmation modal when upgrading
  * [x] Auth: add backend code that handles upgrading an organization (WIP: https://github.com/aptible/auth.aptible.com/pull/151)
  * [x] display error if upgrade fails
  * [x] track an event, show a modal, when a user clicks "ask about our hipaa compliant plans" button
  * [x] change confirmation modal as explained in #291 

@mixonic for your review cc @sandersonet 

@sandersonet : I've used mostly ad-hoc CSS in `app/styles/billing-plans.scss`. Feedback there welcomed and/or you or I can address styling improvements after merge. These seem to be about 80-90% of the way towards matching the mocks. A notable exception is that I didn't fix the height of the panels, so when the window changes they can get out of sync, height-wise. I've added screenshots in comments below of most of the styled UI.

I am going to punt on displaying the billing overview header for now, as it relies on API calls that we do not yet have.