### PR TITLE
Released v1.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diesel",
-  "version": "1.1.17",
+  "version": "1.1.19",
   "description": "Aptible dashboard",
   "private": true,
   "directories": {


### PR DESCRIPTION
- Fixes #474: Showing 2 log drains in stack metadata when only 1 is provisioned - @sandersonet 
- Fixes #387: Hide the copy-to-clipboard action if browser does not have Flash - @gib
- Update to `ember-data` 1.0.0-beta.19.2 - @rwjblue
- See more improvements via [`ember-cli-aptible-shared`](https://github.com/aptible/ember-cli-aptible-shared/pulls?q=is%3Apr+is%3Aclosed)
