### PR TITLE
Format Currency Helper

### DIFF
--- a/app/components/total-monthly-estimate/component.js
+++ b/app/components/total-monthly-estimate/component.js
@@ -34,6 +34,6 @@ export default Ember.Component.extend({
     return ((netContainers * containerCentsPerHour +
             netDomains * domainCentsPerHour +
             netDisk * diskCentsPerHour) * HOURS_PER_MONTH) +
-            (this.get('billingDetail.planRate') * 100);
+            this.get('billingDetail.planRate');
   })
 });

--- a/app/components/total-monthly-estimate/component.js
+++ b/app/components/total-monthly-estimate/component.js
@@ -24,19 +24,16 @@ export default Ember.Component.extend({
   }),
 
   // Total value
-  total: Ember.computed('netContainers', 'netDomains', 'netDisk', 'billingDetail', function() {
+  total: Ember.computed('netContainers', 'netDomains', 'netDisk', 'billingDetail', 'billingDetail.planRate', function() {
     let billingDetail = this.get('billingDetail');
     let { containerCentsPerHour, domainCentsPerHour, diskCentsPerHour } = billingDetail.getProperties(
       ['containerCentsPerHour', 'domainCentsPerHour', 'diskCentsPerHour']);
     let { netContainers, netDomains, netDisk } = this.getProperties(
       ['netContainers', 'netDomains', 'netDisk']);
 
-    return (netContainers * containerCentsPerHour +
+    return ((netContainers * containerCentsPerHour +
             netDomains * domainCentsPerHour +
-            netDisk * diskCentsPerHour) * HOURS_PER_MONTH;
-  }),
-
-  totalDollars: Ember.computed('total', 'billingDetail.planRate', function() {
-    return ((this.get('total') / 100) + this.get('billingDetail.planRate')).toFixed(2);
+            netDisk * diskCentsPerHour) * HOURS_PER_MONTH) +
+            (this.get('billingDetail.planRate') * 100);
   })
 });

--- a/app/components/total-monthly-estimate/template.hbs
+++ b/app/components/total-monthly-estimate/template.hbs
@@ -1,1 +1,1 @@
-${{totalDollars}}
+{{format-currency total}}

--- a/app/components/usage-quote-by-resource/component.js
+++ b/app/components/usage-quote-by-resource/component.js
@@ -30,9 +30,5 @@ export default Ember.Component.extend({
 
   totalUsageCost: Ember.computed('netUsage', 'hourlyRate', function() {
     return this.get('netUsage') * this.get('hourlyRate') * HOURS_PER_MONTH;
-  }),
-
-  totalUsageInDollars: Ember.computed('totalUsageCost', function() {
-    return `$${(this.get('totalUsageCost') / 100).toFixed(2)}`;
   })
 });

--- a/app/components/usage-quote-by-resource/template.hbs
+++ b/app/components/usage-quote-by-resource/template.hbs
@@ -9,7 +9,7 @@
         Total monthly {{resource}} cost:
       </span>
       <span class="usage-value">
-        {{totalUsageInDollars}}
+        {{format-currency totalUsageCost}}
       </span>
     </div>
   </div>

--- a/app/helpers/format-currency.js
+++ b/app/helpers/format-currency.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+/**
+ * Takes money values in cents and returns a value in dollars
+ * 123456789 will return $1,234,567.89
+ * 12345 will return $123.45
+ * 1 will return $0.01
+ */
+export default Ember.Helper.helper(function([ input ]) {
+  return '$' + (input / 100).toFixed(2).replace(/(\d)(?=(\d{3})+\.)/g, '$1,');
+});

--- a/app/organization/billing/index/template.hbs
+++ b/app/organization/billing/index/template.hbs
@@ -10,7 +10,7 @@
             Monthly Price:
           </span>
           <span class="usage-value">
-            ${{billingDetail.planRate}}
+            ${{billingDetail.planRate}}.00
           </span>
         </div>
       </div>

--- a/app/organization/billing/index/template.hbs
+++ b/app/organization/billing/index/template.hbs
@@ -10,7 +10,7 @@
             Monthly Price:
           </span>
           <span class="usage-value">
-            ${{billingDetail.planRate}}.00
+            {{format-currency billingDetail.planRate}}
           </span>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
