### PR TITLE
Improved visual design of payment method edit form

### DIFF
--- a/app/components/stripe-cc-form/component.js
+++ b/app/components/stripe-cc-form/component.js
@@ -8,8 +8,8 @@ export default Ember.Component.extend({
   name: null,
   number: null,
   cvc: null,
-  expMonth: null,
-  expYear: null,
+  expMonth: '01',
+  expYear: '2015',
   zip: null,
 
   isSaving: false,

--- a/app/organization/billing/payment-method/route.js
+++ b/app/organization/billing/payment-method/route.js
@@ -15,6 +15,11 @@ export default Ember.Route.extend({
     showPaymentForm() {
       this.controller.set('showPaymentForm', true);
     },
+
+    hidePaymentForm() {
+      this.controller.set('showPaymentForm', false);
+    },
+
     updatedPayment() {
       this.controller.set('showPaymentForm', false);
       Ember.get(this, 'flashMessages').success('Updated payment method.');

--- a/app/organization/billing/payment-method/template.hbs
+++ b/app/organization/billing/payment-method/template.hbs
@@ -1,21 +1,41 @@
-<div class="layout-container">
-  <div class="row">
-    <div class="panel billing-payment-method">
-      <div class="panel-heading">
-        <h5>Payment Method</h5>
+<div class="row">
+  <div class="col-xs-6">
+    <div class="panel panel-default resource-list-item billing-payment-method">
+      <div class="panel-heading with-actions">
+        {{#if showPaymentForm}}
+          <h3>Edit Payment Method</h3>
+        {{else}}
+          <h3>Current Payment Method</h3>
+          <div class="panel-heading-actions">
+            <button class="btn btn-default btn-xs" {{action 'showPaymentForm'}}>Edit</button>
+          </div>
+        {{/if}}
       </div>
       <div class="panel-body">
-        <p>
-          {{model.paymentMethodName}} ****{{model.paymentMethodDisplay}}
-          Expires {{model.paymentExpMonth}}/{{model.paymentExpYear}}
-        </p>
+        {{#if showPaymentForm}}
+          {{stripe-cc-form organization=organization action="updatedPayment"}}
+        {{else}}
+          <ul class="resource-metadata">
+            <li class="resource-metadata-item">
+              <h5 class="resource-metadata-title">Card Type</h5>
+              <h3 class="resource-metadata-value">{{model.paymentMethodName}}</h3>
+            </li>
+            <li class="resource-metadata-item">
+              <h5 class="resource-metadata-title">Last 4</h5>
+              <h3 class="resource-metadata-value">{{model.paymentMethodDisplay}}</h3>
+            </li>
+            <li class="resource-metadata-item">
+              <h5 class="resource-metadata-title">Expiration</h5>
+              <h3 class="resource-metadata-value">{{model.paymentExpMonth}}/{{model.paymentExpYear}}</h3>
+            </li>
+          </ul>
+        {{/if}}
       </div>
     </div>
+    {{#if showPaymentForm}}
+      <div class="resource-actions">
+        <button class="btn btn-default" {{action 'hidePaymentForm'}}>Cancel</button>
+      </div>
+    {{/if}}
   </div>
 </div>
-
-{{#if showPaymentForm}}
-  {{stripe-cc-form organization=organization action="updatedPayment"}}
-{{else}}
-    <button class='btn btn-primary' {{action 'showPaymentForm'}}>Update Payment Method</button>
-{{/if}}

--- a/tests/acceptance/organization/billing/payment-method-test.js
+++ b/tests/acceptance/organization/billing/payment-method-test.js
@@ -16,7 +16,7 @@ const organizationId = 'o1';
 const paymentMethodUrl = `/organizations/${organizationId}/billing/payment-method`;
 const url = paymentMethodUrl;
 
-const updatePaymentMethodButton = "Update Payment Method";
+const updatePaymentMethodButton = "Edit";
 
 module('Acceptance: Organizations: Billing: Payment Method', {
   beforeEach: function() {
@@ -77,7 +77,7 @@ test(`shows current payment method`, (assert) => {
   });
 });
 
-test(`shows credit card form after clicking "Update Payment Method"`, (assert) => {
+test(`shows credit card form after clicking "Edit"`, (assert) => {
   stubOrganization();
   stubBillingDetail();
   signInAndVisit(url);


### PR DESCRIPTION
Relates to #243 

Also adding a default `expMonth` and `expYear` to the `stripe-cc-form` prevents an error when the user doesn't actually toggle the select values for expiration month/year.  

![screenshot 2015-08-11 11 31 33](https://cloud.githubusercontent.com/assets/884151/9201758/a3831864-401c-11e5-9c56-081f5fbc0d57.png)

![screenshot 2015-08-11 11 31 42](https://cloud.githubusercontent.com/assets/884151/9201769/ad4ec2bc-401c-11e5-9804-2bff1cf690d6.png)
