### PR TITLE
Support HTTPS log drains

### DIFF
--- a/app/stack/log-drains/new/controller.js
+++ b/app/stack/log-drains/new/controller.js
@@ -18,9 +18,13 @@ function parseUrl(url) {
 
 export default Ember.Controller.extend({
   isSyslogDrain: Ember.computed.equal('model.drainType', 'syslog_tls_tcp'),
-  disableSave: Ember.computed('isSyslogDrain', 'esDatabases', function() {
+  isHttpsDrain: Ember.computed.equal('model.drainType', 'https'),
+  isHostPortDrain: Ember.computed('isSyslogDrain', 'isHttpsDrain', function () {
+    return this.get('isSyslogDrain') || this.get('isHttpsDrain');
+  }),
+  disableSave: Ember.computed('isHostPortDrain', 'esDatabases', function() {
     return this.get('model.isSaving') ||
-           (!this.get('isSyslogDrain') &&
+           (!this.get('isHostPortDrain') &&
            this.get('esDatabases.length') === 0);
   }),
   actions: {
@@ -33,6 +37,13 @@ export default Ember.Controller.extend({
       model.set('drainPort', a.port);
       model.set('drainUsername', a.username);
       model.set('drainPassword', a.password);
+    },
+    httpsSelected () {
+      // Set default port to HTTPS if no port is currently set
+      let model = this.get('model');
+      if (!model.get('drainPort')) {
+        model.set('drainPort', '443');
+      }
     }
   }
 });

--- a/app/stack/log-drains/new/template.hbs
+++ b/app/stack/log-drains/new/template.hbs
@@ -33,10 +33,15 @@
                   Elasticsearch
                 {{/radio-button}}
               </div>
+              <div>
+                {{#radio-button value="https" groupValue=model.drainType name="drain-type" changed="httpsSelected"}}
+                  HTTPS
+                {{/radio-button}}
+              </div>
             </div>
           </div>
 
-          {{#if isSyslogDrain }}
+          {{#if isHostPortDrain }}
             <div class="form-group">
               <label class="block" for="drain-host">Host</label>
               {{input name='drain-host' value=model.drainHost class="form-control"}}

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -318,6 +318,52 @@ test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
   });
 });
 
+test(`visit ${addLogUrl} and create log to HTTPS`, function(assert){
+  assert.expect(7);
+
+  this.prepareStubs();
+
+  let drainHost = 'abc-host.com',
+      drainPort = '443',
+      drainType = 'https',
+      handle    = 'https-test',
+      logDrainId = 'log-drain-bar';
+
+  stubRequest('post', '/accounts/:stack_id/log_drains', function(request){
+    assert.ok(true, 'posts to log_drains');
+
+    let json = this.json(request);
+    assert.equal(json.drain_host, drainHost);
+    assert.equal(json.drain_port, drainPort);
+    assert.equal(json.drain_type, drainType);
+    assert.equal(json.handle, handle);
+
+    json.id = logDrainId;
+    return this.success(json);
+  });
+
+  stubRequest('post', `/log_drains/${logDrainId}/operations`, function(request){
+    let json = this.json(request);
+    assert.equal(json.type, 'configure', 'creates configure operation');
+    return this.success();
+  });
+
+  signInAndVisit(addLogUrl);
+  andThen(function(){
+    let formEl = find('form.create-log');
+    let context = formEl;
+
+    click( find('label:contains(HTTPS)')); // click HTTPS radio button
+    fillInput('drain-host', drainHost, {context});  // Port should default to 443
+    fillInput('handle', handle, {context});
+    clickButton('Save Log Drain', {context});
+  });
+
+  andThen(function(){
+    assert.equal(currentPath(), 'dashboard.stack.log-drains.index');
+  });
+});
+
 test(`visit ${addLogUrl} and create log failure`, function(assert){
   this.prepareStubs();
   let errorMessage = 'The log drain is invalid';


### PR DESCRIPTION
Requires https://github.com/aptible/api.aptible.com/pull/299 in the backend and https://github.com/aptible/sweetness/pull/497 in Sweetness.

This would be used to deploy Logstash as an app-level Logstash log drain using https://github.com/aptible/docker-logstash/pull/1.

@gib, what do you think? Any recommendations / suggestions?

cc @fancyremarker 