### PR TITLE
`--initialize-from` support

### DIFF
--- a/app/components/operation-icon/component.js
+++ b/app/components/operation-icon/component.js
@@ -11,7 +11,8 @@ var types = {
   tunnel: 'fa-exchange',
   clone: 'fa-copy',
   deprovision: 'fa-remove',
-  reprovision: 'fa-refresh'
+  reprovision: 'fa-refresh',
+  replicate: 'fa-clone'
 };
 
 var statuses = {

--- a/app/components/operation-item/component.js
+++ b/app/components/operation-item/component.js
@@ -6,10 +6,10 @@ export default Ember.Component.extend({
     var type = this.get('operation.type');
     if(type === 'execute') {
       return 'SSHed';
-    } else if (type === 'configure') {
-      return 'configured';
-    } else {
-      return `${type}ed`;
     }
+    if (type.slice(-1) === 'e') {
+      return `${type}d`;
+    }
+    return `${type}ed`;
   }.property('operation.type')
 });

--- a/app/database/deprovision/template.hbs
+++ b/app/database/deprovision/template.hbs
@@ -15,6 +15,14 @@
             </div>
           {{/if}}
 
+          {{#if model.dependents}}
+          <p>
+            These other databases depend on {{model.handle}}, you must delete them first:
+          </p>
+          <p>
+            {{partial 'database/replicas'}}
+          </p>
+          {{else}}
           <p>
             This action CANNOT be undone. This will permanently deprovision
             <strong>{{model.handle}}</strong>.
@@ -27,6 +35,7 @@
               Deprovision Permanently
             {{/button-with-confirmation}}
           </div>
+          {{/if}}
         </form>
 
       </div>

--- a/app/database/replicate/controller.js
+++ b/app/database/replicate/controller.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import config from '../../config/environment';
+
+export default Ember.Controller.extend({
+  supportPortal: config.externalUrls.supportPortal
+});

--- a/app/database/replicate/route.js
+++ b/app/database/replicate/route.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  titleToken: function(){
+    var database = this.modelFor('database');
+    return `Replicate ${database.get('handle')}`;
+  }
+});

