### PR TITLE
Use "dummy" s3-static-index adapter to statically upload index.html

### DIFF
--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,5 +1,7 @@
 module.exports = {
   production: {
+    buildEnv: 'production',
+
     store: {
       type: 's3-static',
       accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
@@ -18,6 +20,8 @@ module.exports = {
   },
 
   staging: {
+    buildEnv: 'staging',
+
     store: {
       type: 's3-static',
       accessKeyId: process.env['AWS_ACCESS_KEY_ID'],

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,6 +1,11 @@
 module.exports = {
   production: {
     store: {
+      type: 's3-static',
+      accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
+      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
+      acl: 'public-read',
+      bucket: 'dashboard.aptible.com'
     },
 
     assets: {
@@ -14,6 +19,11 @@ module.exports = {
 
   staging: {
     store: {
+      type: 's3-static',
+      accessKeyId: process.env['AWS_ACCESS_KEY_ID'],
+      secretAccessKey: process.env['AWS_SECRET_ACCESS_KEY'],
+      acl: 'public-read',
+      bucket: 'dashboard.aptible-staging.com'
     },
 
     assets: {

--- a/lib/ember-deploy-s3-static-index/adapter.js
+++ b/lib/ember-deploy-s3-static-index/adapter.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/*
+ * Borrowed heavily from https://github.com/Kerry350/ember-deploy-s3-index
+ * See lib/s3-adapter.js
+ */
+
+var CoreObject = require('core-object');
+var Promise = require('ember-cli/lib/ext/promise');
+var SilentError = require('ember-cli/lib/errors/silent');
+var AWS = require('aws-sdk');
+
+module.exports = CoreObject.extend({
+  init: function() {
+    CoreObject.prototype.init.apply(this, arguments);
+
+    if (!this.config) {
+      throw new SilentError('You must supply a config');
+    }
+
+    this.client = this.S3 || new AWS.S3(this.config);
+  },
+
+  /* Public methods */
+
+  upload: function(buffer) {
+    return this._upload(buffer, 'index.html');
+  },
+
+  activate: function(revision) {
+    // Don't need to support list() or activate()
+  },
+
+  list: function() {
+    // Don't need to support list() or activate()
+  },
+
+  /* Private methods */
+
+  _getUploadParams: function(key, value) {
+    return {
+      ACL: this.config.acl || 'public-read',
+      Bucket: this.config.bucket,
+      Key: key,
+      Body: value,
+      ContentType: 'text/html',
+      CacheControl: 'max-age=0, no-cache'
+    }
+  },
+
+  _upload: function(buffer, key) {
+    return new Promise(function(resolve, reject) {
+      var params = this._getUploadParams(key, buffer);
+      this.client.putObject(params, function(err, data) {
+        if (err) {
+          this._logUploadError(reject, err);
+        } else {
+          this._logUploadSuccess(resolve);
+        }
+      }.bind(this));
+    }.bind(this));
+  },
+
+  _logUploadError: function(reject, error) {
+    var errorMessage = 'Unable to sync: ' + error.stack;
+    reject(new SilentError(errorMessage));
+  },
+
+  _logUploadSuccess: function(resolve) {
+    this.ui.writeLine('Index file was successfully uploaded');
+    resolve();
+  }
+});

--- a/lib/ember-deploy-s3-static-index/index.js
+++ b/lib/ember-deploy-s3-static-index/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var Adapter = require('./adapter');
+
+module.exports = {
+  name: 'ember-deploy-s3-static-index',
+  type: 'ember-deploy-addon',
+
+  adapters: {
+    index: {
+      's3-static': Adapter
+    }
+  }
+};

--- a/lib/ember-deploy-s3-static-index/package.json
+++ b/lib/ember-deploy-s3-static-index/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "ember-deploy-s3-static-index",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "aws-sdk": "^2.1.34",
     "broccoli-asset-rev": "^2.0.2",
     "broccoli-sass": "^0.2.4",
+    "core-object": "^1.1.0",
     "ember-cli": "0.2.6",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-aptible-shared": "0.0.18",
@@ -54,7 +56,8 @@
   },
   "ember-addon": {
     "paths": [
-      "lib/bootstrap-sass"
+      "lib/bootstrap-sass",
+      "lib/ember-deploy-s3-static-index"
     ]
   }
 }

--- a/script/travis-deploy.sh
+++ b/script/travis-deploy.sh
@@ -10,10 +10,8 @@ fi
 
 if [ "$TRAVIS_BRANCH" == "master" ]; then
   # Deploy to staging on a merge to master
-  ember build -e staging
-  ember deploy:assets -e staging
+  ember deploy -e staging
 elif [ "$TRAVIS_BRANCH" == "release" ]; then
   # Deploy to production on a merge to release
-  ember build -e production
-  ember deploy:assets -e production
+  ember deploy -e production
 fi


### PR DESCRIPTION
The index.html will be uploaded to the same S3 bucket as other site assets, but this way we get to set no-cache headers on index.html.

cc: @sandersonet 