### PR TITLE
Fix stale environment header vhost metadata

### DIFF
--- a/app/components/stack-metadata/component.js
+++ b/app/components/stack-metadata/component.js
@@ -12,16 +12,16 @@ export default Ember.Component.extend({
     return this.model.get('vhostNames.length') > this.get('maxVisibleDomainNames');
   }),
 
-  vhostRemaining: Ember.computed('vhostNames', function() {
+  vhostRemaining: Ember.computed('model.vhostNames', function() {
     return this.model.get('vhostNames.length') - this.get('maxVisibleDomainNames');
   }),
 
-  vhostNamesSnippet: Ember.computed('vhostNames', function() {
+  vhostNamesSnippet: Ember.computed('model.vhostNames', function() {
     let names = this.model.get('vhostNames');
     return names.slice(0, this.get('maxVisibleDomainNames')).join(', ');
   }),
 
-  vhostNamesTooltip: Ember.computed('vhostNames', function() {
+  vhostNamesTooltip: Ember.computed('model.vhostNames', function() {
     let names = this.model.get('vhostNames');
     return names.slice(this.get('maxVisibleDomainNames')).join(', ');
   })


### PR DESCRIPTION
**Really** closes https://github.com/aptible/dashboard.aptible.com/issues/496 by binding the computed vhosts metadata to the parent environment.

Here's the bug, requiring a refresh to get the right data...
![bug](https://cloud.githubusercontent.com/assets/94830/13410534/9081b388-def5-11e5-9aec-a6247e2e8d99.gif)

With the parent model included in the ember computed scope, the update works as expected...
![fixed](https://cloud.githubusercontent.com/assets/94830/13410557/b249d194-def5-11e5-9966-28a4598c4630.gif)
