### PR TITLE
Temporarily remove fetch all pages

### DIFF
--- a/app/apps/route.js
+++ b/app/apps/route.js
@@ -9,6 +9,6 @@ export default Ember.Route.extend({
 
   model: function(){
     var stack = this.modelFor('stack');
-    return fetchAllPages(this.store, stack, 'app');
+    return stack.get('apps');
   }
 });

--- a/app/databases/route.js
+++ b/app/databases/route.js
@@ -9,6 +9,6 @@ export default Ember.Route.extend({
 
   model: function(){
     var stack = this.modelFor('stack');
-    return fetchAllPages(this.store, stack, 'database');
+    return stack.get('databases');
   }
 });


### PR DESCRIPTION
@rwjblue - I had to temporarily disable `fetchAllPages` as it was breaking on pages that actually had more than one page of resources (currently just one environment for one customer).  The stack trace is available here in sentry: https://app.getsentry.com/aptible/dashboard/group/86487465/

