### PR TITLE
Update broccoli-sass to latest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "aws-sdk": "^2.1.34",
     "broccoli-asset-rev": "^2.0.2",
-    "broccoli-sass": "^0.2.4",
+    "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
     "ember-cli": "0.2.6",
     "ember-cli-app-version": "0.3.3",


### PR DESCRIPTION
Allows usage of iojs 2.2.1 (due to using node-sass^3.0.0).

This is a large jump for node-sass version (from ^0.9.2 to ^3.0.0), and the UX should definitely be reviewed for look/feel issues.  Initial review looks good to me.

@sandersonet for review.