### PR TITLE
Preselect current vhost certificate when editing

### DIFF
--- a/app/app/vhosts/edit/route.js
+++ b/app/app/vhosts/edit/route.js
@@ -29,11 +29,9 @@ export default Ember.Route.extend({
 
   setupController(controller, model) {
     let vhost = model.vhost;
-    let certificates = model.certificates;
 
     controller.set('model', vhost);
     controller.set('certificates', model.certificates);
-    controller.set('vhostCertificate', certificates.get('firstObject'));
     controller.set('originalCertificate', vhost.get('certificate'));
   },
 

--- a/app/app/vhosts/edit/template.hbs
+++ b/app/app/vhosts/edit/template.hbs
@@ -25,7 +25,7 @@
             </select>
           </div>
 
-          {{select-or-create-certificate certificates=certificates vhost=model}}
+          {{select-or-create-certificate certificates=certificates vhost=model selected=model.certificate}}
 
         </form>
 

--- a/app/components/object-select/template.hbs
+++ b/app/components/object-select/template.hbs
@@ -1,8 +1,8 @@
 <select class="form-control" name={{name}} {{action 'update' on="change"}}>
   {{#if prompt}}
-    <option disabled>{{prompt}}</option>
+    <option disabled selected={{if (not selected) true null}}>{{prompt}}</option>
   {{/if}}
   {{#each items as |item|}}
-      <option selected={{if (eq selected item) true null}} value="{{item.id}}">{{item.name}}</option>
+      <option selected={{if (eq selected.id item.id) true null}} value="{{item.id}}">{{item.name}}</option>
   {{/each}}
 </select>

--- a/app/components/select-or-create-certificate/component.js
+++ b/app/components/select-or-create-certificate/component.js
@@ -6,7 +6,9 @@ export default Ember.Component.extend({
     this.set('vhost.privateKey', null);
 
     if(this.get('certificates.length') > 0) {
-      this.set('vhost.certificate', this.get('certificates.firstObject'));
+      if(!this.get('selected.id')) {
+        this.set('vhost.certificate', this.get('certificates.firstObject'));
+      }
     } else {
       this.set('addNewCertificate', true);
     }

--- a/app/components/select-or-create-certificate/template.hbs
+++ b/app/components/select-or-create-certificate/template.hbs
@@ -18,7 +18,7 @@
   {{#if certificates}}
     <div class="form-group">
       <label>Certificate</label>
-      {{object-select name="certificate" items=certificates update=(action (mut vhost.certificate))}}
+      {{object-select name="certificate" items=certificates update=(action (mut vhost.certificate)) selected=selected}}
     </div>
 
     <div class="form-group">

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.6",
     "ember-cli-app-version": "0.4.0",
-    "ember-cli-aptible-shared": "0.0.31",
+    "ember-cli-aptible-shared": "0.0.32",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",


### PR DESCRIPTION
This ensures that when editing a VHOST, the currently selected certificate is the default selection option.

Also bumping aptible-shared to fix certificate#apps relation.
