### PR TITLE
add stub for polling update

### DIFF
--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -427,6 +427,15 @@ test(`visit ${addLogUrl} and create log to HTTPS`, function(assert){
     return this.success(json);
   });
 
+  stubRequest('get', '/log_drains/:id', function(request){
+    return this.success({
+      id: request.params.id,
+      handle: handle,
+      drain_host: drainHost,
+      drain_port: drainPort
+    });
+  });
+
   stubRequest('post', `/log_drains/${logDrainId}/operations`, function(request){
     let json = this.json(request);
     assert.equal(json.type, 'configure', 'creates configure operation');


### PR DESCRIPTION
@krallin @fancyremarker 

The issue was a missing stub.  I assume this passed previously because the test completed before the poll timeout was hit.  

An alternative fix would be to update the `/log_drains` index stub to only return `status: provisioned` log drains, but that would probably require altering additional tests.  This was the simplest fix.

