### PR TITLE
Automatically fetch all apps and databases.

### DIFF
--- a/app/apps/route.js
+++ b/app/apps/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import fetchAllPages from '../utils/fetch-all-pages';
 
 export default Ember.Route.extend({
   title: function(){
@@ -8,10 +9,12 @@ export default Ember.Route.extend({
   model: function(){
     var stack = this.modelFor('stack');
     var apps = stack.get('apps');
-    if (apps.get('isFulfilled')) {
-      return apps.reload();
-    } else {
-      return apps;
-    }
+
+    var promise = apps.get('isFulfilled') ? apps.reload() : Ember.RSVP.resolve();
+
+    return promise
+      .then(() => {
+        return fetchAllPages(this.store, stack, 'app');
+      });
   }
 });

--- a/app/databases/route.js
+++ b/app/databases/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import fetchAllPages from '../utils/fetch-all-pages';
 
 export default Ember.Route.extend({
   title: function(){
@@ -8,10 +9,12 @@ export default Ember.Route.extend({
   model: function(){
     var stack = this.modelFor('stack');
     var databases = stack.get('databases');
-    if (databases.get('isFulfilled')) {
-      return databases.reload();
-    } else {
-      return databases;
-    }
+
+    var promise = databases.get('isFulfilled') ? databases.reload() : Ember.RSVP.resolve();
+
+    return promise
+      .then(() => {
+        return fetchAllPages(this.store, stack, 'database');
+      });
   }
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-aptible-shared": "0.0.39",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.1",
+    "ember-cli-dependency-checker": "^1.1.0",
     "ember-cli-deploy": "^0.4.1",
     "ember-cli-deprecation-workflow": "^0.1.4",
     "ember-cli-fake-server": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
-    "ember-cli-aptible-shared": "0.0.39",
+    "ember-cli-aptible-shared": "0.0.40",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",

--- a/tests/acceptance/apps/basic-test.js
+++ b/tests/acceptance/apps/basic-test.js
@@ -91,6 +91,76 @@ test(`visiting ${url} shows list of apps`, function(assert) {
   });
 });
 
+test(`visiting ${url} shows all pages of apps`, function(assert) {
+  assert.expect(3);
+
+  let orgId = 1;
+  let stackHandle = 'my-stack-1';
+
+  let apps = [{
+    id: 1,
+    handle: 'my-app-1-stack-1',
+    status: 'provisioned',
+    _embedded: {
+      services: [{
+        id: '1',
+        handle: 'the-service',
+        container_count: 1
+      }]
+    },
+    _links: {
+      account: { href: '/accounts/my-stack-1'}
+    }
+  }, {
+    id: 2,
+    handle: 'my-app-2-stack-1',
+    status: 'provisioned',
+    _embedded: {
+      services: [{
+        id: '2',
+        handle: 'the-service-2',
+        container_count: 1
+      }]
+    },
+    _links: {
+      account: { href: '/accounts/my-stack-1'}
+    }
+  }];
+
+  stubStacks();
+
+  stubRequest('get', '/accounts/my-stack-1/apps', function(request){
+    let page = request.queryParams.page || 1;
+
+    assert.ok(true, `app request was made for page #${page}`);
+
+    return this.success({
+      _links: {},
+      _embedded: {
+        apps: [ apps[page - 1]]
+      },
+      current_page: page,
+      per_page: 1,
+      total_count: 2
+    });
+  });
+
+  stubStack({
+    id: stackId,
+    handle: stackHandle,
+    _links: {
+      apps: { href: `/accounts/${stackId}/apps` },
+      organization: { href: `/organizations/${orgId}` }
+    }
+  });
+  stubOrganization();
+  stubOrganizations();
+
+  signInAndVisit(url);
+  andThen(function() {
+    assert.equal(find('.panel.app').length, 2, '2 apps');
+  });
+});
 
 test(`visiting ${url} shows list of provisioning apps`, function(assert) {
   let orgId = 1;


### PR DESCRIPTION
Requires https://github.com/aptible/ember-cli-aptible-shared/pull/47 and a release of ember-cli-aptible-shared@0.0.40.

Fixes #428.