### PR TITLE
Fix header overflow

### DIFF
--- a/app/components/stack-metadata/template.hbs
+++ b/app/components/stack-metadata/template.hbs
@@ -19,7 +19,7 @@
 
     <li class="resource-metadata-item">
       <h5 class="resource-metadata-title">{{persistedDatabases.length}} {{plural-string "Database" persistedDatabases.length}}</h5>
-      <h3 class="resource-metadata-value">Using {{persistedDatabases.length}} {{plural-string "container" persistedDatabases.length}} and {{format-disk-size totalDiskSize}} of disk</h3>
+      <h3 class="resource-metadata-value">Using {{format-disk-size totalDiskSize}} of disk</h3>
     </li>
 
     <li class="resource-metadata-item">
@@ -38,7 +38,7 @@
     </li>
 
     <li class="resource-metadata-item">
-      <h5 class="resource-metadata-title">Log Drains</h5>
+      <h5 class="resource-metadata-title">{{model.logDrains.length }} Log {{plural-string "Drain" model.logDrains.length}}</h5>
       <h3 class="resource-metadata-value">
         {{#with model.logDrains.firstObject as |logDrain|}}
           {{logDrain.drainHost}}:{{logDrain.drainPort}}

--- a/tests/acceptance/stack/show-test.js
+++ b/tests/acceptance/stack/show-test.js
@@ -112,7 +112,7 @@ test(`visit ${url} shows basic stack info`, function(assert) {
        'has containers count');
 
     // 4 + 2
-    assert.ok(find(`h3:contains(Using 2 containers and 6GB of disk)`).length,
+    assert.ok(find(`h3:contains(Using 6GB of disk)`).length,
        'has disk size header');
   });
 });


### PR DESCRIPTION
The header tends to overflow with long domains, so shortening some of the field values and adding a log drain count to be consistent with the other fields. 

Ultimately, I think the "PHI-Ready" should be a badge or icon of some kind next to the stack handle, rather than included in the list of stack metadata.