### PR TITLE
Support actor tokens

### DIFF
--- a/app/login/route.js
+++ b/app/login/route.js
@@ -10,7 +10,8 @@ export function buildCredentials(email, password) {
     username: email,
     password,
     grant_type: 'password',
-    scope: 'manage'
+    scope: 'manage',
+    expires_in: 12 * 60 * 60  // 12 hours
   };
 }
 

--- a/app/router.js
+++ b/app/router.js
@@ -107,6 +107,7 @@ Router.map(function() {
       this.route('admin');
       this.route('profile');
       this.route('ssh');
+      this.route('impersonate');
     });
   });
 

--- a/app/settings/impersonate/controller.js
+++ b/app/settings/impersonate/controller.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  inProgress: false
+});

--- a/app/settings/impersonate/route.js
+++ b/app/settings/impersonate/route.js
@@ -5,7 +5,8 @@ import config from 'diesel/config/environment';
 export default Ember.Route.extend({
   model: function() {
     return Ember.Object.create({
-      email: ''
+      email: '',
+      manage: false
     });
   },
 
@@ -19,7 +20,7 @@ export default Ember.Route.extend({
           actor_token_type: 'urn:ietf:params:oauth:token-type:jwt',
           subject_token: authAttempt.get('email'),
           subject_token_type: 'aptible:user:email',
-          scope: 'manage'
+          scope: authAttempt.get('manage') ? 'manage' : 'read'
       };
 
       this.controller.set('inProgress', true);

--- a/app/settings/impersonate/route.js
+++ b/app/settings/impersonate/route.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+import ajax from "diesel/utils/ajax";
+import config from 'diesel/config/environment';
+
+export default Ember.Route.extend({
+  model: function() {
+    return Ember.Object.create({
+      email: ''
+    });
+  },
+
+  actions: {
+    impersonate: function(authAttempt) {
+      let adminToken = this.get("session.token");
+
+      let credentials = {
+          grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+          actor_token: adminToken.get('accessToken'),
+          actor_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+          subject_token: authAttempt.get('email'),
+          subject_token_type: 'aptible:user:email',
+          scope: 'manage'
+      };
+
+      this.controller.set('inProgress', true);
+      this.currentModel.set('error', null);
+
+      // Log out and then log back in as the impersonated user
+      this.session.close('application', {noDelete: true})
+      .then(() => {
+        return this.session.open('application', credentials);
+      })
+      .then(() => {
+        // Do *not* pass withCredentials to avoid clearing *user* session cookie.
+        return ajax(`${config.authBaseUri}/tokens/${adminToken.get('id')}`, {
+          type: 'DELETE',
+          headers: {'Authorization': 'Bearer ' + adminToken.get('accessToken')}
+        });
+      }, (e) => {
+        // Log back in as the (presumed) admin user and propagate the error.
+        return this.session.open('application', {token: adminToken}).then(() => {throw e;});
+      })
+      .then(() => {
+        return this.transitionTo('index');
+      }, (e) => {
+        this.currentModel.set('error', `Error: ${e.message || JSON.stringify()}`);
+      })
+      .finally(() => {
+        this.controller.set('inProgress', false);
+      });
+    }
+  }
+});

--- a/app/settings/impersonate/template.hbs
+++ b/app/settings/impersonate/template.hbs
@@ -19,6 +19,12 @@
             autofocus=true
             class="form-control"}}
           </div>
+          <div class="form-group">
+            <label>Read-write access</label>
+            {{input type="checkbox"
+              name="read-write"
+              checked=model.manage}}
+          </div>
         </div>
       </div>
     </div>

--- a/app/settings/impersonate/template.hbs
+++ b/app/settings/impersonate/template.hbs
@@ -1,0 +1,36 @@
+<form role="form">
+  <div class="row">
+    <div class="col-xs-8">
+      <div class="panel panel-default ">
+        <div class="panel-heading">
+          <h3>Impersonate a user</h3>
+        </div>
+        {{#if model.error}}
+          {{#bs-alert alert="danger"}}
+            {{model.error}}
+          {{/bs-alert}}
+        {{/if}}
+        <div class="panel-body">
+          <div class="form-group">
+            <label>User email </label>
+            {{input type="email"
+            name="email"
+            value=model.email
+            autofocus=true
+            class="form-control"}}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="resource-actions">
+    <button class="btn btn-primary" type="submit" {{action 'impersonate' model}} disabled={{inProgress}}>
+      {{#if inProgress}}
+        <i class="fa fa-spin fa-spinner"></i> Please wait
+      {{else}}
+        Impersonate
+      {{/if}}
+    </button>
+  </div>
+</form>

--- a/app/templates/sidebars/settings.hbs
+++ b/app/templates/sidebars/settings.hbs
@@ -44,4 +44,8 @@
   {{#activating-item currentWhen='settings.ssh' tagName='li'}}
     {{link-to 'SSH Keys' 'settings.ssh'}}
   {{/activating-item}}
+
+  {{#activating-item currentWhen='settings.impersonate' tagName='li'}}
+    {{link-to 'Impersonate' 'settings.impersonate'}}
+  {{/activating-item}}
 </ul>

--- a/app/templates/sidebars/settings.hbs
+++ b/app/templates/sidebars/settings.hbs
@@ -45,7 +45,9 @@
     {{link-to 'SSH Keys' 'settings.ssh'}}
   {{/activating-item}}
 
-  {{#activating-item currentWhen='settings.impersonate' tagName='li'}}
-    {{link-to 'Impersonate' 'settings.impersonate'}}
-  {{/activating-item}}
+  {{#if session.currentUser.superuser}}
+    {{#activating-item currentWhen='settings.impersonate' tagName='li'}}
+      {{link-to 'Impersonate' 'settings.impersonate'}}
+    {{/activating-item}}
+  {{/if}}
 </ul>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "0.0.64",
+    "ember-cli-aptible-shared": "0.0.66",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/tests/acceptance/impersonate-test.js
+++ b/tests/acceptance/impersonate-test.js
@@ -6,14 +6,15 @@ import { stubRequest } from '../helpers/fake-server';
 let App;
 let impersonateUrl = '/settings/impersonate';
 
-let targetUserId = 'user2';
-let targetUserEmail = 'user@email.com';
+let targetUserId = 'test-user-id';
+let targetUserEmail = 'testUser@email.com';
 let targetUserName = 'Test User';
 let targetUserUrl = `/users/${targetUserId}`;
 
-let adminUserTokenId = 'stubbed-token-id';
-let adminUserToken = 'my-token';
-let adminUserId = 'user1';
+let adminTokenId = 'admin-token-id';
+let adminTokenValue = 'admin-token-value';
+
+let adminUserId = 'admin-user-id';
 let adminUserName = 'Admin User';
 let adminUserUrl = `/users/${adminUserId}`;
 
@@ -23,8 +24,8 @@ let adminUserData = {
 };
 
 let adminTokenData = {
-  id: adminUserTokenId,
-  access_token: adminUserToken
+  id: adminTokenId,
+  access_token: adminTokenValue
 };
 
 
@@ -65,7 +66,7 @@ test('Impersonation succeeds', function(assert) {
   stubRequest('post', '/tokens', function(request) {
     let params = this.json(request);
     assert.equal(params.grant_type, 'urn:ietf:params:oauth:grant-type:token-exchange');
-    assert.equal(params.actor_token, adminUserToken);
+    assert.equal(params.actor_token, adminTokenValue);
     assert.equal(params.actor_token_type, 'urn:ietf:params:oauth:token-type:jwt');
     assert.equal(params.subject_token, targetUserEmail);
     assert.equal(params.subject_token_type, 'aptible:user:email');
@@ -88,8 +89,8 @@ test('Impersonation succeeds', function(assert) {
     });
   });
 
-  stubRequest('delete', `/tokens/${adminUserTokenId}`, function(request) {
-    assert.equal(request.requestHeaders.Authorization, `Bearer ${adminUserToken}`, 'DELETEd admin token as admin user');
+  stubRequest('delete', `/tokens/${adminTokenId}`, function(request) {
+    assert.equal(request.requestHeaders.Authorization, `Bearer ${adminTokenValue}`, 'DELETEd admin token as admin user');
     deletedAdminToken = true;
     return this.success();
   });

--- a/tests/acceptance/impersonate-test.js
+++ b/tests/acceptance/impersonate-test.js
@@ -1,0 +1,125 @@
+import Ember from 'ember';
+import {module, test} from 'qunit';
+import startApp from '../helpers/start-app';
+import { stubRequest } from '../helpers/fake-server';
+
+let App;
+let impersonateUrl = '/settings/impersonate';
+
+let targetUserId = 'user2';
+let targetUserEmail = 'user@email.com';
+let targetUserName = 'Test User';
+let targetUserUrl = `/users/${targetUserId}`;
+
+let adminUserTokenId = 'stubbed-token-id';
+let adminUserToken = 'my-token';
+let adminUserId = 'user1';
+let adminUserName = 'Admin User';
+let adminUserUrl = `/users/${adminUserId}`;
+
+let adminUserData = {
+  id: adminUserId,
+  name: adminUserName
+};
+
+let adminTokenData = {
+  id: adminUserTokenId,
+  access_token: adminUserToken
+};
+
+
+module('Acceptance: Impersonation', {
+  beforeEach: function() {
+    App = startApp();
+    stubStacks();
+    stubOrganization();
+    stubOrganizations();
+
+    stubRequest('get', adminUserUrl, function (request) {
+      request.ok({
+        id: adminUserId,
+        name: adminUserName,
+      });
+    });
+
+    stubRequest('get', targetUserUrl, function (request) {
+      request.ok({
+        id: targetUserId,
+        name: targetUserName,
+        email: targetUserEmail
+      });
+    });
+  },
+  afterEach: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test(`${impersonateUrl} requires authentication`, function() {
+  expectRequiresAuthentication(impersonateUrl);
+});
+
+test('Impersonation succeeds', function(assert) {
+  var deletedAdminToken = false;
+
+  stubRequest('post', '/tokens', function(request) {
+    let params = this.json(request);
+    assert.equal(params.grant_type, 'urn:ietf:params:oauth:grant-type:token-exchange');
+    assert.equal(params.actor_token, adminUserToken);
+    assert.equal(params.actor_token_type, 'urn:ietf:params:oauth:token-type:jwt');
+    assert.equal(params.subject_token, targetUserEmail);
+    assert.equal(params.subject_token_type, 'aptible:user:email');
+
+    return this.success({
+      id: 'new-token-id',
+      access_token: 'new-token',
+      token_type: 'bearer',
+      expires_in: 2,
+      scope: 'manage',
+      type: 'token',
+      _links: {
+        user: {
+          href: targetUserUrl
+        },
+        actor: {
+          href: adminUserUrl
+        }
+      }
+    });
+  });
+
+  stubRequest('delete', `/tokens/${adminUserTokenId}`, function(request) {
+    assert.equal(request.requestHeaders.Authorization, `Bearer ${adminUserToken}`, 'DELETEd admin token as admin user');
+    deletedAdminToken = true;
+    return this.success();
+  });
+
+  signInAndVisit(impersonateUrl, adminUserData, {}, adminTokenData);
+  fillInput('email', targetUserEmail);
+  clickButton('Impersonate');
+  andThen(() => {
+    assert.ok(deletedAdminToken, 'admin token was deleted');
+    findWithAssert(`header.navbar:contains('${adminUserName} (as ${targetUserName})')`);
+    assert.equal(currentPath(), 'dashboard.stack.apps.index', 'redirected to index');
+  });
+});
+
+test('Impersonation fails', function(assert) {
+  stubRequest('post', '/tokens', function() {
+    return this.error(401, {
+      code: 401,
+      error: 'invalid_grant',
+      message: 'Invalid grant'
+    });
+  });
+
+  signInAndVisit(impersonateUrl, adminUserData, {}, adminTokenData);
+  fillInput('email', targetUserEmail);
+  clickButton('Impersonate');
+  andThen(() => {
+    findWithAssert(`header.navbar:contains('${adminUserName}')`);
+    findWithAssert("div:contains('Error: Invalid grant')");
+    assert.equal(find(`header.navbar:contains('${targetUserName}')`).length, 0, 'user is not in navbar');
+    assert.equal(currentPath(), 'dashboard.settings.impersonate', 'remained in impersonation settings');
+  });
+});

--- a/tests/acceptance/impersonate-test.js
+++ b/tests/acceptance/impersonate-test.js
@@ -20,7 +20,14 @@ let adminUserUrl = `/users/${adminUserId}`;
 
 let adminUserData = {
   id: adminUserId,
-  name: adminUserName
+  name: adminUserName,
+  superuser: true
+};
+
+let targetUserData = {
+  id: targetUserId,
+  email: targetUserEmail,
+  name: targetUserName,
 };
 
 let adminTokenData = {
@@ -37,18 +44,11 @@ module('Acceptance: Impersonation', {
     stubOrganizations();
 
     stubRequest('get', adminUserUrl, function (request) {
-      request.ok({
-        id: adminUserId,
-        name: adminUserName,
-      });
+      request.ok(adminUserData);
     });
 
     stubRequest('get', targetUserUrl, function (request) {
-      request.ok({
-        id: targetUserId,
-        name: targetUserName,
-        email: targetUserEmail
-      });
+      request.ok(targetUserData);
     });
   },
   afterEach: function() {
@@ -122,5 +122,20 @@ test('Impersonation fails', function(assert) {
     findWithAssert("div:contains('Error: Invalid grant')");
     assert.equal(find(`header.navbar:contains('${targetUserName}')`).length, 0, 'user is not in navbar');
     assert.equal(currentPath(), 'dashboard.settings.impersonate', 'remained in impersonation settings');
+  });
+});
+
+test('Impersonate link is shown to superusers', function() {
+  signInAndVisit('/settings', adminUserData, {}, adminTokenData);
+
+  andThen(() => {
+    expectLink(impersonateUrl);
+  });
+});
+
+test('Impersonate link is not shown to regular users', function() {
+  signInAndVisit('/settings', targetUserData);
+  andThen(() => {
+    expectNoLink(impersonateUrl);
   });
 });


### PR DESCRIPTION
This:

- Adds support for impersonation and actor tokens in the Dashboard. 
- Defaults token expiry to 12 hours. See https://github.com/aptible/auth.aptible.com/pull/201 for some context.

--

Note: the tests are going to fail until the corresponding PR in https://github.com/aptible/ember-cli-aptible-shared (https://github.com/aptible/ember-cli-aptible-shared/pull/92) is merged.

cc @fancyremarker @sandersonet @gib 