### PR TITLE
Ensure database slider is kept in sync.

### DIFF
--- a/app/databases/new/route.js
+++ b/app/databases/new/route.js
@@ -23,6 +23,10 @@ export default Ember.Route.extend({
     }
   },
 
+  resetController() {
+    this.controller.set('diskSize', 10);
+  },
+
   actions: {
     willTransition() {
       this.currentModel.rollback();

--- a/app/databases/new/template.hbs
+++ b/app/databases/new/template.hbs
@@ -52,7 +52,7 @@
               <div class="slider-wrapper">
                 {{no-ui-slider didSlide="didSlide"
                                  classNames="disk-size"
-                                 start=10 rangeMin=10 rangeMax=200 step=10}}
+                                 start=diskSize rangeMin=10 rangeMax=200 step=10}}
                 <div class="label-wrapper">
                   <div class="label pull-left">10 GB</div>
                   <div class="label pull-right">200 GB</div>

--- a/tests/acceptance/databases/create-test.js
+++ b/tests/acceptance/databases/create-test.js
@@ -198,6 +198,25 @@ test(`visit ${url} and click cancel button`, function(){
   });
 });
 
+test(`diskSize is reset when leaving ${url} (#372)`, function(){
+  expect(1);
+
+  var diskSize = 30;
+
+  signInAndVisit(url);
+  andThen(function(){
+    triggerSlider('.disk-size', diskSize);
+    clickButton('Cancel');
+  });
+  visit(url);
+
+  andThen(function() {
+    let slider = find('.disk-size');
+
+    equal(slider.val(), '10.00');
+  });
+});
+
 test(`visit ${url} and transition away`, function(){
   expect(2);
 


### PR DESCRIPTION
* Use `{{diskSize}}` as the `nouislider`'s start value (to ensure they are in sync).
* Use `resetController` to set the controller's state back to the default value when the `database.new` route is exited.

Fixes #372.

@sandersonet -- ready for review.