-    "ember-cli-aptible-shared": "0.0.33",
+    "ember-cli-aptible-shared": "0.0.34",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",

--- a/tests/integration/components/total-monthly-estimate-test.js
+++ b/tests/integration/components/total-monthly-estimate-test.js
@@ -17,13 +17,13 @@ test('sums usage correctly', function(assert) {
   // Net domain rate: (8 + 1 - 4) * 5 * 730 = 18250
   // Net disk rate: (2000 + 1000 - 1000) * .0507 * 730 = 74022
   // Net cents: 138992
-  // net dollars: $1389.92
+  // net dollars: $1,389.92
 
   this.set('stacks', [stack1, stack2]);
   this.set('billingDetail', billingDetail);
   this.render(hbs('{{total-monthly-estimate stacks=stacks billingDetail=billingDetail}}'));
 
-  assert.equal(this.$().text(), '$1389.92', 'has correct total value');
+  assert.equal(this.$().text().trim(), '$1,389.92', 'has correct total value');
 });
 
 test('sums usage with base plan rate correctly', function(assert) {
@@ -38,11 +38,11 @@ test('sums usage with base plan rate correctly', function(assert) {
   // Net disk rate: (2000 + 1000 - 1000) * .0507 * 730 = 74022
   // Net plan rate 349900
   // Net cents: 488892
-  // net dollars: $4888.92
+  // net dollars: $4,888.92
 
   this.set('stacks', [stack1, stack2]);
   this.set('billingDetail', billingDetail);
   this.render(hbs('{{total-monthly-estimate stacks=stacks billingDetail=billingDetail}}'));
 
-  assert.equal(this.$().text(), '$4888.92', 'has correct total value');
+  assert.equal(this.$().text().trim(), '$4,888.92', 'has correct total value');
 });

--- a/tests/integration/components/total-monthly-estimate-test.js
+++ b/tests/integration/components/total-monthly-estimate-test.js
@@ -31,7 +31,7 @@ test('sums usage with base plan rate correctly', function(assert) {
   let stack2 = Ember.Object.create({ handle: 'stack2',  containerCount: 3, domainCount: 1, totalDiskSize: 1000 });
   let billingDetail = Ember.Object.create({ containerAllowance: 6, domainAllowance: 4,
                                             diskAllowance: 1000, containerCentsPerHour: 8,
-                                            domainCentsPerHour: 5, diskCentsPerHour: 0.0507, planRate: 3499 });
+                                            domainCentsPerHour: 5, diskCentsPerHour: 0.0507, planRate: 349900 });
 
   // Net container rate: (11 + 3 - 6) * 8 * 730 = 46720
   // Net domain rate: (8 + 1 - 4) * 5 * 730 = 18250

--- a/tests/integration/helpers/format-currency-test.js
+++ b/tests/integration/helpers/format-currency-test.js
@@ -1,0 +1,44 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('format-currency', 'helper:format-currency', {
+  integration: true
+});
+
+test('properly formats an integer cents value to dollars', function(assert) {
+  this.set('inputValue', 1234);
+
+  this.render(hbs`{{format-currency inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '$12.34');
+});
+
+test('properly adds comma delimiters for large values', function(assert) {
+  this.set('inputValue', 123456789);
+
+  this.render(hbs`{{format-currency inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '$1,234,567.89');
+});
+
+test('properly formats values under $1', function(assert) {
+  this.set('inputValue', 8);
+
+  this.render(hbs`{{format-currency inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '$0.08');
+
+  this.set('inputValue', 99);
+
+  this.render(hbs`{{format-currency inputValue}}`);
+
+  assert.equal(this.$().text().trim(), '$0.99');
+});
+
+test('adds a dollar sign to the beginning of the output', function(assert) {
+  this.set('inputValue', 1);
+
+  this.render(hbs`{{format-currency inputValue}}`);
+
+  assert.equal(this.$().text().trim().indexOf('$'), 0);
+});


### PR DESCRIPTION
My minor addition to the overview work I had done before @sandersonet picked it up. This PR adds a helper to display currency values in cents.

In an effort to display the dollar values consistently, there is some code smell around formatting the `billingDetails.planRate` since it is in dollars. I'm sure there is a better way to provide logic in the helper to do both. Would love to hear thoughts from @sandersonet and @rwjblue on that for a follow up.

