### PR TITLE
Standardize endpoint URI configuration by domain and subdomain suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,14 @@ An addon is used to create new websites on top of S3 bucket with website hosting
 
 To create a new website use the following command:
 
-```
-ember create-website --domain=aptible-staging.com --subdomain=dashboard-rwjblue
+```bash
+ember create-website --domain=aptible-sandbox.com --subdomain-suffix="-rwjblue"
 ```
 
 To build and deploy to this newly created bucket, use the following command:
 
 ```bash
-AWS_BUCKET=dashboard-rwjblue.aptible-staging.com ember deploy --environment staging
+DOMAIN=aptible-sandbox.com SUBDOMAIN_SUFFIX="-rwjblue" ember deploy -e sandbox
 ```
 
 #### Continuous Deployment

--- a/README.md
+++ b/README.md
@@ -56,13 +56,25 @@ An addon is used to create new websites on top of S3 bucket with website hosting
 To create a new website use the following command:
 
 ```bash
-ember create-website --domain=aptible-sandbox.com --subdomain-suffix="-rwjblue"
+ember create-website --domain=aptible-sandbox.com --subdomain-suffix=rwjblue
 ```
 
 To build and deploy to this newly created bucket, use the following command:
 
 ```bash
-DOMAIN=aptible-sandbox.com SUBDOMAIN_SUFFIX="-rwjblue" ember deploy -e sandbox
+DOMAIN=aptible-sandbox.com SUBDOMAIN_SUFFIX=rwjblue ember deploy -e sandbox
+```
+
+Using the arguments from the above example, the Ember app would then be accessible at https://dashboard-rwjblue.aptible-sandbox.com, and would reference Auth, API, and Billing endoints also suffixed with "-rwjblue", i.e.:
+
+* `https://auth-rwjblue.aptible-sandbox.com`
+* `https://api-rwjblue.aptible-sandbox.com`
+* `https://billing-rwjblue.aptible-sandbox.com`
+
+If, instead, you wish to deploy a "suffixed" Dashboard but point at the non-suffixed Auth/API/Billing, you could run:
+
+```bash
+DOMAIN=aptible-sandbox.com S3_BUCKET=dashboard-rwjblue.aptible-sandbox.com ember deploy -e sandbox
 ```
 
 #### Continuous Deployment

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -4,7 +4,7 @@ var detectEndpointUri = require('../lib/detect-endpoint-uri');
 function optionsFor(environment, type) {
   var accessKeyId = process.env['AWS_ACCESS_KEY_ID'];
   var secretAccessKey = process.env['AWS_SECRET_ACCESS_KEY'];
-  var bucket = detectEndpointUri('dashboard', environment, '');
+  var bucket = process.env['S3_BUCKET'] || detectEndpointUri('dashboard', environment, '');
 
   if (!bucket) {
     throw new SilentError('No bucket was found for ' + environment);

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,17 +1,10 @@
 var SilentError = require('silent-error');
-
-var bucketMap = {
-  production: 'dashboard.aptible.com',
-  staging: 'dashboard.aptible-staging.com'
-};
-
-function defaultOptions() {
-}
+var detectEndpointUri = require('../lib/detect-endpoint-uri');
 
 function optionsFor(environment, type) {
   var accessKeyId = process.env['AWS_ACCESS_KEY_ID'];
   var secretAccessKey = process.env['AWS_SECRET_ACCESS_KEY'];
-  var bucket = process.env['AWS_BUCKET'] || bucketMap[environment];
+  var bucket = detectEndpointUri('dashboard', environment, '');
 
   if (!bucket) {
     throw new SilentError('No bucket was found for ' + environment);
@@ -35,7 +28,7 @@ function optionsFor(environment, type) {
 }
 
 var options = {};
-var environments = ['production', 'staging'];
+var environments = ['production', 'staging', 'sandbox'];
 
 environments.forEach(function(environment) {
   options[environment] = {

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,5 +1,7 @@
 /* jshint node: true */
 
+var detectEndpointUri = require('../lib/detect-endpoint-uri');
+
 module.exports = function(environment) {
   var ENV = {
     modulePrefix: 'diesel',
@@ -7,13 +9,13 @@ module.exports = function(environment) {
     baseURL: '/',
     locationType: 'auto',
 
-    authBaseUri: process.env.AUTH_BASE_URI || "http://localhost:4000",
-    apiBaseUri: process.env.API_BASE_URI || "http://localhost:4001",
-    billingBaseUri: process.env.BILLING_BASE_URI || "http://localhost:4004",
+    authBaseUri: detectEndpointUri('auth', environment) || 'http://localhost:4000',
+    apiBaseUri: detectEndpointUri('api', environment) || 'http://localhost:4001',
+    billingBaseUri: detectEndpointUri('billing', environment) || 'http://localhost:4004',
     aptibleHosts: {
-      compliance: 'http://localhost:3001',
-      dashboard: "http://localhost:4200",
-      support: "https://support.aptible.com"
+      compliance: detectEndpointUri('compliance', environment) || 'http://localhost:3001',
+      dashboard: detectEndpointUri('dashboard', environment) || 'http://localhost:4200',
+      support: 'https://support.aptible.com'
     },
 
     authTokenKey: '_aptible_authToken',
@@ -65,7 +67,7 @@ module.exports = function(environment) {
       'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com http://www.google-analytics.com http://p.typekit.net https://track.customer.io https://js.intercomcdn.com data: app.getsentry.com",
       'script-src': "'self' 'unsafe-inline' https://js.stripe.com https://api.stripe.com http://use.typekit.net http://cdn.segment.com https://assets.customer.io http://www.google-analytics.com http://cdn.mxpnl.com https://js.intercomcdn.com https://static.intercomcdn.com https://widget.intercom.io http://cdn.ravenjs.com",
       'font-src': "'self' data:",
-      'object-src': "http://localhost:4200"
+      'object-src': 'http://localhost:4200'
     },
 
     featureFlags: {
@@ -114,31 +116,18 @@ module.exports = function(environment) {
   }
 
   if (environment === 'staging') {
-    ENV.authBaseUri = "https://auth.aptible-staging.com";
-    ENV.apiBaseUri = "https://api.aptible-staging.com";
-    ENV.billingBaseUri = "https://billing.aptible-staging.com";
-    ENV.aptibleHosts = {
-      compliance: 'https://compliance.aptible-staging.com',
-      dashboard: "https://dashboard.aptible-staging.com",
-      support: "https://support.aptible-staging.com"
-    };
     ENV.segmentioKey = '6jZlAcweTojgXShBvn4B9Tvwr1IlqkEE';
+
     ENV.featureFlags['price-estimator'] = false;
+
     ENV.sentry.whitelistUrls = ['dashboard.aptible-staging.com'];
     ENV.sentry.development = false;
   }
 
   if (environment === 'production') {
     ENV.stripePublishableKey = 'pk_live_ujeTeUIMpUcvNsWwu7R9b3Zy';
-    ENV.authBaseUri = "https://auth.aptible.com";
-    ENV.apiBaseUri = "https://api.aptible.com";
-    ENV.billingBaseUri = "https://billing.aptible.com";
-    ENV.aptibleHosts = {
-      compliance: 'https://compliance.aptible.com',
-      dashboard: "https://dashboard.aptible.com",
-      support: "https://support.aptible.com"
-    };
     ENV.segmentioKey = '5aOlxMYapu6bQCQYFbDz7rhNvVV7B1A5';
+
     ENV.featureFlags['organization-settings'] = true;
     ENV.featureFlags['price-estimator'] = false;
     ENV.featureFlags['notifications'] = true;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,7 +9,7 @@ module.exports = function(defaults) {
     }
   };
 
-  if (process.env.EMBER_ENV === 'staging') {
+  if (process.env.EMBER_ENV === 'staging' || process.env.EMBER_ENV === 'sandbox') {
     options.minifyCSS = {
       enabled: true
     };

--- a/lib/create-website/commands/create-website.js
+++ b/lib/create-website/commands/create-website.js
@@ -9,7 +9,7 @@ module.exports = {
 
   availableOptions: [
     { name: 'domain', type: String },
-    { name: 'subdomainSuffix', type: String, default: '' },
+    { name: 'subdomain-suffix', type: String, default: '' },
     { name: 'cloudfront', type: Boolean, default: true },
     { name: 'region', type: String, default: 'us-east-1' }
   ],
@@ -25,7 +25,12 @@ module.exports = {
   },
 
   buildParams: function(commandOptions) {
-    var stackName = 'website-dashboard' + commandOptions.subdomainSuffix + '-' + commandOptions.domain;
+    // Prefix subdomainSuffix with '-', if it is present
+    var subdomainSuffix = '';
+    if (commandOptions.subdomainSuffix) {
+      var subdomainSuffix = '-' + commandOptions.subdomainSuffix;
+    }
+    var stackName = 'website-dashboard' + subdomainSuffix + '.' + commandOptions.domain;
     // stack name can only be alpha, numeric, and dashes
     stackName = stackName.replace(/[^a-zA-Z0-9]/g, '-');
 
@@ -41,7 +46,7 @@ module.exports = {
         },
         {
           ParameterKey: 'Subdomain',
-          ParameterValue: 'dashboard' + commandOptions.subdomainSuffix
+          ParameterValue: 'dashboard' + subdomainSuffix
         }
       ],
       TemplateBody: templateBody

--- a/lib/create-website/commands/create-website.js
+++ b/lib/create-website/commands/create-website.js
@@ -9,7 +9,7 @@ module.exports = {
 
   availableOptions: [
     { name: 'domain', type: String },
-    { name: 'subdomain', type: String },
+    { name: 'subdomainSuffix', type: String, default: '' },
     { name: 'cloudfront', type: Boolean, default: true },
     { name: 'region', type: String, default: 'us-east-1' }
   ],
@@ -25,7 +25,7 @@ module.exports = {
   },
 
   buildParams: function(commandOptions) {
-    var stackName = 'website-' + commandOptions.subdomain + '-' + commandOptions.domain;
+    var stackName = 'website-dashboard' + commandOptions.subdomainSuffix + '-' + commandOptions.domain;
     // stack name can only be alpha, numeric, and dashes
     stackName = stackName.replace(/[^a-zA-Z0-9]/g, '-');
 
@@ -41,7 +41,7 @@ module.exports = {
         },
         {
           ParameterKey: 'Subdomain',
-          ParameterValue: commandOptions.subdomain
+          ParameterValue: 'dashboard' + commandOptions.subdomainSuffix
         }
       ],
       TemplateBody: templateBody

--- a/lib/detect-endpoint-uri.js
+++ b/lib/detect-endpoint-uri.js
@@ -26,6 +26,11 @@ module.exports = function(subdomain, environment, protocol) {
     protocol = 'https://';
   }
 
-  var subdomainSuffix = process.env['SUBDOMAIN_SUFFIX'] || '';
+  // Prefix subdomain suffix with '-', if it is present
+  if (process.env['SUBDOMAIN_SUFFIX']) {
+    var subdomainSuffix = '-' + process.env['SUBDOMAIN_SUFFIX'];
+  } else {
+    var subdomainSuffix = '';
+  }
   return protocol + subdomain + subdomainSuffix + '.' + domain;
 }

--- a/lib/detect-endpoint-uri.js
+++ b/lib/detect-endpoint-uri.js
@@ -1,0 +1,31 @@
+module.exports = function(subdomain, environment, protocol) {
+  var explicitEndpoint = process.env[subdomain.toUpperCase() + '_BASE_URI'];
+  if (explicitEndpoint) {
+    return explicitEndpoint;
+  }
+
+  var domain = process.env['DOMAIN'];
+  if (!domain) {
+    // Set domain based on environment
+    switch(environment) {
+      case 'sandbox':
+        domain = 'aptible-sandbox.com';
+        break;
+      case 'staging':
+        domain = 'aptible-staging.com';
+        break;
+      case 'production':
+        domain = 'aptible-foobar.com';
+        break;
+      default:
+        return null;
+    }
+  }
+
+  if (protocol === undefined) {
+    protocol = 'https://';
+  }
+
+  var subdomainSuffix = process.env['SUBDOMAIN_SUFFIX'] || '';
+  return protocol + subdomain + subdomainSuffix + '.' + domain;
+}


### PR DESCRIPTION
The goal of this PR is to extract "endpoint" URI configuration (i.e., auth, api, billing, etc.) into a separate helper `detectEndpointUri`, and to standardize the way in which these endpoint URIs are determined for a given database deployment.

Ultimately, the idea is to make it easier to deploy "primary" stacks (see aptible/pancake#8), for personal or feature-specific use, with their own Auth/API/Billing, and front these with a dedicated Dashboard.