### PR TITLE
Fix database header for provisioning databases [fixes #426]

### DIFF
--- a/app/templates/database/-header.hbs
+++ b/app/templates/database/-header.hbs
@@ -31,31 +31,32 @@
         <h3 class="resource-metadata-value">{{model.type}}</h3>
       </li>
 
-      {{#if model.disk}}
+      {{#if model.isProvisioned}}
+        {{#if model.disk}}
+          <li class="resource-metadata-item">
+            <h5 class="resource-metadata-title">Size</h5>
+            <h3 class="resource-metadata-value db-size">{{model.disk.size}} GB</h3>
+          </li>
+        {{/if}}
         <li class="resource-metadata-item">
-          <h5 class="resource-metadata-title">Size</h5>
-          <h3 class="resource-metadata-value">{{model.disk.size}} GB</h3>
+          <h5 class="resource-metadata-title">Connection URL</h5>
+          <h3 class="resource-metadata-value">
+            <span class="db-connection-url">{{model.connectionUrl}}</span>
+            {{#click-to-copy text=model.connectionUrl as |copied|}}
+              {{#if copied}}
+                Copied
+              {{else}}
+                <a href='#'>Copy</a>
+              {{/if}}
+            {{/click-to-copy}}
+          </h3>
         </li>
       {{else}}
         <li class="resource-metadata-item">
-          <h5 class="resource-metadata-title">Size</h5>
-          <h3 class="resource-metadata-value"><i class="fa fa-spin fa-spinner"></i></h3>
+          <h5 class="resource-metadata-title">Status</h5>
+          <h3 class="resource-metadata-value"><i class="fa fa-spin fa-spinner"></i> <span class="db-status">Provisioning</span></h3>
         </li>
       {{/if}}
-
-      <li class="resource-metadata-item">
-        <h5 class="resource-metadata-title">Connection URL</h5>
-        <h3 class="resource-metadata-value">
-          {{model.connectionUrl}}
-          {{#click-to-copy text=model.connectionUrl as |copied|}}
-            {{#if copied}}
-              Copied
-            {{else}}
-              <a href='#'>Copy</a>
-            {{/if}}
-          {{/click-to-copy}}
-        </h3>
-      </li>
     {{/if}}
 
     </ul>

--- a/tests/acceptance/databases/show-test.js
+++ b/tests/acceptance/databases/show-test.js
@@ -46,3 +46,104 @@ test('visiting /databases/my-db-id shows the database', function(assert) {
     assert.ok(contentNode.length > 0, 'my-database is on the page');
   });
 });
+
+test('visiting /databases/my-db-id with provisioned database and disk shows disk size', function(assert) {
+  stubStack({ id: 'my-stack-1' });
+  stubRequest('get', '/databases/my-db-id', function(){
+    return this.success({
+      id: 'my-db-id',
+      handle: 'my-database',
+      status: 'provisioned',
+      connectionUrl: 'postgresql://me:pw@10.0.0.0/db',
+      _links: {
+        account: { href: '/accounts/my-stack-1' },
+        disk: { href: '/disks/my-disk-1' }
+      }
+    });
+  });
+
+  stubRequest('get', '/disks/my-disk-1', function(){
+    return this.success({
+      id: 'my-disk-1',
+      size: 10,
+      _links: {
+        database: { href: '/disks/my-db-id' }
+      }
+    });
+  });
+
+  stubRequest('get', '/databases/my-db-id/operations', function(){
+    return this.success({
+      _embedded: {
+        operations: []
+      }
+    });
+  });
+
+  signInAndVisit('/databases/my-db-id');
+  andThen(function() {
+    assert.equal(currentPath(), 'dashboard.database.activity', 'show page is visited');
+    var sizeNode = findWithAssert('.db-size:contains(10 GB)');
+    var urlNode = findWithAssert('.db-connection-url:contains(postgresql://me:pw@10.0.0.0/db)');
+    assert.ok(sizeNode.length > 0, 'shows database size');
+    assert.ok(urlNode.length > 0, 'shows database connection url');
+  });
+});
+
+test('visiting /databases/my-db-id with provisioning database shows a spinner', function(assert) {
+  stubStack({ id: 'my-stack-1' });
+  stubRequest('get', '/databases/my-db-id', function(){
+    return this.success({
+      id: 'my-db-id',
+      handle: 'my-database',
+      status: 'provisioning',
+      _links: {
+        account: { href: '/accounts/my-stack-1' }
+      }
+    });
+  });
+
+  stubRequest('get', '/databases/my-db-id/operations', function(){
+    return this.success({
+      _embedded: {
+        operations: []
+      }
+    });
+  });
+
+  signInAndVisit('/databases/my-db-id');
+  andThen(function() {
+    assert.equal(currentPath(), 'dashboard.database.activity', 'show page is visited');
+    var contentNode = findWithAssert('.db-status:contains(Provisioning)');
+    assert.ok(contentNode.length > 0, 'shows provisioning status');
+  });
+});
+
+test('visiting /databases/my-db-id with provisioned database but no disk doesn\'t show size', function(assert) {
+  stubStack({ id: 'my-stack-1' });
+  stubRequest('get', '/databases/my-db-id', function(){
+    return this.success({
+      id: 'my-db-id',
+      handle: 'my-database',
+      status: 'provisioned',
+      _links: {
+        account: { href: '/accounts/my-stack-1' }
+      }
+    });
+  });
+
+  stubRequest('get', '/databases/my-db-id/operations', function(){
+    return this.success({
+      _embedded: {
+        operations: []
+      }
+    });
+  });
+
+  signInAndVisit('/databases/my-db-id');
+  andThen(function() {
+    assert.equal(currentPath(), 'dashboard.database.activity', 'show page is visited');
+    var contentNode = find('.db-size');
+    assert.ok(contentNode.length === 0, 'my-database is on the page');
+  });
+});


### PR DESCRIPTION
Thanks for reporting this issue @evan-007.  This PR updates the database header to only render a spinner while provisioning.  Also added more robust specs.

