### PR TITLE
Billing update payment

### DIFF
--- a/app/components/stripe-cc-form/component.js
+++ b/app/components/stripe-cc-form/component.js
@@ -1,0 +1,60 @@
+import Ember from 'ember';
+import { createStripeToken } from 'diesel/utils/stripe';
+
+export default Ember.Component.extend({
+  store: Ember.inject.service(),
+  error: null,
+
+  name: null,
+  number: null,
+  cvc: null,
+  expMonth: null,
+  expYear: null,
+  zip: null,
+
+  isSaving: false,
+
+  organization: null,
+  plan: Ember.computed.reads('organization.plan'),
+
+  actions: {
+    saveCC() {
+      let {
+        name,
+        number,
+        cvc,
+        zip,
+        plan,
+        organization,
+        expMonth: exp_month,
+        expYear: exp_year
+      } = this.getProperties(
+        ['name', 'number', 'cvc',
+         'expMonth', 'expYear', 'zip',
+         'organization', 'plan']);
+
+      let stripeOptions = { name, number, cvc, exp_month, exp_year, zip };
+
+      this.set('isSaving', true);
+      this.set('error', null);
+      let success = false;
+      createStripeToken(stripeOptions).then(({id: stripeToken}) => {
+        const subscription = this.get('store').createRecord(
+          'subscription', { plan, stripeToken, organization }
+        );
+        return subscription.save();
+      }).then(() => {
+        success = true;
+      }).catch((e) => {
+        const message = e.message ? e.message : e;
+        this.set('error', message);
+      }).finally(() => {
+        this.set('isSaving', false);
+
+        if (success) {
+          this.sendAction();
+        }
+      });
+    }
+  }
+});

