### PR TITLE
Improved log drain UX

### DIFF
--- a/app/components/database-selector/template.hbs
+++ b/app/components/database-selector/template.hbs
@@ -1,4 +1,4 @@
-<select name="database-selector" {{action 'change' on='change'}}>
+<select name="database-selector" {{action 'change' on='change'}} class="form-control">
   {{#each databases as |item|}}
     <option value="{{item.id}}">
       {{item.handle}}

--- a/app/stack/log-drains/index/controller.js
+++ b/app/stack/log-drains/index/controller.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  provisionedLogDrains: Ember.computed.filterBy('model', 'isProvisioned'),
+  pendingLogDrains: Ember.computed.filterBy('model', 'isPending'),
+  deprovisionedLogDrains: Ember.computed.filterBy('model', 'hasBeenDeprovisioned'),
+  hasActive: Ember.computed.gt('provisionedLogDrains.length', 0),
+  hasPending: Ember.computed.gt('pendingLogDrains.length', 0),
+  hasDeprovisioning: Ember.computed.gt('deprovisionedLogDrains.length', 0),
+  showSortableHeader: Ember.computed.or('hasPending', 'hasDeprovisioning')
+});

--- a/app/stack/log-drains/index/template.hbs
+++ b/app/stack/log-drains/index/template.hbs
@@ -1,9 +1,44 @@
-{{#each model as |logDrain|}}
-  <div class="log-drain panel panel-subdued">
-    <div class="panel-heading with-actions">
-      <h3>{{logDrain.drainHost}}:{{logDrain.drainPort}}</h3>
+{{#if hasActive}}
+  <div class="sort-group provisioned-log-drains">
+    {{#if showSortableHeader}}
+      <h5 class="sort-header">Provisioned Log Drains</h5>
+    {{/if}}
+    <div class="row">
+      {{#each provisionedLogDrains as |logDrain|}}
+        <div class="col-xs-12">
+          {{partial 'stack/log-drain'}}
+        </div>
+      {{/each}}
     </div>
   </div>
-{{/each}}
+{{/if}}
 
-{{link-to 'Add Log' 'stack.log-drains.new' class="btn btn-primary"}}
+{{#if hasPending}}
+  <div class="sort-group pending-log-drains">
+    <h5 class="sort-header">Provisioning Log Drains</h5>
+    <div class="row">
+      {{#each pendingLogDrains as |logDrain|}}
+        <div class="col-xs-12">
+          {{partial 'stack/log-drain'}}
+        </div>
+      {{/each}}
+    </div>
+  </div>
+{{/if}}
+
+{{#if hasDeprovisioning}}
+  <div class="sort-group deprovisioning-log-drains">
+    <h5 class="sort-header">Deprovisioned Log Drains</h5>
+    <div class="row">
+      {{#each deprovisionedLogDrains as |logDrain|}}
+        <div class="col-xs-12">
+          {{partial 'stack/log-drain'}}
+        </div>
+      {{/each}}
+    </div>
+  </div>
+{{/if}}
+
+<div class="resource-actions">
+  {{link-to 'Add Log Drain' 'stack.log-drains.new' class="btn btn-primary"}}
+</div>

--- a/app/stack/log-drains/new/controller.js
+++ b/app/stack/log-drains/new/controller.js
@@ -17,6 +17,12 @@ function parseUrl(url) {
 }
 
 export default Ember.Controller.extend({
+  isSyslogDrain: Ember.computed.equal('model.drainType', 'syslog_tls_tcp'),
+  disableSave: Ember.computed('isSyslogDrain', 'esDatabases', function() {
+    return this.get('model.isSaving') ||
+           (!this.get('isSyslogDrain') &&
+           this.get('esDatabases.length') === 0);
+  }),
   actions: {
     setDrainFromDatabase(database) {
       let connectionUrl = database.get('connectionUrl');
@@ -27,8 +33,6 @@ export default Ember.Controller.extend({
       model.set('drainPort', a.port);
       model.set('drainUsername', a.username);
       model.set('drainPassword', a.password);
-    }},
-    isSyslogDrain: Ember.computed("model.drainType", function() {
-      return this.get("model.drainType") === "syslog_tls_tcp";
-    })
-  });
+    }
+  }
+});

--- a/app/stack/log-drains/new/route.js
+++ b/app/stack/log-drains/new/route.js
@@ -3,25 +3,25 @@ import DS from 'ember-data';
 
 export default Ember.Route.extend({
 
-  model: function(){
+  model() {
     var stack = this.modelFor('stack');
+
     return Ember.RSVP.hash({
-      logDrain: this.store.createRecord('log-drain', {drainType: 'syslog_tls_tcp' }),
+      stack: stack,
+      logDrain: this.store.createRecord('log-drain', { drainType: 'syslog_tls_tcp' }),
       elasticsearchDbs: stack.get('databases').then((databases) => {
-        return databases.filter((database) => {
-          return database.get('type') === 'elasticsearch' && !!database.get('connectionUrl');
-      });
-    })
-  });
+        return databases.filterBy('type', 'elasticsearch').filter((d) => d.get('connectionUrl'));
+      })
+    });
   },
 
   setupController(controller, model) {
     controller.set('model', model.logDrain);
     controller.set('esDatabases', model.elasticsearchDbs);
+    controller.set('stack', model.stack);
   },
 
-
-renderTemplate: function(controller){
+  renderTemplate(controller) {
     if (!this.session.get('currentUser.verified')) {
       controller.set('resourceType', 'log drain');
       this.render('unverified');
@@ -31,12 +31,12 @@ renderTemplate: function(controller){
   },
 
   actions: {
-    cancel: function(log){
+    cancel(log) {
       log.deleteRecord();
       this.transitionTo('stack.log-drains.index');
     },
 
-    createLog: function(log){
+    createLog(log) {
       log.set('stack', this.modelFor('stack'));
 
       log.save().then( () => {

--- a/app/stack/log-drains/new/template.hbs
+++ b/app/stack/log-drains/new/template.hbs
@@ -6,55 +6,66 @@
           <h3>Create a new log drain</h3>
         </div>
         <div class="panel-body">
+
           {{#if model.errors.length}}
-          <div class="alert alert-warning">
-            {{#each model.errors.messages as |message|}}
-            <p>{{message}}</p>
-            {{/each}}
-          </div>
+            <div class="alert alert-warning">
+              {{#each model.errors.messages as |message|}}
+              <p>{{message}}</p>
+              {{/each}}
+            </div>
           {{/if}}
 
           <div class="form-group">
             <label class="block" for="drain-handle">Handle</label>
             {{handle-input class="form-control" update=(action (mut model.handle)) value=model.handle name='handle' autofocus=true}}
           </div>
+
           <div class="form-group">
             <label class="block" for="drain-type">Type</label>
             <div class="radio">
               <div>
                 {{#radio-button value="syslog_tls_tcp" groupValue=model.drainType name="drain-type"}}
-                Syslog TLS TCP
+                  Syslog TLS TCP
                 {{/radio-button}}
               </div>
               <div>
                 {{#radio-button value="elasticsearch" groupValue=model.drainType name="drain-type"}}
-                Elasticsearch
+                  Elasticsearch
                 {{/radio-button}}
               </div>
             </div>
           </div>
 
           {{#if isSyslogDrain }}
-          <div class="form-group">
-            <label class="block" for="drain-host">Host</label>
-            {{input name='drain-host' value=model.drainHost class="form-control"}}
-          </div>
-          <div class="">
-            <label class="block" for="drain-port">Port</label>
-            {{input name='drain-port' value=model.drainPort class="form-control"}}
-          </div>
+            <div class="form-group">
+              <label class="block" for="drain-host">Host</label>
+              {{input name='drain-host' value=model.drainHost class="form-control"}}
+            </div>
+            <div>
+              <label class="block" for="drain-port">Port</label>
+              {{input name='drain-port' value=model.drainPort class="form-control"}}
+            </div>
           {{else}}
-          {{ database-selector databases=esDatabases select='setDrainFromDatabase' }}
+            {{#if esDatabases}}
+              <label class="block" for="database-selector">Elasticsearch Database</label>
+              {{database-selector databases=esDatabases select='setDrainFromDatabase'}}
+            {{else}}
+              <div class="no-es-databases-warning">
+                {{stack.handle}} doesn't have any Elasticsearch Databases.
+                {{link-to 'Create one' 'databases.new' stack}}.
+              </div>
+            {{/if}}
           {{/if}}
         </div>
       </div>
+
       <div class="resource-actions">
         <button {{action 'cancel' model}} class='btn btn-lg-text btn-default' type="reset">Cancel</button>
-        <button {{action 'createLog' model}} disabled={{model.isSaving}} class='btn btn-primary' type="submit">
+        <button {{action 'createLog' model}} disabled={{disableSave}} class='btn btn-primary' type="submit">
           {{#if model.isSaving}}
-          Saving
+            Saving
           {{else}}
-          Save Log Drain
+            Save Log Drain
           {{/if}}
         </button>
       </div>

--- a/app/styles/components/resource-list-grid.scss
+++ b/app/styles/components/resource-list-grid.scss
@@ -154,3 +154,49 @@
     padding-bottom: 4px;
   }
 }
+
+.panel {
+  .panel-heading {
+    .fa.fa-spinner {
+      font-size: 12px;
+      margin: 0 10px 0 0;
+    }
+
+    h3 {
+      float: left;
+    }
+  }
+
+  .fa-arrow-right {
+    font-size: 11px;
+    margin: 0 8px;
+    vertical-align: 2px;
+    color: $color-subdued;
+  }
+
+  .resource-subtitle {
+    color: $color-light;
+  }
+
+  .panel-heading-actions {
+    float: right;
+    margin-top: 4px;
+
+    .label {
+      font-size: 11px;
+      text-transform: uppercase;
+    }
+
+    button {
+      margin-left: 5px;
+    }
+  }
+
+  &.default-true .panel-heading-actions {
+    margin-top: 9px;
+  }
+}
+
+.capitalize {
+  text-transform: capitalize;
+}

--- a/app/styles/components/vhost-panel.scss
+++ b/app/styles/components/vhost-panel.scss
@@ -1,42 +1,6 @@
-.panel.vhost {
-  .panel-heading {
-    .fa.fa-spinner {
-      font-size: 12px;
-      margin: 0 10px 0 0;
-    }
-
-    h3 {
-      float: left;
-    }
-  }
-
-  .fa-arrow-right {
-    font-size: 11px;
-    margin: 0 8px;
-    vertical-align: 2px;
-    color: $color-subdued;
-  }
-
+.vhost.panel {
   .vhost-service {
     color: $color-light;
     text-transform: capitalize;
-  }
-
-  .panel-heading-actions {
-    float: right;
-    margin-top: 4px;
-
-    .label {
-      font-size: 11px;
-      text-transform: uppercase;
-    }
-
-    button {
-      margin-left: 5px;
-    }
-  }
-
-  &.default-true .panel-heading-actions {
-    margin-top: 9px;
   }
 }

--- a/app/templates/app/-domain.hbs
+++ b/app/templates/app/-domain.hbs
@@ -13,10 +13,9 @@
         {{/bs-tooltip}}
       {{/if}}
 
-
-      <span class="vhost-virtualdomain">{{vhost.virtualDomain}}</span>
+      <span class="resource-titel vhost-virtualdomain">{{vhost.virtualDomain}}</span>
       <i class="fa fa-arrow-right"></i>
-      <span class="vhost-service">{{vhost.service.processType}} Service</span>
+      <span class="resource-subttle vhost-service">{{vhost.service.processType}} Service</span>
     </h3>
 
     <div class="panel-heading-actions">

--- a/app/templates/stack/-log-drain.hbs
+++ b/app/templates/stack/-log-drain.hbs
@@ -1,0 +1,48 @@
+<div class="panel panel-default log-drain status-{{logDrain.status}} resource-list-item">
+  <div class="panel-heading with-actions">
+    <h3>
+      {{#if logDrain.isProvisioning}}
+        {{#bs-tooltip placement="bottom" title='Provisioning...' bs-container=false}}
+          <i class="fa fa-spin fa-spinner success"></i>
+        {{/bs-tooltip}}
+      {{/if}}
+
+      {{#if logDrain.isPending}}
+        {{#bs-tooltip placement="bottom" title='Provisioning...' bs-container=false}}
+          <i class="fa fa-spin fa-spinner success"></i>
+        {{/bs-tooltip}}
+      {{/if}}
+
+      {{#if logDrain.isDeprovisioning}}
+        {{#bs-tooltip placement="bottom" title='Deprovisioning...' bs-container=false}}
+        <i class="fa fa-spin fa-spinner danger"></i>
+        {{/bs-tooltip}}
+      {{/if}}
+
+      <span class="resource-title">{{logDrain.handle}}</span>
+      <i class="fa fa-arrow-right"></i>
+      <span class="resource-subtitle vhost-service">{{logDrain.drainType}}</span>
+    </h3>
+  </div>
+  <div class="panel-body">
+    <ul class="resource-metadata">
+      <li class="resource-metadata-item">
+        <h5 class="resource-metadata-title">
+          Status
+        </h5>
+        <h3 class="resource-metadata-value">
+          <span class="capitalize">{{logDrain.status}}</span>
+        </h3>
+      </li>
+
+      <li class="resource-metadata-item">
+        <h5 class="resource-metadata-title">
+          Host
+        </h5>
+        <h3 class="resource-metadata-value">
+          {{logDrain.drainHost}}:{{logDrain.drainPort}}
+        </h3>
+      </li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds a few UX improvements to Log Drains.

LogDrains#index is updated to show the log drains handle, type and status.  Log drains are also sorted by their current status, like apps, dbs, and domains.  Log Drains that are either `provisioning` or `deprovisioning` get a colored spinner.

![screenshot 2015-08-07 10 58 54](https://cloud.githubusercontent.com/assets/884151/9138702/69cc7f56-3cf3-11e5-86f9-78403553e399.png)

As a fix to #371, users are now prevented from saving new Elasticsearch Log Drains if they do not have any ES databases for the current environment.  Users are prompted with a warning and a link to create the ES database.

![screenshot 2015-08-07 11 00 32](https://cloud.githubusercontent.com/assets/884151/9138728/97cdacf4-3cf3-11e5-8fa1-59acd78157c2.png)

