### PR TITLE
Fixes two cases of the UI reporting stale or confusing state

### DIFF
--- a/app/app/vhosts/edit/route.js
+++ b/app/app/vhosts/edit/route.js
@@ -80,15 +80,12 @@ export default Ember.Route.extend({
     },
 
     cancel() {
-      this.transitionTo('app.vhosts.index');
-    },
-
-    willTransition() {
       this.currentModel.vhost.set(
         'certificate',
         this.controller.get('originalCertificate')
       );
       this.currentModel.vhost.rollback();
+      this.transitionTo('app.vhosts.index');
     }
   }
 });

--- a/app/components/stack-metadata/component.js
+++ b/app/components/stack-metadata/component.js
@@ -4,28 +4,25 @@ export default Ember.Component.extend({
   tagName: '',
   maxVisibleDomainNames: 1,
 
-  persistedVhosts: Ember.computed.filterBy('model.vhosts', 'isNew', false),
-  vhostNames: Ember.computed.mapBy('persistedVhosts', 'virtualDomain'),
-
-  displayVhostNames: Ember.computed('vhostNames', function() {
-    return this.get('vhostNames').join(', ');
+  displayVhostNames: Ember.computed('model.vhostNames', function() {
+    return this.model.get('vhostNames').join(', ');
   }),
 
-  showVhostTooltip: Ember.computed('vhostNames', function() {
-    return this.get('vhostNames.length') > this.get('maxVisibleDomainNames');
+  showVhostTooltip: Ember.computed('model.vhostNames', function() {
+    return this.model.get('vhostNames.length') > this.get('maxVisibleDomainNames');
   }),
 
   vhostRemaining: Ember.computed('vhostNames', function() {
-    return this.get('vhostNames.length') - this.get('maxVisibleDomainNames');
+    return this.model.get('vhostNames.length') - this.get('maxVisibleDomainNames');
   }),
 
   vhostNamesSnippet: Ember.computed('vhostNames', function() {
-    let names = this.get('vhostNames');
+    let names = this.model.get('vhostNames');
     return names.slice(0, this.get('maxVisibleDomainNames')).join(', ');
   }),
 
   vhostNamesTooltip: Ember.computed('vhostNames', function() {
-    let names = this.get('vhostNames');
+    let names = this.model.get('vhostNames');
     return names.slice(this.get('maxVisibleDomainNames')).join(', ');
   })
 });

--- a/app/components/stack-metadata/template.hbs
+++ b/app/components/stack-metadata/template.hbs
@@ -23,7 +23,7 @@
     </li>
 
     <li class="resource-metadata-item">
-      <h5 class="resource-metadata-title">{{persistedVhosts.length}} {{plural-string "Domain" persistedVhosts.length}}</h5>
+      <h5 class="resource-metadata-title">{{model.persistedVhosts.length}} {{plural-string "Domain" model.persistedVhosts.length}}</h5>
       <h3 class="resource-metadata-value">
         {{#if showVhostTooltip}}
           {{vhostNamesSnippet}}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.12",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-aptible-shared": "0.0.54",
+    "ember-cli-aptible-shared": "0.0.55",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",


### PR DESCRIPTION
![stateful](https://cloud.githubusercontent.com/assets/94830/12310185/1d0e25f2-ba0c-11e5-9d02-eeac75054144.gif)
Closes https://github.com/aptible/dashboard.aptible.com/issues/496 - Domains in the meta data header of an environment would get out of sync. See also https://github.com/aptible/ember-cli-aptible-shared/pull/76
Closes https://github.com/aptible/dashboard.aptible.com/issues/499 - When editing a vhost, changes were being rolledback (intended to be used on cancel).

