### PR TITLE
Add in-repo addon for dns-prefetch tags

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -36,6 +36,16 @@ module.exports = function(environment) {
       injectionFactories : ['route', 'router', 'controller', 'view']
     },
 
+    prefetch: ['use.typekit.net', 'www.gravatar.com', 'js.stripe.com',
+               'api.stripe.com', 'cdn.segment.com', 'support.aptible.com',
+               'assets.customer.io', 'track.customer.io',
+               'www.google-analytics.com', 'js.intercomcdn.com',
+               'app.getsentry.com', 'cdn.mxpnl.com', 'js.intercomcdn.com',
+               'static.intercomcdn.com', 'widget.intercom.io',
+               'cdn.ravenjs.com', 'api.mixpanel.com', 'api.segment.io',
+               'api-ping.intercom.io', 'intercom.io', 'p.typekit.net',
+               'secure.gravatar.com'],
+
     sentry: {
       skipCdn: false,
       cdn: '//cdn.ravenjs.com',
@@ -122,6 +132,10 @@ module.exports = function(environment) {
 
     ENV.sentry.whitelistUrls = ['dashboard.aptible-staging.com'];
     ENV.sentry.development = false;
+    var stagingHosts = ['api.aptible-staging.com', 'auth.aptible-staging.com',
+                        'billing.aptible-staging.com', 'www.aptible-staging.com',
+                        'compliance.aptible-staging.com'];
+    ENV.prefetch = ENV.prefetch.concat(stagingHosts);
   }
 
   if (environment === 'production') {
@@ -136,6 +150,10 @@ module.exports = function(environment) {
     ENV.sentry.whitelistUrls = ['dashboard.aptible.com'];
     ENV.sentry.development = false;
     ENV.sentry.dsn = 'https://2dc5b29fd35e408cbadf581f9a167074@app.getsentry.com/22629';
+    var productionHosts = ['api.aptible.com', 'auth.aptible.com',
+                           'billing.aptible.com', 'www.aptible.com',
+                           'compliance.aptible.com'];
+    ENV.prefetch = ENV.prefetch.concat(productionHosts);
   }
 
   return ENV;

--- a/lib/dns-prefetch/index.js
+++ b/lib/dns-prefetch/index.js
@@ -1,0 +1,18 @@
+/* jshint node: true */
+'use strict';
+
+module.exports = {
+  name: 'dns-prefetch',
+  contentFor: function(type, config) {
+    if (type !== 'head' || !Array.isArray(config.prefetch)) {
+      return '';
+    }
+    var indent = "    ";
+    var tags = config.prefetch.map(function(host) {
+      return indent + '<link rel="dns-prefetch" href="//' + host + '">';
+    });
+
+    tags.unshift(indent + '<meta http-equiv="x-dns-prefetch-control" content="on">');
+    return tags.join('\n');
+  }
+};

--- a/lib/dns-prefetch/package.json
+++ b/lib/dns-prefetch/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dns-prefetch",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "paths": [
       "lib/bootstrap-sass",
       "lib/ember-deploy-s3-static-index",
-      "lib/create-website"
+      "lib/create-website",
+      "lib/dns-prefetch"
     ]
   }
 }


### PR DESCRIPTION
This in-repo addon will loop through an array of hosts and output `dns-prefetch` tags in the index.html HEAD.

Example output:

![screenshot 2015-09-24 11 23 25](https://cloud.githubusercontent.com/assets/884151/10077579/e31f29cc-62ae-11e5-9f15-9c912fa5f59f.png)

We load an awful lot of different domains. 

cc @rwjblue 
