### PR TITLE
Use organization_id instead of organization_url

### DIFF
--- a/app/organization/environments/new/route.js
+++ b/app/organization/environments/new/route.js
@@ -7,8 +7,7 @@ export default Ember.Route.extend({
     let organization = this.modelFor('organization');
     const billingDetail = this.store.find('billing-detail', organization.get('id'));
     const stack = this.store.createRecord('stack', {
-      organization,
-      organizationUrl: organization.get('_data.links.self')
+      organization
     });
 
     return Ember.RSVP.hash({

--- a/app/welcome/payment-info/route.js
+++ b/app/welcome/payment-info/route.js
@@ -60,14 +60,12 @@ export default Ember.Route.extend({
 
         return subscription.save();
       }).then(function(){
-        var organizationUrl = organization.get('_data.links.self');
-
         saveProgress.set('currentStep', 3);
 
         return store.createRecord('stack', {
           handle: welcomeModel.stackHandle,
           type: model.plan === 'development' ? 'development' : 'production',
-          organizationUrl: organizationUrl
+          organization: organization
         }).save();
       }).then(function(stack) {
         var promises = [];

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -189,7 +189,7 @@ test('submitting valid payment info for development plan should create dev stack
 
   stackAssertions[stackHandle] = (params) => {
     assert.ok(true, 'stack handle is correct');
-    assert.equal(params.organization_url, '/organizations/1', 'correct organization_url is posted');
+    assert.equal(params.organization_id, '1', 'correct organization_id is posted');
     assert.equal(params.type, 'development', 'stack type is correct');
     stackAssertions[params.handle] = null;
   };


### PR DESCRIPTION
This commit uses organization_id instead of organization_url
to create new stacks with. This is the UI part of aptible/api.aptible.com#231.

cc @fancyremarker @sandersonet 