### PR TITLE
Use model attrs rather than calculating stack metadata

### DIFF
--- a/app/components/stack-metadata/component.js
+++ b/app/components/stack-metadata/component.js
@@ -1,14 +1,11 @@
 import Ember from 'ember';
-import sum from '../../utils/sum';
 
 export default Ember.Component.extend({
   tagName: '',
   maxVisibleDomainNames: 1,
 
-  persistedApps: Ember.computed.filterBy('model.apps', 'isNew', false),
-  persistedDatabases: Ember.computed.filterBy('model.databases', 'isNew', false),
   persistedVhosts: Ember.computed.filterBy('model.vhosts', 'isNew', false),
-  vhostNames: Ember.computed.mapBy('persistedVhosts', 'commonName'),
+  vhostNames: Ember.computed.mapBy('persistedVhosts', 'virtualDomain'),
 
   displayVhostNames: Ember.computed('vhostNames', function() {
     return this.get('vhostNames').join(', ');
@@ -30,20 +27,5 @@ export default Ember.Component.extend({
   vhostNamesTooltip: Ember.computed('vhostNames', function() {
     let names = this.get('vhostNames');
     return names.slice(this.get('maxVisibleDomainNames')).join(', ');
-  }),
-
-  totalDiskSize: function(){
-    let sizes = this.get('persistedDatabases').mapBy('disk.size').compact();
-    return sum(sizes);
-  }.property('persistedDatabases.[]'),
-
-  totalContainerCount: function(){
-    let containerCounts = [];
-    this.get('persistedApps').forEach(function(app){
-      let counts = app.get('services').mapBy('containerCount').compact();
-      containerCounts = containerCounts.concat(counts);
-    });
-
-    return sum(containerCounts);
-  }.property('persistedApps.[]')
+  })
 });

--- a/app/components/stack-metadata/template.hbs
+++ b/app/components/stack-metadata/template.hbs
@@ -13,13 +13,13 @@
     {{/if}}
 
     <li class="resource-metadata-item">
-      <h5 class="resource-metadata-title">{{persistedApps.length}} {{plural-string "App" persistedApps.length}}</h5>
-      <h3 class="resource-metadata-value">Using {{totalContainerCount}} {{plural-string "container" totalContainerCount}}</h3>
+      <h5 class="resource-metadata-title">{{model.totalAppCount}} {{plural-string "App" model.totalAppCount}}</h5>
+      <h3 class="resource-metadata-value">Using {{model.appContainerCount}} {{plural-string "container" totalContainerCount}}</h3>
     </li>
 
     <li class="resource-metadata-item">
-      <h5 class="resource-metadata-title">{{persistedDatabases.length}} {{plural-string "Database" persistedDatabases.length}}</h5>
-      <h3 class="resource-metadata-value">Using {{format-disk-size totalDiskSize}} of disk</h3>
+      <h5 class="resource-metadata-title">{{model.totalDatabaseCount}} {{plural-string "Database" model.totalDatabaseCount}}</h5>
+      <h3 class="resource-metadata-value">Using {{format-disk-size model.totalDiskSize}} of disk</h3>
     </li>
 
     <li class="resource-metadata-item">

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.8",
     "ember-cli-app-version": "0.5.0",
-    "ember-cli-aptible-shared": "0.0.42",
+    "ember-cli-aptible-shared": "0.0.44",
     "ember-cli-babel": "^5.1.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",

--- a/tests/acceptance/stack/show-test.js
+++ b/tests/acceptance/stack/show-test.js
@@ -24,6 +24,10 @@ test(`visit ${url} shows basic stack info`, function(assert) {
   let stackData = {
     id: stackId,
     handle: stackHandle,
+    total_app_count: 2,
+    total_database_count: 2,
+    total_disk_size: 6,
+    app_container_count: 5,
     _links: {
       apps: { href: appsURL },
       databases: { href: databasesURL }
@@ -52,36 +56,11 @@ test(`visit ${url} shows basic stack info`, function(assert) {
     }
   }];
 
-  let databaseData = [{
-    id: 'db-1',
-    _embedded: {
-      disk: {
-        id: 'disk-1',
-        size: 4
-      }
-    }
-  }, {
-    id: 'db-2',
-    _embedded: {
-      disk: {
-        id: 'disk-2',
-        size: 2
-      }
-    }
-  }];
 
   stubRequest('get', appsURL, function(){
     return this.success({
       _embedded: {
         apps: appData
-      }
-    });
-  });
-
-  stubRequest('get', databasesURL, function(){
-    return this.success({
-      _embedded: {
-        databases: databaseData
       }
     });
   });
@@ -104,7 +83,7 @@ test(`visit ${url} shows basic stack info`, function(assert) {
     assert.ok(find(`h5:contains(${appData.length} Apps)`).length,
        'Header that contains app length');
 
-    assert.ok(find(`h5:contains(${databaseData.length} Databases)`).length,
+    assert.ok(find(`h5:contains(2 Databases)`).length,
        'Header that contains db length');
 
     // 2 + 3


### PR DESCRIPTION
This removes metadata calculation and instead relies on values returned by API. 