### PR TITLE
Ensure `index.html` is gzipped when deployed.

### DIFF
--- a/lib/ember-deploy-s3-static-index/adapter.js
+++ b/lib/ember-deploy-s3-static-index/adapter.js
@@ -9,6 +9,7 @@ var CoreObject = require('core-object');
 var Promise = require('ember-cli/lib/ext/promise');
 var SilentError = require('ember-cli/lib/errors/silent');
 var AWS = require('aws-sdk');
+var zlib = require('zlib');
 
 module.exports = CoreObject.extend({
   init: function() {
@@ -42,9 +43,10 @@ module.exports = CoreObject.extend({
       ACL: this.config.acl || 'public-read',
       Bucket: this.config.bucket,
       Key: key,
-      Body: value,
+      Body: zlib.gzipSync(value, { level: zlib.Z_BEST_COMPRESSION }),
       ContentType: 'text/html',
-      CacheControl: 'max-age=0, no-cache'
+      CacheControl: 'max-age=0, no-cache',
+      ContentEncoding: 'gzip'
     }
   },
 


### PR DESCRIPTION
This updates to store the `index.html` as gzipped content in S3 and adds the `Content-Encoding: gzip` header. This was already being handled properly by the ember-deploy-s3 adapter that is used for `assets`.

This brings the `index.html` payload from 4.5KB to 2.0KB.

Closes #273.