### PR TITLE
Add slider for service container size

### DIFF
--- a/app/app/services/index/route.js
+++ b/app/app/services/index/route.js
@@ -20,7 +20,7 @@ export default Ember.Route.extend({
   },
 
   actions: {
-    scaleService: function(service, containerCount, deferred){
+    scaleService: function(service, containerCount, containerSize, deferred) {
       let reloadUntilOperationStatusChanged = (operation, maximumTimeout, timeout) => {
         return operation.reload().then((o) => {
           return new Ember.RSVP.Promise((resolve, reject) => {
@@ -44,6 +44,7 @@ export default Ember.Route.extend({
 
       this.store.createRecord('operation', {
         type: 'scale',
+        containerSize: containerSize,
         containerCount: containerCount,
         service: service
       }).save()
@@ -52,5 +53,4 @@ export default Ember.Route.extend({
         .then(deferred.resolve, deferred.reject);
     }
   }
-
 });

--- a/app/components/estimated-cost/component.js
+++ b/app/components/estimated-cost/component.js
@@ -22,7 +22,7 @@ export default Ember.Component.extend({
 
   total: function() {
     return centsToDollars(
-      hoursPerMonth * this.get('count') * this.get('stack.appContainerCentsPerHour')
+      hoursPerMonth * (this.get('count') * (this.get('size') / 1024)) * this.get('stack.appContainerCentsPerHour')
     );
-  }.property('stack.appContainerCentsPerHour', 'count')
+  }.property('stack.appContainerCentsPerHour', 'count', 'size')
 });

--- a/app/components/estimated-cost/template.hbs
+++ b/app/components/estimated-cost/template.hbs
@@ -1,4 +1,4 @@
 <div class="cost-estimate">
-  <h4 class="rate">{{count}} {{unitOfMeasure}} at {{rateInDollars}}/container/hour</h4>
+  <h4 class="rate">{{count}} {{unitOfMeasure}} ({{size}} MB) at {{rateInDollars}}/container/hour</h4>
   <h2 class="total">{{total}}/month</h2>
 </div>

--- a/app/components/service-scaler/template.hbs
+++ b/app/components/service-scaler/template.hbs
@@ -1,6 +1,5 @@
 <div class="row">
   <div class="col-xs-7">
-    <label>Containers</label>
     <div class="slider-input-wrapper">
       {{#if error}}
         <div class="alert alert-danger">
@@ -20,6 +19,7 @@
         </div>
       {{/if}}
 
+      <label>Containers</label>
       <div class="slider-input-wrapper--flex">
         <div class="container-count">
           {{containerCount}}
@@ -31,6 +31,7 @@
                          start=containerCount
                          rangeMin=0
                          rangeMax=10
+                         disabled=isSaving
                          step=1}}
           <div class="label-wrapper">
             <div class="label pull-left">0</div>
@@ -40,20 +41,45 @@
 
         <div class="slider-actions" data-visible="{{showActionButtons}}">
           <button {{action "cancel"}} class="btn btn-xs btn-default btn-cancel">Cancel</button>
-          <button {{action "scale"}} class="btn btn-xs btn-primary slider-confirm">
+          <button {{action "scale"}} class="btn btn-xs btn-primary slider-confirm" disabled={{ isSaving }}>
             {{#if isSaving}}
-              Saving...
+              Scaling...
             {{else}}
               Scale
             {{/if}}
           </button>
         </div>
       </div>
+
+      <label>Memory size</label>
+      <div class="slider-input-wrapper--flex">
+        <div class="container-count">
+          {{containerSize}}
+        </div>
+
+        <div class="slider-wrapper">
+          {{no-ui-slider didSlide="setContainerSize"
+                         didSet="finishSliding"
+                         start=containerSize
+                         rangeMin=256
+                         rangeMax=8192
+                         snap=true
+                         disabled=shouldDisable
+                         range="256,512,1024,2048,4096"}}
+          <div class="label-wrapper">
+            <div class="label pull-left">256</div>
+            <div class="label pull-right">8192</div>
+          </div>
+        </div>
+
+        <div class="slider-actions"></div>
+      </div>
+
     </div>
   </div>
   <div class="col-xs-5">
     <div class="pull-right">
-      {{estimated-cost count=containerCount stack=service.stack}}
+      {{estimated-cost count=containerCount stack=service.stack size=containerSize}}
     </div>
   </div>
 </div>

--- a/app/styles/components/slider.scss
+++ b/app/styles/components/slider.scss
@@ -19,6 +19,12 @@
     background: $color-bright-blue;
   }
 
+  [disabled].noUi-connect {
+    cursor: $cursor-disabled;
+    background: $gray-lighter;
+    opacity: .3;
+  }
+
   .noUi-horizontal .noUi-handle {
     background-image: -o-linear-gradient(-89deg, #fff 0%, #ebebeb 100%);
     background-image: -moz-linear-gradient(-89deg, #fff 0%, #ebebeb 100%);
@@ -96,12 +102,16 @@
 
   .slider-input-wrapper--flex {
     display: flex;
+    margin-bottom: 15px;
+    & + .slider-input-wrapper--flex {
+      margin-top: 20px;
+    }
   }
 
   .slider-actions {
     text-align: right;
     visibility: hidden;
-    // width: 60px;
+    min-width: 64px;
 
     &[data-visible='true'] {
       visibility: visible;

--- a/tests/unit/components/estimated-cost-test.js
+++ b/tests/unit/components/estimated-cost-test.js
@@ -21,6 +21,7 @@ moduleForComponent('estimated-cost', 'EstimatedCostComponent', {
     return klass.create({
       features: opts.features || mockFeaturesService(true),
       count: 5,
+      size: 2048,
       stack: Ember.Object.create({
         appContainerCentsPerHour: 10,
         type: 'production'
@@ -46,7 +47,7 @@ test('calculates accurate estimate', function(assert) {
 
   assert.equal(component.get('rateInDollars'), '$0.10');
   assert.equal(component.get('unitOfMeasure'), 'Production App Containers');
-  assert.equal(component.get('total'), '$365.50');
+  assert.equal(component.get('total'), '$731.00');
 });
 
 test('is visible with priceEstimator feature flag', function(assert) {

--- a/tests/unit/components/no-ui-slider-test.js
+++ b/tests/unit/components/no-ui-slider-test.js
@@ -47,6 +47,39 @@ test('sliding sends action didSlide with the value', function(assert) {
   var element = this.$();
 
   Ember.$(element).trigger('slide', 4);
+  var disabled = element.attr('disabled');
 
+  assert.equal(disabled, null, 'disabled attribute');
   assert.equal(slideValue, 4, 'slide action called with value');
+});
+
+test('disabling component should set disabled attribute', function(assert) {
+  var slideValue;
+
+  var MockController = Ember.Object.extend(Ember.ActionHandler, {
+    _actions: {
+      mySlideAction: function(val){
+        slideValue = val;
+      }
+    }
+  });
+
+  var mockController = MockController.create();
+
+  this.subject({
+    targetObject: mockController,
+    start: 1,
+    rangeMin: 1,
+    rangeMax: 5,
+    step: 1,
+    disabled: true,
+    didSlide: 'mySlideAction'
+  });
+
+  var element = this.$();
+  var disabled = element.attr('disabled');
+
+  Ember.$(element).trigger('slide', 4);
+
+  assert.equal(disabled, 'disabled', 'disabled attribute');
 });

--- a/tests/unit/components/service-scaler-test.js
+++ b/tests/unit/components/service-scaler-test.js
@@ -29,6 +29,7 @@ test('it renders', function(assert) {
   // creates the component instance
   var component = this.subject({
     service: Ember.Object.create({
+      containerSize: 1024,
       containerCount: 1
     })
   });


### PR DESCRIPTION
Initial commit for setting the service container size for an app.

* Needs some extra styling
* Needs some extra test cases
* This has not been wired up to set the container size on the api yet
* `Object.assign` is not included in PhantomJS 1.9.x, so the tests
there currently fail. Not sure how to handle that.

Relates to #516.

cc @sandersonet @gib 