### PR TITLE
Add vhosts to stack header

### DIFF
--- a/app/components/stack-metadata/component.js
+++ b/app/components/stack-metadata/component.js
@@ -3,9 +3,34 @@ import sum from '../../utils/sum';
 
 export default Ember.Component.extend({
   tagName: '',
+  maxVisibleDomainNames: 2,
 
   persistedApps: Ember.computed.filterBy('model.apps', 'isNew', false),
   persistedDatabases: Ember.computed.filterBy('model.databases', 'isNew', false),
+  persistedVhosts: Ember.computed.filterBy('model.vhosts', 'isNew', false),
+  vhostNames: Ember.computed.mapBy('persistedVhosts', 'commonName'),
+
+  displayVhostNames: Ember.computed('vhostNames', function() {
+    return this.get('vhostNames').join(', ');
+  }),
+
+  showVhostTooltip: Ember.computed('vhostNames', function() {
+    return this.get('vhostNames.length') > this.get('maxVisibleDomainNames');
+  }),
+
+  vhostRemaining: Ember.computed('vhostNames', function() {
+    return this.get('vhostNames.length') - this.get('maxVisibleDomainNames');
+  }),
+
+  vhostNamesSnippet: Ember.computed('vhostNames', function() {
+    let names = this.get('vhostNames');
+    return names.slice(0, this.get('maxVisibleDomainNames')).join(', ');
+  }),
+
+  vhostNamesTooltip: Ember.computed('vhostNames', function() {
+    let names = this.get('vhostNames');
+    return names.slice(this.get('maxVisibleDomainNames')).join(', ');
+  }),
 
   totalDiskSize: function(){
     let sizes = this.get('persistedDatabases').mapBy('disk.size').compact();

--- a/app/components/stack-metadata/template.hbs
+++ b/app/components/stack-metadata/template.hbs
@@ -14,12 +14,27 @@
 
     <li class="resource-metadata-item">
       <h5 class="resource-metadata-title">{{persistedApps.length}} {{plural-string "App" persistedApps.length}}</h5>
-      <h3 class="resource-metadata-value">Running on {{totalContainerCount}} {{plural-string "container" totalContainerCount}}</h3>
+      <h3 class="resource-metadata-value">Using {{totalContainerCount}} {{plural-string "container" totalContainerCount}}</h3>
     </li>
 
     <li class="resource-metadata-item">
       <h5 class="resource-metadata-title">{{persistedDatabases.length}} {{plural-string "Database" persistedDatabases.length}}</h5>
-      <h3 class="resource-metadata-value">Using {{format-disk-size totalDiskSize}} of Disk</h3>
+      <h3 class="resource-metadata-value">Using {{persistedDatabases.length}} {{plural-string "container" persistedDatabases.length}} and {{format-disk-size totalDiskSize}} of disk</h3>
+    </li>
+
+    <li class="resource-metadata-item">
+      <h5 class="resource-metadata-title">{{persistedVhosts.length}} {{plural-string "Domain" persistedVhosts.length}}</h5>
+      <h3 class="resource-metadata-value">
+        {{#if showVhostTooltip}}
+          {{vhostNamesSnippet}}
+           and
+          {{#bs-tooltip title=vhostNamesTooltip placement="bottom" bs-container=false}}
+            <u>{{vhostRemaining}} more</u>
+          {{/bs-tooltip}}
+        {{else}}
+          {{displayVhostNames}}
+        {{/if}}
+      </h3>
     </li>
 
     <li class="resource-metadata-item">

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
-    "ember-cli-aptible-shared": "0.0.39",
+    "ember-cli-aptible-shared": "0.0.40",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.1",

--- a/tests/acceptance/stack/show-test.js
+++ b/tests/acceptance/stack/show-test.js
@@ -108,11 +108,11 @@ test(`visit ${url} shows basic stack info`, function(assert) {
        'Header that contains db length');
 
     // 2 + 3
-    assert.ok(find(`h3:contains(Running on 5 containers)`).length,
+    assert.ok(find(`h3:contains(Using 5 containers)`).length,
        'has containers count');
 
     // 4 + 2
-    assert.ok(find(`h3:contains(Using 6GB of Disk)`).length,
+    assert.ok(find(`h3:contains(Using 2 containers and 6GB of disk)`).length,
        'has disk size header');
   });
 });


### PR DESCRIPTION
This updates the stack#show header to be a bit more explicit about what resources live under the stack.

* Added container count to databases section
* Added new domains count section, with comma-separated list of all running domains

![screenshot 2015-09-18 11 50 47](https://cloud.githubusercontent.com/assets/884151/9963927/9dfdcd6a-5dfb-11e5-804e-1c605eb50f87.png)
