### PR TITLE
Update to ember-cli@0.2.7.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "broccoli-asset-rev": "^2.0.2",
     "broccoli-sass": "^0.2.4",
     "core-object": "^1.1.0",
-    "ember-cli": "0.2.6",
+    "ember-cli": "0.2.7",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-aptible-shared": "0.0.21",
     "ember-cli-babel": "^5.0.0",


### PR DESCRIPTION
The blueprinted files that changed upstream have already been overridden, so the only change is for `package.json`.