### PR TITLE
Follow afterAuthUrl cookie

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "broccoli-sass": "^0.2.4",
     "ember-cli": "0.2.6",
     "ember-cli-app-version": "0.3.3",
-    "ember-cli-aptible-shared": "0.0.12",
+    "ember-cli-aptible-shared": "0.0.13",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",

--- a/tests/helpers/authentication.js
+++ b/tests/helpers/authentication.js
@@ -1,0 +1,9 @@
+import Ember from "ember";
+
+Ember.Test.registerAsyncHelper('expectRequiresAuthentication', function(app, url){
+  visit(url);
+
+  andThen(function(){
+    equal(currentPath(), 'login');
+  });
+});

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -9,6 +9,7 @@ import MockAnalytics from './helpers/mock-analytics';
 import storage from '../utils/storage';
 import MockLocation from './helpers/mock-location';
 import MockTitle from './helpers/mock-title';
+import './helpers/authentication';
 
 setResolver(resolver);
 


### PR DESCRIPTION
Requires merge and release of https://github.com/aptible/ember-cli-aptible-shared/pull/14

If a cookie is set with an `afterAuthURL`, follow it when login succeeds.