### PR TITLE
Scale containers to 0 in dashboard

### DIFF
--- a/app/components/service-scaler/template.hbs
+++ b/app/components/service-scaler/template.hbs
@@ -41,11 +41,11 @@
         {{no-ui-slider didSlide="setContainerCount"
                        didSet="finishSliding"
                        start=containerCount
-                       rangeMin=1
+                       rangeMin=0
                        rangeMax=10
                        step=1}}
         <div class="label-wrapper">
-          <div class="label pull-left">1</div>
+          <div class="label pull-left">0</div>
           <div class="label pull-right">10</div>
         </div>
       </div>


### PR DESCRIPTION
Closes https://github.com/aptible/dashboard.aptible.com/issues/390 with a pretty small change. We should probably follow up with some messaging updates.

Went through creating a new service, which defaults to 1 container (https://github.com/aptible/api.aptible.com/blob/master/app/models/service.rb#L13) and verified the everything saves as expected through the API.

![scale-to-zero](https://cloud.githubusercontent.com/assets/94830/11351229/a76d625e-91f2-11e5-8343-940fd2dc5e22.gif)
