### PR TITLE
Log Drains - Poll new (for real), restart, and deprovision/delete

### DIFF
--- a/app/components/log-drain-actions/component.js
+++ b/app/components/log-drain-actions/component.js
@@ -14,15 +14,14 @@ export default Ember.Component.extend({
     restart(){
       let message = `Successfully restarted ${this.logDrain.get('handle')}`;
       let errorMessage = `There was an error restarting ${this.logDrain.get('handle')}.`;
-      let logDrain = this.logDrain;
       let component = this;
       var op = this.get('store').createRecord('operation', {
         type: 'configure',
         logDrain: this.logDrain
       });
-      op.save().then(function(){
-        logDrain.set('status', 'provisioning');
-        logDrain.save().then(function() {
+      op.save().then(() => {
+        component.logDrain.set('status', 'provisioning');
+        component.logDrain.save().then(() => {
           component.sendAction('completedAction', message);
         }).catch( (e) => { component.sendError(e, errorMessage); });
       }).catch( (e) => { component.sendError(e, errorMessage); });
@@ -31,19 +30,19 @@ export default Ember.Component.extend({
     deprovision(){
       let message = `Successfully deprovisioned ${this.logDrain.get('handle')}`;
       let errorMessage = `There was an error restarting ${this.logDrain.get('handle')}.`;
-      let logDrain = this.logDrain;
       let component = this;
+      let logDrain = this.logDrain; // Keep a ref for the run later
       var op = this.get('store').createRecord('operation', {
         type: 'deprovision',
         logDrain: logDrain
       });
-      op.save().then(function(){
+      op.save().then(() => {
         logDrain.set('status', 'deprovisioning');
-        logDrain.save().then(function() {
+        logDrain.save().then(() => {
           component.sendAction('completedAction', message);
         }).catch( (e) => { component.sendError(e, errorMessage); });
       }).catch( (e) => { component.sendError(e, errorMessage); });
-      Ember.run.later(component, function() {
+      Ember.run.later(component, () => {
         logDrain.deleteRecord();
       }, 5000);
     }

--- a/app/components/log-drain-actions/component.js
+++ b/app/components/log-drain-actions/component.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  store: Ember.inject.service(),
+
+  logDrain: null,
+
+  sendError(e, message) {
+    message = Ember.get(e, 'responseJSON.message') || message;
+    this.sendAction('failedAction', message);
+  },
+
+  actions: {
+    restart(){
+      let message = `Successfully restarted ${this.logDrain.get('handle')}`;
+      let errorMessage = `There was an error restarting ${this.logDrain.get('handle')}.`;
+      let logDrain = this.logDrain;
+      let component = this;
+      var op = this.get('store').createRecord('operation', {
+        type: 'configure',
+        logDrain: this.logDrain
+      });
+      op.save().then(function(){
+        logDrain.set('status', 'provisioning');
+        logDrain.save().then(function() {
+          component.sendAction('completedAction', message);
+        }).catch( (e) => { component.sendError(e, errorMessage); });
+      }).catch( (e) => { component.sendError(e, errorMessage); });
+    },
+
+    deprovision(){
+      let message = `Successfully deprovisioned ${this.logDrain.get('handle')}`;
+      let errorMessage = `There was an error restarting ${this.logDrain.get('handle')}.`;
+      let logDrain = this.logDrain;
+      let component = this;
+      var op = this.get('store').createRecord('operation', {
+        type: 'deprovision',
+        logDrain: logDrain
+      });
+      op.save().then(function(){
+        logDrain.set('status', 'deprovisioning');
+        logDrain.save().then(function() {
+          component.sendAction('completedAction', message);
+        }).catch( (e) => { component.sendError(e, errorMessage); });
+      }).catch( (e) => { component.sendError(e, errorMessage); });
+      Ember.run.later(component, function() {
+        logDrain.deleteRecord();
+      }, 5000);
+    }
+  }
+});

--- a/app/components/log-drain-actions/template.hbs
+++ b/app/components/log-drain-actions/template.hbs
@@ -1,0 +1,8 @@
+<div class="panel-heading-actions">
+  {{#unless logDrain.isDeprovisioning}}
+    {{#unless logDrain.isProvisioning}}
+      <button class="btn btn-default btn-xs" {{action "restart" logDrain}}>Restart</button>
+    {{/unless}}
+    <button class="btn btn-default btn-xs" {{action "deprovision" logDrain}}>Deprovision</button>
+  {{/unless}}
+</div>

--- a/app/components/log-drain-actions/template.hbs
+++ b/app/components/log-drain-actions/template.hbs
@@ -1,8 +1,8 @@
 <div class="panel-heading-actions">
-  {{#unless logDrain.isDeprovisioning}}
-    {{#unless logDrain.isProvisioning}}
-      <button class="btn btn-default btn-xs" {{action "restart" logDrain}}>Restart</button>
-    {{/unless}}
+  {{#if logDrain.isProvisioned}}
+    <button class="btn btn-default btn-xs" {{action "restart" logDrain}}>Restart</button>
+  {{/if}}
+  {{#unless logDrain.hasBeenDeprovisioned}}
     <button class="btn btn-default btn-xs" {{action "deprovision" logDrain}}>Deprovision</button>
   {{/unless}}
 </div>

--- a/app/stack/log-drains/index/route.js
+++ b/app/stack/log-drains/index/route.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  actions: {
+    completedAction(message) {
+      Ember.get(this, 'flashMessages').success(message);
+    },
+    failedAction(message) {
+      Ember.get(this, 'flashMessages').danger(message);
+    }
+  }
+});

--- a/app/stack/log-drains/new/route.js
+++ b/app/stack/log-drains/new/route.js
@@ -43,6 +43,8 @@ export default Ember.Route.extend({
           type: 'configure',
           logDrain: log
         });
+        // Ensures polling for status updates, no need to save via API
+        log.set('status', 'provisioning');
         return op.save();
       }).then( () => {
         this.transitionTo('stack.log-drains.index');

--- a/app/templates/stack/-log-drain.hbs
+++ b/app/templates/stack/-log-drain.hbs
@@ -23,6 +23,7 @@
       <i class="fa fa-arrow-right"></i>
       <span class="resource-subtitle vhost-service">{{logDrain.drainType}}</span>
     </h3>
+    {{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}
   </div>
   <div class="panel-body">
     <ul class="resource-metadata">

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -26,7 +26,8 @@ module('Acceptance: Log Drains', {
       id: 'drain-1',
       handle: 'first-drain',
       drain_host: 'abcdef.com',
-      drain_port: 123
+      drain_port: 123,
+      status: 'provisioning'
     }];
     options = options || {logDrains: defaultLogDrains};
 
@@ -182,7 +183,14 @@ test(`visit ${url} with log drains and click add log shows form`, function(asser
 });
 
 test(`visit ${url} with log drains and restart one`, function(assert){
-  this.prepareStubs();
+  let defaultLogDrains = { logDrains: [{
+    id: 'drain-1',
+    handle: 'first-drain',
+    drain_host: 'abcdef.com',
+    drain_port: 123,
+    status: 'provisioned'
+  }]};
+  this.prepareStubs(defaultLogDrains);
 
   stubRequest('post', `/log_drains/:id/operations`, function(request){
     let json = this.json(request);
@@ -204,7 +212,6 @@ test(`visit ${url} with log drains and restart one`, function(assert){
   });
   andThen(function() {
     assert.equal(find('.alert-success').length, 1, 'displays a success message');
-    assert.equal(find(".capitalize:contains('provisioning')").length, 1, 'sets status to provisionging');
   });
 });
 
@@ -250,7 +257,7 @@ test(`visit ${addLogUrl} and cancel`, function(assert){
 });
 
 test(`visit ${addLogUrl} and create log success`, function(assert){
-  assert.expect(8);
+  assert.expect(9);
 
   this.prepareStubs();
 
@@ -322,7 +329,7 @@ test(`visit ${addLogUrl} without elasticsearch databases`, function(assert){
 });
 
 test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
-  assert.expect(8);
+  assert.expect(9);
 
   let drainUser = 'someUser',
       drainPassword = 'somePw',

--- a/tests/integration/components/log-drain-actions-test.js
+++ b/tests/integration/components/log-drain-actions-test.js
@@ -14,8 +14,7 @@ let logDrain = Ember.Object.create({
   logDrainId: 'provisioned-drain-1',
 });
 
-let failedAction, completedAction = function(message) {
-};
+let failedAction, completedAction = function() { };
 
 test('shows reset and deprovisioned actions for provisioned log drains', function(assert) {
   logDrain.status = 'provisioned';

--- a/tests/integration/components/log-drain-actions-test.js
+++ b/tests/integration/components/log-drain-actions-test.js
@@ -1,0 +1,60 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('log-drain-actions', {
+  integration: true
+});
+
+let logDrain = Ember.Object.create({
+  handle: 'provisioned-drain-1',
+  drainHost: 'example.com',
+  drainPort: '1234',
+  drainType: 'syslog_tls_tcp',
+  logDrainId: 'provisioned-drain-1',
+});
+
+let failedAction, completedAction = function(message) {
+};
+
+test('shows reset and deprovisioned actions for provisioned log drains', function(assert) {
+  logDrain.status = 'provisioned';
+  logDrain.isProvisioning = false;
+  logDrain.isDeprovisioning = false;
+  this.set('failedAction', failedAction);
+  this.set('completedAction', completedAction);
+  this.set('logDrain', logDrain);
+  this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
+
+  assert.equal(this.$('.panel-heading-actions button').length, 2);
+  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 1);
+});
+
+test('shows only deprovisioned action for provisioning log drains', function(assert) {
+  logDrain.status = 'provisioning';
+  logDrain.isProvisioning = true;
+  logDrain.isDeprovisioning = false;
+  this.set('failedAction', failedAction);
+  this.set('completedAction', completedAction);
+  this.set('logDrain', logDrain);
+  this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
+
+  assert.equal(this.$('.panel-heading-actions button').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 0);
+});
+
+test('shows no actions for deprovisioning log drains', function(assert) {
+  logDrain.status = 'deprovisioning';
+  logDrain.isProvisioning = false;
+  logDrain.isDeprovisioning = true;
+  this.set('failedAction', failedAction);
+  this.set('completedAction', completedAction);
+  this.set('logDrain', logDrain);
+  this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
+
+  assert.equal(this.$('.panel-heading-actions button').length, 0);
+  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 0);
+  assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 0);
+});

--- a/tests/integration/components/log-drain-actions-test.js
+++ b/tests/integration/components/log-drain-actions-test.js
@@ -2,27 +2,21 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-moduleForComponent('log-drain-actions', {
-  integration: true
-});
+moduleForComponent('log-drain-actions', { integration: true });
 
 let logDrain = Ember.Object.create({
-  handle: 'provisioned-drain-1',
+  id: 'drain-1',
+  handle: 'drain-1',
   drainHost: 'example.com',
   drainPort: '1234',
-  drainType: 'syslog_tls_tcp',
-  logDrainId: 'provisioned-drain-1',
+  drainType: 'syslog_tls_tcp'
 });
 
 let failedAction, completedAction = function() { };
 
 test('shows reset and deprovisioned actions for provisioned log drains', function(assert) {
-  logDrain.status = 'provisioned';
-  logDrain.isProvisioning = false;
-  logDrain.isDeprovisioning = false;
-  this.set('failedAction', failedAction);
-  this.set('completedAction', completedAction);
-  this.set('logDrain', logDrain);
+  logDrain.setProperties({ status: 'provisioned', isProvisioned: true, hasBeenDeprovisioned: false });
+  this.setProperties({ failedAction: failedAction, completedAction: completedAction, logDrain: logDrain });
   this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
 
   assert.equal(this.$('.panel-heading-actions button').length, 2);
@@ -31,12 +25,8 @@ test('shows reset and deprovisioned actions for provisioned log drains', functio
 });
 
 test('shows only deprovisioned action for provisioning log drains', function(assert) {
-  logDrain.status = 'provisioning';
-  logDrain.isProvisioning = true;
-  logDrain.isDeprovisioning = false;
-  this.set('failedAction', failedAction);
-  this.set('completedAction', completedAction);
-  this.set('logDrain', logDrain);
+  logDrain.setProperties({ status: 'provisioning', isProvisioned: false, hasBeenDeprovisioned: false });
+  this.setProperties({ failedAction: failedAction, completedAction: completedAction, logDrain: logDrain });
   this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
 
   assert.equal(this.$('.panel-heading-actions button').length, 1);
@@ -45,12 +35,8 @@ test('shows only deprovisioned action for provisioning log drains', function(ass
 });
 
 test('shows no actions for deprovisioning log drains', function(assert) {
-  logDrain.status = 'deprovisioning';
-  logDrain.isProvisioning = false;
-  logDrain.isDeprovisioning = true;
-  this.set('failedAction', failedAction);
-  this.set('completedAction', completedAction);
-  this.set('logDrain', logDrain);
+  logDrain.setProperties({ status: 'deprovisioning', isProvisioned: false, hasBeenDeprovisioned: true });
+  this.setProperties({ failedAction: failedAction, completedAction: completedAction, logDrain: logDrain });
   this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
 
   assert.equal(this.$('.panel-heading-actions button').length, 0);

--- a/tests/integration/components/usage-quote-by-resource-test.js
+++ b/tests/integration/components/usage-quote-by-resource-test.js
@@ -107,7 +107,6 @@ test('disk usage exceeding allowance results in overage billing', function(asser
   let total = this.$('.resource-usage-total .usage-value');
   let allowance = this.$('.allowance');
   let net = this.$('.net-usage');
-  console.log(this.$('.panel').html());
   assert.equal($.trim(total.text()), '$259.08', 'has overage billing total');
   assert.equal(allowance.text(), '-1000', 'has an allowance');
   assert.equal(net.text(), '700', 'has 700 net usage');


### PR DESCRIPTION
Polling was not previously working right after a new log drain was created because it had a status of "pending" and not "provisioning". The shared polling mixin only acts on "provisioning" objects. This is now fixed...for real.

<img width="1010" alt="screen shot 2016-01-25 at 7 09 48 pm" src="https://cloud.githubusercontent.com/assets/94830/12622150/48269942-c4e1-11e5-8c63-611fdfbf9464.png">

A new component provides a Restart and Deprovision action on provisioned log drains, only the Deprovision action on provisioning / pending log drains, and no actions on a deprovisioning log drain. This is in a tested component.

Seeing a deprovisioning log drain in the UI is not likely to happen since sweetness deletes it once the operation is complete and we now remove it from the local store. Subsequent calls to fetch all log
drains will no longer include it once the operation is complete.

Closes https://github.com/aptible/dashboard.aptible.com/issues/383