--- a/app/database/replicate/template.hbs
+++ b/app/database/replicate/template.hbs
@@ -1,0 +1,31 @@
+<div class="row">
+<div class="col-xs-9">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3>Submit a support request</h3>
+    </div>
+    <div class="panel-body">
+      <p>
+      Replication is currently in beta.
+      To request a new replica for this database, <a href="{{supportPortal}}">please contact support</a>.
+      </p>
+      <p>
+      Make sure you include the database handle in your request.
+      </p>
+    </div>
+  </div>
+
+  {{#if model.dependents}}
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3>Existing replicas for {{model.handle}}</h3>
+      </div>
+      <div class="panel-body">
+        <p>
+        {{partial 'database/replicas'}}
+        </p>
+      </div>
+    </div>
+  {{/if}}
+</div>
+</div>

--- a/app/router.js
+++ b/app/router.js
@@ -39,6 +39,7 @@ Router.map(function() {
       path: "databases/:database_id"
     }, function() {
       this.route("activity");
+      this.route("replicate");
       this.route("deprovision");
     });
 

--- a/app/templates/database/-header.hbs
+++ b/app/templates/database/-header.hbs
@@ -3,7 +3,14 @@
 
     <div class="resource-title">
       <i class="resource-icon resource-db"></i>
-      <h1>{{model.handle}}</h1>
+      <h1>
+        {{model.handle}}
+        {{#if model.initializeFrom}}
+          <span class="resource-affix">
+            replicates {{#link-to 'database' model.initializeFrom}}{{ model.initializeFrom.handle }}{{/link-to}}
+          </span>
+        {{/if}}
+      </h1>
     </div>
 
     <ul class="resource-metadata">

--- a/app/templates/database/-nav.hbs
+++ b/app/templates/database/-nav.hbs
@@ -3,6 +3,12 @@
     {{link-to "Activity" "database.activity"}}
   {{/activating-item}}
 
+  {{#if model.supportsReplication}}
+    {{#activating-item currentWhen="database.replicate" tagName="li"}}
+      {{link-to "Replicate" "database.replicate"}}
+    {{/activating-item}}
+  {{/if}}
+
   {{#unless model.hasBeenDeprovisioned}}
     {{#activating-item currentWhen="database.deprovision" tagName="li"}}
       {{link-to "Deprovision" "database.deprovision"}}

--- a/app/templates/database/-replicas.hbs
+++ b/app/templates/database/-replicas.hbs
@@ -1,0 +1,5 @@
+<ul>
+{{#each model.dependents as |dependent|}}
+  <li>{{#link-to 'database' dependent}}{{ dependent.handle }}{{/link-to}}</li>
+  {{/each}}
+</ul>

--- a/config/environment.js
+++ b/config/environment.js
@@ -26,7 +26,8 @@ module.exports = function(environment) {
     segmentioKey: 'Jp74HTqG03zhS4cAJK4pueo2FL1Z6bM3',
 
     externalUrls: {
-      gettingStartedDocs: 'https://support.aptible.com/quickstart'
+      gettingStartedDocs: 'https://support.aptible.com/quickstart',
+      supportPortal: 'https://aptible.zendesk.com/hc/en-us/requests/new'
     },
 
     flashMessageDefaults: {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "0.0.57",
+    "ember-cli-aptible-shared": "0.0.58",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/tests/acceptance/databases/replicate-test.js
+++ b/tests/acceptance/databases/replicate-test.js
@@ -1,0 +1,153 @@
+import Ember from 'ember';
+import {module, test} from 'qunit';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from '../../helpers/fake-server';
+
+var App;
+var stackHandle = 'rrriggi';
+
+module('Acceptance: Database Replication', {
+  beforeEach: function() {
+    App = startApp();
+    stubOrganizations();
+    stubStacks();
+
+    stubStack({
+      id: stackHandle,
+      handle: stackHandle
+    });
+
+    stubRequest('get', '/databases/:id/operations', function(){
+      return this.success({
+        _embedded: {
+          operations: []
+        }
+      });
+    });
+
+    [[1, 'redis'], [2, 'mysql'], [3, 'postgresql'], [4, 'elasticsearch']].forEach((testDb) => {
+      stubDatabase({
+        id: testDb[0],
+        handle: `${testDb[1]}-test`,
+        type: testDb[1],
+        _links: {
+          stack: { href: `/accounts/${stackHandle}` }
+        }
+      });
+    });
+
+    var master = {
+      id: 10,
+      handle: 'redis-master',
+      type: 'redis',
+      _links: {
+        self: { href: '/databases/10' },
+        stack: { href: `/accounts/${stackHandle}` },
+        dependents: { href: '/databases/10/dependents' }
+      }
+    };
+
+    var replica = {
+      id: 11,
+      handle: 'redis-replica',
+      type: 'redis',
+      _embedded: {
+        initialize_from: master
+      },
+      _links: {
+        self: { href: '/databases/11' },
+        stack: { href: `/accounts/${stackHandle}` }
+      }
+    };
+
+    stubDatabase(replica);
+    stubDatabase(master);
+    stubRequest('get', '/databases/10/dependents', function(){
+      return this.success({
+        _embedded: {
+          dependents: [replica]
+        }
+      });
+    });
+
+  },
+  afterEach: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('/databases/:id/replicate requires authentication', function() {
+  expectRequiresAuthentication('/databases/1/replicate');
+});
+
+test('/databases/:id/replicate links to support', function() {
+  signInAndVisit('/databases/1/replicate');
+  andThen(function(){
+    var panel = findWithAssert('.panel-body');
+    findWithAssert('a:contains(contact support)', panel);
+    expectTitle(`Replicate redis-test - ${stackHandle}`);
+  });
+});
+
+test('/databases/:id/replicate links to dependents', function(assert) {
+  signInAndVisit('/databases/10/replicate');
+  andThen(function(){
+    // There are two panels here, so we have a to be a bit less
+    // specific.
+    var page = findWithAssert('.layout-container');
+
+    expectLink('/databases/11', {context: page});
+    findWithAssert('a:contains(redis-replica)', page);
+
+    var links = find('.panel li a', page);
+    assert.ok(links.length === 1);
+  });
+});
+
+test('/databases/:id links to replicate for Redis', function() {
+  signInAndVisit('/databases/1');
+  andThen(function(){
+    expectLink('/databases/1/replicate');
+  });
+});
+
+test('/databases/:id does not link to replicate for ElasticSearch', function() {
+  signInAndVisit('/databases/4');
+  andThen(function(){
+    expectNoLink('/databases/4/replicate');
+  });
+});
+
+test('/databases/:id links to parent', function() {
+  signInAndVisit('/databases/11');
+  andThen(function(){
+    var header = findWithAssert('.resource-header .resource-title');
+    findWithAssert('span:contains(replicates)', header);
+    findWithAssert('a:contains(redis-master)', header);
+    expectLink('/databases/10', {context: header});
+  });
+});
+
+test('/databases/:id/deprovision requires dependents to be deleted', function (assert) {
+  signInAndVisit('/databases/10/deprovision');
+
+  andThen(function(){
+    var panel = findWithAssert('.panel-body');
+
+    expectNoButton('Deprovision Permanently', {context: panel});
+    expectLink('/databases/11', {context: panel});
+    findWithAssert('a:contains(redis-replica)', panel);
+
+    var links = find('li a', panel);
+    assert.ok(links.length === 1);
+  });
+});
+
+test('/databases/:id/deprovision allows dependents to be deleted', function () {
+  signInAndVisit('/databases/11/deprovision');
+  andThen(function(){
+    var panel = findWithAssert('.panel-body');
+    expectButton('Deprovision Permanently', {context: panel});
+  });
+});
+


### PR DESCRIPTION
This adds basic support for `--initialize-from` in the UI

Specifically, it:

+ Adds a "Replicate" tab to databases that support it. The tab currently prompts users to contact support, and shows replicas after we've provisioned them.
+ Updates the "Deprovision" tab to not let you delete a database unless you've deleted all dependents first. This is mainly here to ensure users don't expect to just be able to just use the replica after deleting the master.

Here are a couple of screenshots:

- https://www.evernote.com/l/AXs21987ukdOzrVMUuNFp5JsEhbcC-7m_V0
- https://www.evernote.com/l/AXvxQznQZL5OBJKBPGH3d6JQnXgDWZSIB8E

In the future (e.g. when we support ElasticSearch replication), we'll need to make this a little smarter and have the names depend on the DB type (e.g. "cluster" instead of "replicate).

Thanks @sandersonet for helping me understand where the issue fixed in https://github.com/201-created/ember-data-hal-9000/pull/40 was coming from :)

Note: this depends on https://github.com/aptible/ember-cli-aptible-shared/pull/84 and https://github.com/201-created/ember-data-hal-9000/pull/40

cc @fancyremarker @gib @sandersonet 