### PR TITLE
Log Drains - Poll new (for real), restart, and deprovision

### DIFF
--- a/app/components/log-drain-actions/component.js
+++ b/app/components/log-drain-actions/component.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  store: Ember.inject.service(),
+
+  logDrain: null,
+
+  sendError(e, message) {
+    message = Ember.get(e, 'responseJSON.message') || message;
+    this.sendAction('failedAction', message);
+  },
+
+  actions: {
+    restart(){
+      let message = `Successfully restarted ${this.logDrain.get('handle')}`;
+      let errorMessage = `There was an error restarting ${this.logDrain.get('handle')}.`;
+      let logDrain = this.logDrain;
+      let component = this;
+      var op = this.get('store').createRecord('operation', {
+        type: 'configure',
+        logDrain: this.logDrain
+      });
+      op.save().then(function(){
+        logDrain.set('status', 'provisioning');
+        logDrain.save().then(function() {
+          component.sendAction('completedAction', message);
+        }).catch( (e) => { component.sendError(e, errorMessage); });
+      }).catch( (e) => { component.sendError(e, errorMessage); });
+    },
+
+    deprovision(){
+      let message = `Successfully deprovisioned ${this.logDrain.get('handle')}`;
+      let errorMessage = `There was an error restarting ${this.logDrain.get('handle')}.`;
+      let logDrain = this.logDrain;
+      let component = this;
+      var op = this.get('store').createRecord('operation', {
+        type: 'deprovision',
+        logDrain: logDrain
+      });
+      op.save().then(function(){
+        logDrain.set('status', 'deprovisioning');
+        logDrain.save().then(function() {
+          component.sendAction('completedAction', message);
+        }).catch( (e) => { component.sendError(e, errorMessage); });
+      }).catch( (e) => { component.sendError(e, errorMessage); });
+      Ember.run.later(component, function() {
+        logDrain.deleteRecord();
+      }, 5000);
+    }
+  }
+});

