### PR TITLE
Confirm deletes of log drains and certificates

### DIFF
--- a/app/certificates/route.js
+++ b/app/certificates/route.js
@@ -17,6 +17,10 @@ export default Ember.Route.extend({
 
   actions: {
     delete: function(model){
+      // Confirm...
+      let confirmMsg = `\nAre you sure you want to delete ${model.get('commonName')}?\n`;
+      if (!confirm(confirmMsg)) { return false; }
+
       let stack = model.get('stack');
 
       model.deleteRecord();
@@ -29,4 +33,3 @@ export default Ember.Route.extend({
     }
   }
 });
-

--- a/app/components/log-drain-actions/component.js
+++ b/app/components/log-drain-actions/component.js
@@ -28,6 +28,11 @@ export default Ember.Component.extend({
     },
 
     deprovision(){
+      // Confirm...
+      let confirmMsg = `\nDeprovisioning will remove ${this.logDrain.get('handle')} and CANNOT be undone.\n\n`;
+      confirmMsg += 'Are you sure you want to continue?\n';
+      if (!confirm(confirmMsg)) { return false; }
+
       let message = `Successfully deprovisioned ${this.logDrain.get('handle')}`;
       let errorMessage = `There was an error restarting ${this.logDrain.get('handle')}.`;
       let component = this;

--- a/app/components/log-drain-actions/template.hbs
+++ b/app/components/log-drain-actions/template.hbs
@@ -3,6 +3,6 @@
     <button class="btn btn-default btn-xs" {{action "restart" logDrain}}>Restart</button>
   {{/if}}
   {{#unless logDrain.hasBeenDeprovisioned}}
-    <button class="btn btn-default btn-xs" {{action "deprovision" logDrain}}>Deprovision</button>
+    <button class="btn btn-default btn-xs" {{action "deprovision" logDrain}}>Delete</button>
   {{/unless}}
 </div>

--- a/tests/acceptance/certificates/delete-test.js
+++ b/tests/acceptance/certificates/delete-test.js
@@ -79,6 +79,8 @@ test(`visiting ${url} and deleting a certificate should delete the certificate`,
   signInAndVisit(url);
   andThen(function() {
     let deleteButton = find('button:contains(Delete)');
+    // Clobber window confirm to accept delete.
+    window.confirm = () => { return true; };
     deleteButton.click();
   });
 

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -234,7 +234,9 @@ test(`visit ${url} with log drains and deprovisions one`, function(assert){
   signInAndVisit(url);
 
   andThen(function(){
-    clickButton('Deprovision');
+    // Clobber window confirm to accept delete.
+    window.confirm = () => { return true; };
+    clickButton('Delete');
   });
   andThen(function() {
     assert.equal(find('.alert-success').length, 1, 'displays a success message');

--- a/tests/integration/components/log-drain-actions-test.js
+++ b/tests/integration/components/log-drain-actions-test.js
@@ -20,7 +20,7 @@ test('shows reset and deprovisioned actions for provisioned log drains', functio
   this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
 
   assert.equal(this.$('.panel-heading-actions button').length, 2);
-  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Delete")').length, 1);
   assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 1);
 });
 
@@ -30,7 +30,7 @@ test('shows only deprovisioned action for provisioning log drains', function(ass
   this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
 
   assert.equal(this.$('.panel-heading-actions button').length, 1);
-  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 1);
+  assert.equal(this.$('.panel-heading-actions button:contains("Delete")').length, 1);
   assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 0);
 });
 
@@ -40,6 +40,6 @@ test('shows no actions for deprovisioning log drains', function(assert) {
   this.render(hbs('{{log-drain-actions logDrain=logDrain completedAction="completedAction" failedAction="failedAction"}}'));
 
   assert.equal(this.$('.panel-heading-actions button').length, 0);
-  assert.equal(this.$('.panel-heading-actions button:contains("Deprovision")').length, 0);
+  assert.equal(this.$('.panel-heading-actions button:contains("Delete")').length, 0);
   assert.equal(this.$('.panel-heading-actions button:contains("Restart")').length, 0);
 });


### PR DESCRIPTION
Closes https://github.com/aptible/dashboard.aptible.com/issues/514

![confirm-delete](https://cloud.githubusercontent.com/assets/94830/12685104/93f39ef2-c67f-11e5-8df4-0608ed44b6af.gif)

We haven't used these native confirm dialogs in the app before. It may be an Ember anti-pattern, but I think it's a good compromise to get the log drain actions available. (@sandersonet, @mixonic)