### PR TITLE
Fix PHI ready upgrade link

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -45,13 +45,13 @@ app.import("bower_components/zeroclipboard/dist/ZeroClipboard.swf", {
 });
 
 // Should become and addon or use a tree
-app.import('bower_components/aptible-sass/dist/images/aptible-circle-logo.png', { destDir: "/" });
-app.import('bower_components/aptible-sass/dist/images/aptible-mark.png', { destDir: "/" });
-app.import('bower_components/aptible-sass/dist/images/aptible-mark@2x.png', { destDir: "/" });
-app.import('bower_components/aptible-sass/dist/images/nav-logo-dark.png', { destDir: "/" });
-app.import('bower_components/aptible-sass/dist/images/nav-logo-dark@2x.png', { destDir: "/" });
-app.import('bower_components/aptible-sass/dist/images/nav-logo.png', { destDir: "/" });
-app.import('bower_components/aptible-sass/dist/images/nav-logo@2x.png', { destDir: "/" });
+app.import('bower_components/aptible-sass/dist/images/aptible-circle-logo.png', { destDir: "images" });
+app.import('bower_components/aptible-sass/dist/images/aptible-mark.png', { destDir: "images" });
+app.import('bower_components/aptible-sass/dist/images/aptible-mark@2x.png', { destDir: "images" });
+app.import('bower_components/aptible-sass/dist/images/nav-logo-dark.png', { destDir: "images" });
+app.import('bower_components/aptible-sass/dist/images/nav-logo-dark@2x.png', { destDir: "images" });
+app.import('bower_components/aptible-sass/dist/images/nav-logo.png', { destDir: "images" });
+app.import('bower_components/aptible-sass/dist/images/nav-logo@2x.png', { destDir: "images" });
 
 // Use `app.import` to add additional libraries to the generated
 // output files.

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -12,6 +12,7 @@
 @import "components/focus";
 @import "components/funnel";
 @import "components/git-ref";
+@import "components/header";
 @import "components/login-box";
 @import "components/operation-item";
 @import "components/payment-form";

--- a/app/styles/components/header.scss
+++ b/app/styles/components/header.scss
@@ -1,0 +1,9 @@
+header.navbar.current-user-header .navbar-header .navbar-brand {
+  background-image: url("/images/nav-logo-dark.png");
+}
+
+@media only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-resolution: 192dppx) {
+  header.navbar.current-user-header .navbar-header .navbar-brand {
+    background-image: url("/images/nav-logo-dark@2x.png");
+  }
+}

--- a/app/styles/components/resource-icon.scss
+++ b/app/styles/components/resource-icon.scss
@@ -1,5 +1,5 @@
 .resource-icon {
-  background: image-url('images/sprite.png');
+  background: url('/images/sprite.png');
   background-repeat: no-repeat;
   height: 35px;
   width: 35px;

--- a/app/templates/environment/-form.hbs
+++ b/app/templates/environment/-form.hbs
@@ -15,16 +15,18 @@
       <ul>
         <li>
           <label>
-            {{input type="checkbox"
-              name="environment-phi"
-              disabled=(not organization.allowPHI)
-              checked=allowPHI}}
             {{#if organization.allowPHI}}
-              PHI Ready?
+              {{input type="checkbox"
+                name="environment-phi"
+                disabled=(not organization.allowPHI)
+                checked=allowPHI}}
+              PHI Ready
             {{else}}
-              PHI Ready environments require a Production plan.
-              {{! FIXME should link to where? }}
-              {{link-to "Upgrade now" "index"}}
+              {{! FIXME Once billing.plans is ready for primetime, update this
+              to link there }}
+              {{#link-to-aptible app='support' path='contact'}}
+                Contact support to upgrade to PHI ready plan.
+              {{/link-to-aptible}}
             {{/if}}
           </label>
         </li>

--- a/config/environment.js
+++ b/config/environment.js
@@ -11,7 +11,7 @@ module.exports = function(environment) {
     apiBaseUri: process.env.API_BASE_URI || "http://localhost:4001",
     aptibleHosts: {
       compliance: 'http://localhost:3001',
-      dashboard: "http://localhost:3000",
+      dashboard: "http://localhost:4200",
       support: "https://support.aptible.com"
     },
 

--- a/tests/acceptance/organization/environments/create-test.js
+++ b/tests/acceptance/organization/environments/create-test.js
@@ -13,7 +13,7 @@ let url = `/organizations/${orgId}/environments/new`;
 module('Acceptance: Organizations: Environments: New', {
   beforeEach: function() {
     application = startApp();
-    stubOrganization({id:orgId});
+    stubOrganization({id:orgId, plan: 'production'});
   },
 
   afterEach: function() {


### PR DESCRIPTION
Currently the "Upgrade Plan" link points to a feature that is still behind a feature flag, and likely will be for a while.  I've updated the link to point to our support site for now.

Two other minor issues fixed:

* Fixed dashboard URL config
* Removed dependency on compass `image-url` url-helper