--- a/app/components/log-drain-actions/template.hbs
+++ b/app/components/log-drain-actions/template.hbs
@@ -1,0 +1,8 @@
+<div class="panel-heading-actions">
+  {{#unless logDrain.isDeprovisioning}}
+    {{#unless logDrain.isProvisioning}}
+      <button class="btn btn-default btn-xs" {{action "restart" logDrain}}>Restart</button>
+    {{/unless}}
+    <button class="btn btn-default btn-xs" {{action "deprovision" logDrain}}>Deprovision</button>
+  {{/unless}}
+</div>

--- a/app/stack/log-drains/index/route.js
+++ b/app/stack/log-drains/index/route.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  actions: {
+    completedAction(message) {
+      Ember.get(this, 'flashMessages').success(message);
+    },
+    failedAction(message) {
+      Ember.get(this, 'flashMessages').danger(message);
+    }
+  }
+});

--- a/app/stack/log-drains/new/route.js
+++ b/app/stack/log-drains/new/route.js
@@ -37,6 +37,7 @@ export default Ember.Route.extend({
 
     createLog(log) {
       log.set('stack', this.modelFor('stack'));
+      log.set('status', 'provisioning'); // Ensures polling for status updates
 
       log.save().then( () => {
         let op = this.store.createRecord('operation', {

--- a/app/templates/stack/-log-drain.hbs
+++ b/app/templates/stack/-log-drain.hbs
@@ -23,6 +23,7 @@
       <i class="fa fa-arrow-right"></i>
       <span class="resource-subtitle vhost-service">{{logDrain.drainType}}</span>
     </h3>
+    {{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}
   </div>
   <div class="panel-body">
     <ul class="resource-metadata">

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -215,7 +215,7 @@ test(`visit ${addLogUrl} and create log success`, function(assert){
     assert.equal(json.drain_port, drainPort, 'sets drain port');
     assert.equal(json.drain_type, drainType, 'sets drain type');
     assert.equal(json.handle, handle, 'sets drain handle');
-    assert.equal(json.status, status, 'sets darin status');
+    assert.equal(json.status, status, 'sets drain status');
 
     json.id = logDrainId;
     return this.success(json);
@@ -233,7 +233,7 @@ test(`visit ${addLogUrl} and create log success`, function(assert){
       drainPort: drainPort,
       handle: handle,
       drainType: drainType,
-      logDrainId: request.params.id,
+      id: request.params.id,
       status: status
     });
   });
@@ -269,7 +269,7 @@ test(`visit ${addLogUrl} without elasticsearch databases`, function(assert){
 });
 
 test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
-  assert.expect(7);
+  assert.expect(8);
 
   let drainUser = 'someUser',
       drainPassword = 'somePw',
@@ -311,6 +311,17 @@ test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
 
   stubRequest('post', `/log_drains/${logDrainId}/operations`, function(){
     return this.success();
+  });
+
+  stubRequest('get', 'log_drains/:id', function(request) {
+    return this.success({
+      id: request.params.id,
+      drainHost: drainHost,
+      drainPort: drainPort,
+      handle: logDrainId,
+      drainType: drainType,
+      databaseHandle: databaseHandle
+    });
   });
 
   signInAndVisit(addLogUrl);

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -196,24 +196,26 @@ test(`visit ${addLogUrl} and cancel`, function(assert){
 });
 
 test(`visit ${addLogUrl} and create log success`, function(assert){
-  assert.expect(7);
-
-  this.prepareStubs();
+  assert.expect(10, 'passes 10 assertions');
 
   let drainHost = 'abc-host.com',
       drainPort = '1234',
       handle = 'my-log-name',
       drainType = 'syslog_tls_tcp',
-      logDrainId = 'log-id-1';
+      logDrainId = 'log-id-1',
+      status = 'provisioning';
+
+  this.prepareStubs();
 
   stubRequest('post', '/accounts/:stack_id/log_drains', function(request){
     assert.ok(true, 'posts to log_drains');
 
     let json = this.json(request);
-    assert.equal(json.drain_host, drainHost);
-    assert.equal(json.drain_port, drainPort);
-    assert.equal(json.drain_type, drainType);
-    assert.equal(json.handle, handle);
+    assert.equal(json.drain_host, drainHost, 'sets drain host');
+    assert.equal(json.drain_port, drainPort, 'sets drain port');
+    assert.equal(json.drain_type, drainType, 'sets drain type');
+    assert.equal(json.handle, handle, 'sets drain handle');
+    assert.equal(json.status, status, 'sets darin status');
 
     json.id = logDrainId;
     return this.success(json);
@@ -225,17 +227,26 @@ test(`visit ${addLogUrl} and create log success`, function(assert){
     return this.success();
   });
 
+  stubRequest('get', 'log_drains/:id', function(request) {
+    return this.success({
+      drainHost: drainHost,
+      drainPort: drainPort,
+      handle: handle,
+      drainType: drainType,
+      logDrainId: request.params.id,
+      status: status
+    });
+  });
+
   signInAndVisit(addLogUrl);
   andThen(function(){
     let formEl = find('form.create-log');
     let context = formEl;
-
     fillInput('drain-host', drainHost, {context});
     fillInput('drain-port', drainPort, {context});
     fillInput('handle', handle, {context});
     clickButton('Save Log Drain', {context});
   });
-
   andThen(function(){
     assert.equal(currentPath(), 'dashboard.stack.log-drains.index');
   });
@@ -294,6 +305,7 @@ test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
     assert.equal(json.drain_password, drainPassword);
     assert.equal(json.drain_username, drainUser);
 
+    json.status = 'provistioning';
     json.id = logDrainId;
     return this.success(json);
   });

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -305,7 +305,6 @@ test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
     assert.equal(json.drain_password, drainPassword);
     assert.equal(json.drain_username, drainUser);
 
-    json.status = 'provistioning';
     json.id = logDrainId;
     return this.success(json);
   });

--- a/tests/integration/components/log-drain-actions-test.js
+++ b/tests/integration/components/log-drain-actions-test.js
@@ -1,0 +1,60 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('log-drain-actions', {
+  integration: true
+});
+
+let logDrain = Ember.Object.create({
+  handle: 'provisioned-drain-1',
+  drainHost: 'example.com',
+  drainPort: '1234',
+  drainType: 'syslog_tls_tcp',
+  logDrainId: 'provisioned-drain-1',
+});
+
+let failedAction, completedAction = function(message) {
+};
+
+test('shows reset and deprovisioned actions for provisioned log drains', function(assert) {
+  logDrain.status = 'provisioned';
+  logDrain.isProvisioning = false;
+  logDrain.isDeprovisioning = false;
+  this.set('failedAction', failedAction);
+  this.set('completedAction', completedAction);
+  this.set('logDrain', logDrain);
+  this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
+
+  assert.equal(this.$('.panel-heading-actions button').length, 2);
+  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 1);
+});
+
+test('shows only deprovisioned action for provisioning log drains', function(assert) {
+  logDrain.status = 'provisioning';
+  logDrain.isProvisioning = true;
+  logDrain.isDeprovisioning = false;
+  this.set('failedAction', failedAction);
+  this.set('completedAction', completedAction);
+  this.set('logDrain', logDrain);
+  this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
+
+  assert.equal(this.$('.panel-heading-actions button').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 0);
+});
+
+test('shows no actions for deprovisioning log drains', function(assert) {
+  logDrain.status = 'deprovisioning';
+  logDrain.isProvisioning = false;
+  logDrain.isDeprovisioning = true;
+  this.set('failedAction', failedAction);
+  this.set('completedAction', completedAction);
+  this.set('logDrain', logDrain);
+  this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
+
+  assert.equal(this.$('.panel-heading-actions button').length, 0);
+  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 0);
+  assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 0);
+});

--- a/tests/integration/components/usage-quote-by-resource-test.js
+++ b/tests/integration/components/usage-quote-by-resource-test.js
@@ -107,7 +107,6 @@ test('disk usage exceeding allowance results in overage billing', function(asser
   let total = this.$('.resource-usage-total .usage-value');
   let allowance = this.$('.allowance');
   let net = this.$('.net-usage');
-  console.log(this.$('.panel').html());
   assert.equal($.trim(total.text()), '$259.08', 'has overage billing total');
   assert.equal(allowance.text(), '-1000', 'has an allowance');
   assert.equal(net.text(), '700', 'has 700 net usage');


### PR DESCRIPTION
** Early PR with failing tests. Looking for insight from @sandersonet. **

Polling was not previously working right after a new log drain was created because it was "pending" and not "provisioning". This is fixed now but busts acceptance tests.

<img width="1010" alt="screen shot 2016-01-25 at 7 09 48 pm" src="https://cloud.githubusercontent.com/assets/94830/12570731/981b6a5e-c397-11e5-8ce3-475a29b000a3.png">

A new component provides a Restart and Deprovision action on provisioned log drains, only the Deprovision action on provisioning / pending log drains, and no actions on a deprovisioning log drain. 

Seeing a deprovisioning log drain in the UI is not likely to happen since sweetness deletes it once the operation is complete and we will remove it from the local store. Subsequent calls to fetch all log drains will no longer include it once the operation is complete.