### PR TITLE
Update sentry version and use custom fork of ember-cli-sentry.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,6 +4,7 @@ import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 import AuthenticatedRouteMixin from 'diesel/mixins/routes/authenticated';
 import { RouteExtension, RouterExtension } from 'diesel/utils/title-route-extensions';
+import monkeyPatchRaven from './ext/raven';
 
 Ember.Route.reopen(RouteExtension);
 Ember.Router.reopen(RouterExtension);
@@ -19,5 +20,6 @@ var App = Ember.Application.extend({
 });
 
 loadInitializers(App, config.modulePrefix);
+monkeyPatchRaven();
 
 export default App;

--- a/app/ext/raven.js
+++ b/app/ext/raven.js
@@ -1,0 +1,29 @@
+/* global TraceKit */
+
+import config from '../config/environment';
+
+let attempts = 0;
+
+export default function monkeyPatchRaven() {
+  var originalCaptureMessage;
+
+  if (config.sentry.skipCdn) {
+    return;
+  }
+
+  attempts++;
+
+  if (window.Raven) {
+    originalCaptureMessage = window.Raven.captureMessage;
+
+    window.Raven.captureMessage = function(message, options) {
+      var exception = new Error('Fake exception to track the stack of [object Object] errors.');
+
+      options.stacktrace = TraceKit.computeStackTrace(exception);
+
+      originalCaptureMessage.call(window.Raven, message, options);
+    };
+  } else if (attempts < 10) {
+    setTimeout(monkeyPatchRaven, 500);
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -37,7 +37,7 @@ module.exports = function(environment) {
       skipCdn: false,
       cdn: '//cdn.ravenjs.com',
       dsn: 'https://825dc91773b5407f94cb86bd7b5982d0@app.getsentry.com/46076',
-      version: '1.1.16',
+      version: '1.1.19',
       whitelistUrls: ['localhost:4200'],
       development: true
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.3.13",
-    "ember-cli-sentry": "1.0.4",
+    "ember-cli-sentry": "damiencaselli/ember-cli-sentry#2bcea789ebab6a93700c6edcb67282e0960cfad7",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.18",
     "ember-data-hal-9000": "0.1.7",


### PR DESCRIPTION
* Updates Raven to use 1.1.19 (see [changelog](https://github.com/getsentry/raven-js/blob/master/docs/changelog/index.rst) for list of bugfixes), and uses master of ember-cli-sentry to take advantage of upstream Ember plugin fixes.
* Adds a monkey patch to `Raven.captureMessage` to add a `stacktrace` so that we can track down the source of the `[object Object]` errors.

Addresses https://github.com/aptible/dashboard.aptible.com/issues/346.