--- a/app/components/stripe-cc-form/template.hbs
+++ b/app/components/stripe-cc-form/template.hbs
@@ -1,0 +1,39 @@
+<form role="form" class="payment-form stripe-cc-form" {{action 'saveCC' on='submit'}}>
+  {{#if error}}
+    {{#bs-alert alert="danger"}}
+      <p>There was an error updating: {{error}}</p>
+    {{/bs-alert}}
+  {{/if}}
+
+  <div class="form-group">
+    {{input class="form-control" value=name name="name" placeholder="Name on card"}}
+  </div>
+
+  <div class="form-group">
+    {{input class="form-control number" value=number name="number" placeholder="Card number"}}
+    {{input class="form-control cvc" value=cvc name="cvc" placeholder="CVC" }}
+  </div>
+
+  <div class="form-group">
+    <div class="expiration-month">
+      {{select-month value=expMonth name="exp-month" prompt="Exp month"}}
+    </div>
+    <div class="expiration-year">
+      {{select-year value=expYear name="exp-year" prompt="Exp year"}}
+    </div>
+
+    {{input class="form-control zip" value=zip name="zip" placeholder="ZIP"}}
+  </div>
+
+  <button
+    class="btn btn-primary btn-block btn-lg {{if isSaving 'disabled'}}"
+    disabled={{isSaving}}
+    {{action 'saveCC'}}>
+
+    {{#if isSaving}}
+      Saving
+    {{else}}
+      Save
+    {{/if}}
+  </button>
+</form>

--- a/app/organization/billing/payment-method/route.js
+++ b/app/organization/billing/payment-method/route.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model() {
+    const organization = this.modelFor('organization');
+    return organization.get('billingDetail');
+  },
+
+  setupController(controller, model){
+    controller.set('model', model);
+    controller.set('organization', this.modelFor('organization'));
+  },
+
+  actions: {
+    showPaymentForm() {
+      this.controller.set('showPaymentForm', true);
+    },
+    updatedPayment() {
+      this.controller.set('showPaymentForm', false);
+      Ember.get(this, 'flashMessages').success('Updated payment method.');
+    }
+  }
+});

--- a/app/organization/billing/payment-method/template.hbs
+++ b/app/organization/billing/payment-method/template.hbs
@@ -1,0 +1,24 @@
+<div class="layout-container">
+  <div class="row">
+    <div class="panel billing-payment-method">
+      <div class="panel-heading">
+        <h5>Payment Method</h5>
+      </div>
+      <div class="panel-body">
+        <p>
+          {{model.paymentMethodName}} ****{{model.paymentMethodDisplay}}
+          Expires {{model.paymentExpMonth}}/{{model.paymentExpYear}}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+{{#unless showPaymentForm}}
+  <button class='btn btn-primary' {{action 'showPaymentForm'}}>Update Payment Method</button>
+{{/unless}}
+
+{{#if showPaymentForm}}
+  {{stripe-cc-form organization=organization action="updatedPayment"}}
+{{/if}}
+

--- a/app/organization/billing/template.hbs
+++ b/app/organization/billing/template.hbs
@@ -1,6 +1,6 @@
 {{billing-header organization=model}}
 
-<div class="layout-container">
+<div class="layout-container billing-payment-method">
   <ul class='nav nav-pills resource-navigation'>
     {{#activating-item currentWhen="organization.billing.plan" tagName="li"}}
       {{link-to "Plan" "organization.billing.plan"}}

--- a/app/welcome/first-app/controller.js
+++ b/app/welcome/first-app/controller.js
@@ -30,10 +30,10 @@ export default Ember.Controller.extend(EmberValidationsMixin, {
   actions: {
     create: function(){
       this.validate().then(() => {
-      // model data is already stored on the parent
-      // route (welcome). Just move forward.
+        // model data is already stored on the parent
+        // route (welcome). Just move forward.
 
-      this.transitionToRoute('welcome.payment-info');
+        this.transitionToRoute('welcome.payment-info');
       }).catch(() => {
         // Silence the validation exception, display it in UI
       });

--- a/app/welcome/payment-info/template.hbs
+++ b/app/welcome/payment-info/template.hbs
@@ -25,7 +25,7 @@
 
               <div class="form-group">
                 {{input class="form-control number" value=model.number name="number" placeholder="Card number"}}
-                {{input class="form-control cvc" value=model.cvc name="cvc" placeholder="CVC" }}
+                {{input class="form-control cvc" value=model.cvc name="cvc" placeholder="CVV" }}
               </div>
 
               <div class="form-group">

--- a/app/welcome/payment-info/template.hbs
+++ b/app/welcome/payment-info/template.hbs
@@ -25,7 +25,7 @@
 
               <div class="form-group">
                 {{input class="form-control number" value=model.number name="number" placeholder="Card number"}}
-                {{input class="form-control cvc" value=model.cvc name="cvc" placeholder="CVV" }}
+                {{input class="form-control cvc" value=model.cvc name="cvc" placeholder="CVC" }}
               </div>
 
               <div class="form-group">

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "broccoli-sass": "^0.2.4",
     "ember-cli": "0.2.6",
     "ember-cli-app-version": "0.3.3",
-    "ember-cli-aptible-shared": "0.0.14",
+    "ember-cli-aptible-shared": "bantic/ember-cli-aptible-shared#billing-payment-method",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",

--- a/tests/acceptance/organization/billing/payment-method-test.js
+++ b/tests/acceptance/organization/billing/payment-method-test.js
@@ -1,0 +1,123 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from 'diesel/tests/helpers/start-app';
+import { stubRequest } from 'ember-cli-fake-server';
+import { didTrackEventWith } from 'diesel/tests/helpers/mock-analytics';
+import { UPGRADE_PLAN_REQUEST_EVENT } from 'diesel/models/organization';
+import { mockStripe } from '../../../helpers/mock-stripe';
+
+let application;
+
+// FIXME this is hardcoded to match the value for signIn in
+// aptible-helpers
+const organizationId = 'o1';
+
+const paymentMethodUrl = `/organizations/${organizationId}/billing/payment-method`;
+const url = paymentMethodUrl;
+const apiOrganizationUrl = `/organizations/${organizationId}`;
+
+const updatePaymentMethodButton = "Update Payment Method";
+
+module('Acceptance: Organizations: Billing: Payment Method', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test(`visiting ${url} requires authentication`, () => {
+  stubOrganization();
+  expectRequiresAuthentication(url);
+});
+
+test(`shows Update Payment Method button`, () => {
+  stubOrganization();
+  signInAndVisit(url);
+  andThen(() => {
+    expectButton(updatePaymentMethodButton);
+  });
+});
+
+test(`shows current payment method`, (assert) => {
+  const billingDetailUrl = `/organizations/${organizationId}/billing_detail`;
+
+  const name = 'VISA',
+    display = '4242',
+    invoiceDate = '2015-06-29T11:06:48.000-04:00',
+    expiresAt = '06/15';
+
+  stubOrganization({
+    _links: { billing_detail: { href: billingDetailUrl } }
+  });
+
+  stubRequest('get', billingDetailUrl, (request) => {
+    request.ok({
+      id: 'b-d-id',
+      payment_method_name: name,
+      payment_method_display: display,
+      next_invoice_date: invoiceDate
+    });
+  });
+
+  signInAndVisit(url);
+  andThen(() => {
+    assert.ok(find(`.billing-payment-method:contains(${name})`).length,
+              `has payment name "${name}"`);
+    assert.ok(find(`.billing-payment-method:contains(${display})`).length,
+              `has payment display "${display}"`);
+    /* FIXME auth does not report expiry yet
+    assert.ok(find(`.billing-payment-method:contains(${expiresAt})`).length,
+              `has payment expires at "${expiresAt}"`);
+     */
+  });
+});
+
+test(`shows credit card form after clicking "Update Payment Method"`, (assert) => {
+  stubOrganization();
+  signInAndVisit(url);
+  clickButton(updatePaymentMethodButton);
+  andThen(() => {
+    assert.ok(find('form.stripe-cc-form').length,
+              'displays stripe cc form');
+  });
+});
+
+test(`updates credit card form after clicking "Update Payment Method"`, (assert) => {
+  assert.expect(2);
+  const cardNumber = '4242424242424242',
+        cardCvc = '123',
+        cardExpMonth = '5',
+        cardExpYear = '2017',
+        cardZip = '11211',
+        stripeToken = 'mocked-stripe-token';
+
+  mockStripe.card.createToken = function(options, fn) {
+    setTimeout(function(){
+      fn(200, { id: stripeToken});
+    }, 2);
+  };
+
+  stubRequest('post', `/organizations/:organization_id/subscriptions`, (req) => {
+    assert.ok(true, 'updates subscription');
+    assert.equal(req.json().stripe_token, stripeToken, 'posts stripe token');
+    req.noContent();
+  });
+
+  stubOrganization();
+  signInAndVisit(url);
+  clickButton(updatePaymentMethodButton);
+  andThen(() => {
+    fillInput('number', cardNumber);
+    fillInput('cvc', cardCvc);
+    fillInput('exp-month', cardExpMonth);
+    fillInput('exp-year', cardExpYear);
+    fillInput('zip', cardZip);
+    clickButton('Save', {context: find('form.stripe-cc-form')});
+  });
+});


### PR DESCRIPTION
Adds a form for updating one's credit card at the organization's billings settings page.

This is ready for review but *do not merge*. ~~It depends on a change to the addon: https://github.com/aptible/ember-cli-aptible-shared/pull/18. After that is merged I'll cut a new release and update the package.json on this PR.~~ (done, -@mixonic)

Also depends on these changes to auth: https://github.com/aptible/auth.aptible.com/pull/156

![cc](https://cloud.githubusercontent.com/assets/2023/8011154/44b8e93e-0b84-11e5-88ea-54fb4e1879f0.gif)

@mixonic @sandersonet for your review

refs #291 

An important limitation here is that the UI does not immediately reflect the updated billing details. This is due to a bug (?) in ember-data that prevents reloading the `organization`'s `billingDetail` relationship. Calling `reload` on the model does not reuse the HAL `self` link that it had originally used to load itself, it instead constructs a standard `GET /billingDetails/:billing_details_id` url that 404s on the server side.
I've experimented with manually unloading the billingDetail record from the store and reloading it from the organization (as well as reloading the organization and then re-fetching the billingDetail), but ember-data is persistent about not letting that item out of its identity map.

A few options to fix this, none of which is ideal:

  * reload the entire page — the nuclear option
  * add a `GET /billing_details/:billing_details_id` route on the server side so that the reload works
  * modify the HAL adapter to correctly (?) reuse a `self` link when reloading a resource
  * manually fetch the data via ajax (using the `self` link) and `store.push` it back into the store
