### PR TITLE
Introduce ember-cli-release for handling releases.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,22 @@ The `master` branch of this repo is deployed to [dashboard.aptible-staging.com](
 
 The `release` branch of this repo is deployed to [dashboard.aptible.com](https://dashboard.aptible.com/) upon a successful build.
 
+#### Production Release
+
+To trigger CI to deploy a new version to production, run the following command:
+
+```bash
+ember release
+```
+
+This does the following steps automatically:
+
+* Update `package.json` version
+* Commit the `package.json` changes
+* Tag the next version. This automatically selects a patch level version bump. To bump the minor version you can run `ember release --minor` (same with major).
+* Push tag and `package.json` changes to master.
+* Push master to release (this triggers CI to do a production deployment).
+
 ### Deploying via CI
 
 This repo contains a `.travis.yml` file that will automatically deploy the application to staging/production. To do this, our AWS credentials are encrypted and stored on Travis. To update these credentials, run the following command (inserting the credential values):

--- a/config/release.js
+++ b/config/release.js
@@ -1,0 +1,10 @@
+var execSync = require('child_process').execSync;
+
+module.exports = {
+  // Push master (including version bump) to `release` branch.
+  afterPush: function() {
+    console.log('pushing master to release branch');
+    var output = execSync('git push origin master:release', { encoding: 'utf8' });
+    console.log(output);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-pretender": "^0.3.1",
     "ember-cli-qunit": "0.3.13",
+    "ember-cli-release": "^0.2.5",
     "ember-cli-sentry": "damiencaselli/ember-cli-sentry#2bcea789ebab6a93700c6edcb67282e0960cfad7",
     "ember-cli-uglify": "^1.0.1",
     "ember-data": "1.0.0-beta.18",


### PR DESCRIPTION
```bash
ember release
```

This does the following steps automatically:

* Update `package.json` version
* Commit the `package.json` changes
* Tag the next version. This automatically selects a patch level version
  bump. To bump the minor version you can run `ember release --minor`
  (same with major).
* Push tag and `package.json` changes to master.
* Push master to release (this triggers CI to do a production
  deployment).