### PR TITLE
Remove the usage of two-way binding in {{handle-input}}.

### DIFF
--- a/app/apps/new/template.hbs
+++ b/app/apps/new/template.hbs
@@ -20,7 +20,7 @@
               App handle
               <span class="label-helper">Lowercase alphanumerics, periods, and dashes only</span>
             </label>
-            {{handle-input class="form-control" value=model.handle name='handle' autofocus=true}}
+            {{handle-input class="form-control" update=(action (mut model.handle)) value=model.handle name='handle' autofocus=true}}
           </div>
         </div>
       </div>

--- a/app/components/handle-input/component.js
+++ b/app/components/handle-input/component.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import FocusableInput from '../focusable-input/component';
+import Autofocusable from '../../mixins/views/autofocusable';
 
 export var maxChars = 64;
 
@@ -24,18 +24,36 @@ function sanitizeInput(input){
          replace(nonAlphaNumerics, '');
 }
 
-export default FocusableInput.extend({
-  _sanitizedValue: null,
-  value: Ember.computed({
-    get() {
-      return this._sanitizedValue;
-    },
-    set(key, value) {
-      this._sanitizedValue = sanitizeInput(value);
+function handleChangeEvent() {
+  let value = this.readDOMAttr('value');
 
-      this.attrs.value.update(this._sanitizedValue);
+  processValue.call(this, value);
+}
 
-      return this._sanitizedValue;
+function processValue(rawValue) {
+  let value = sanitizeInput(rawValue);
+
+  if (this._sanitizedValue !== value) {
+    this._sanitizedValue = value;
+    this.attrs.update(value);
+  }
+}
+
+export default Ember.Component.extend(Autofocusable, {
+  tagName: 'input',
+  attributeBindings: [ 'type', 'value', 'placeholder', 'name' ],
+  type: 'text',
+
+  input: handleChangeEvent,
+  change: handleChangeEvent,
+
+  _sanitizedValue: undefined,
+
+  didReceiveAttrs: function() {
+    if (!this.attrs.update) {
+      throw new Error('You must provide an `update` action to `{{handle-input}}`.');
     }
-  })
+
+    processValue.call(this, this.get('value'));
+  }
 });

--- a/app/databases/new/template.hbs
+++ b/app/databases/new/template.hbs
@@ -27,6 +27,7 @@
                     placeholder="e.g., postgresql-prod"
                     name="handle"
                     autofocus=true
+                    update=(action (mut model.handle))
                     value=model.handle}}
           </div>
 

--- a/app/stack/log-drains/new/template.hbs
+++ b/app/stack/log-drains/new/template.hbs
@@ -16,7 +16,7 @@
 
           <div class="form-group">
             <label class="block" for="drain-handle">Handle</label>
-            {{handle-input class="form-control" value=model.handle name='handle' autofocus=true}}
+            {{handle-input class="form-control" update=(action (mut model.handle)) value=model.handle name='handle' autofocus=true}}
           </div>
           <div class="form-group">
             <label class="block" for="drain-type">Type</label>

--- a/app/templates/environment/-form.hbs
+++ b/app/templates/environment/-form.hbs
@@ -6,7 +6,7 @@
       Handle
       <span class="label-helper">Lowercase alphanumerics, periods, and dashes only</span>
     </label>
-    {{handle-input class="form-control" value=model.handle name='environment-handle' autofocus=true}}
+    {{handle-input class="form-control" update=(action (mut model.handle)) value=model.handle name='environment-handle' autofocus=true}}
   </div>
 
   <div class="form-group">
@@ -50,4 +50,3 @@
     </button>
   </div>
 </form>
-

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -21,6 +21,7 @@
               {{handle-input class="stack-handle form-control sanitize-handler"
                 placeholder="e.g., organization-prod"
                 name="stack-handle"
+                update=(action (mut model.stackHandle))
                 value=model.stackHandle
                 }}
               {{validation-feedback error=errors.model.stackHandle value=model.stackHandle fieldName='Environment handle'}}
@@ -38,6 +39,7 @@
               {{handle-input class="app-name form-control sanitize-handler"
                 placeholder="e.g., app-prod"
                 name="app-handle"
+                update=(action (mut model.appHandle))
                 value=model.appHandle
                 autofocus="true"
                 }}
@@ -68,6 +70,7 @@
                 {{handle-input class="database-name form-control sanitize-handler"
                   placeholder="e.g., postgresql-prod"
                   name="db-handle"
+                  update=(action (mut model.dbHandle))
                   value=model.dbHandle
                   }}
                 {{validation-feedback error=errors.model.dbHandle value=model.dbHandle fieldName='Database Handle'}}

--- a/tests/unit/components/handle-input/component-test.js
+++ b/tests/unit/components/handle-input/component-test.js
@@ -13,7 +13,7 @@ moduleForComponent('handle-input', {
 test('entering value with spaces adds dashes', function(assert) {
   assert.expect(2);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -27,7 +27,7 @@ test('entering value with spaces adds dashes', function(assert) {
 test('setting value with spaces adds dashes', function(assert) {
   assert.expect(2);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -40,7 +40,7 @@ test('setting value with spaces adds dashes', function(assert) {
 test('entering value with capital letter lowercases it', function(assert){
   assert.expect(2);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -54,7 +54,7 @@ test('entering value with capital letter lowercases it', function(assert){
 test('setting value with capital letter lowercases it', function(assert){
   assert.expect(2);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -67,7 +67,7 @@ test('setting value with capital letter lowercases it', function(assert){
 test('entering value with bad char removes it', function(assert){
   assert.expect(2);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -81,7 +81,7 @@ test('entering value with bad char removes it', function(assert){
 test('setting value with bad char removes it', function(assert){
   assert.expect(2);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -94,7 +94,7 @@ test('setting value with bad char removes it', function(assert){
 test(`entering more than ${maxChars} chars truncates to ${maxChars}`, function(assert){
   assert.expect(3);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -115,7 +115,7 @@ test(`entering more than ${maxChars} chars truncates to ${maxChars}`, function(a
 test(`setting more than ${maxChars} chars truncates to ${maxChars}`, function(assert){
   assert.expect(3);
 
-  this.render(hbs`{{handle-input value=value}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) value=value}}`);
 
   var input = this.$('input');
 
@@ -133,9 +133,22 @@ test(`setting more than ${maxChars} chars truncates to ${maxChars}`, function(as
 });
 
 test(`autofocusable`, function(assert){
-  this.render(hbs`{{handle-input autofocus=true}}`);
+  this.render(hbs`{{handle-input update=(action (mut value)) autofocus=true}}`);
 
   var el = this.$('input')[0];
 
   assert.equal(document.activeElement, el, 'input is focused');
+});
+
+test('fires an action when updated', function(assert) {
+  assert.expect(1);
+
+  this.on('update', (value) => {
+    assert.equal(value, 'new-val');
+  });
+  this.render(hbs`{{handle-input update=(action 'update') value=value}}`);
+
+  var input = this.$('input');
+  input.val('new val');
+  input.trigger('input');
 });


### PR DESCRIPTION
When the `input` or `change` events are fired, invoke `this.attrs.update`.

DDAU FTW