### PR TITLE
Drag-n-drop .crt, bundled .crt, and .key files to create certificates

### DIFF
--- a/app/certificates/new/template.hbs
+++ b/app/certificates/new/template.hbs
@@ -17,12 +17,24 @@
 
           <div class="form-group">
             <label>Certificate</label>
-            {{textarea class="form-control" value=model.certificateBody name="body" rows=10 autofocus=true}}
+            <p>
+              Drag and drop your certificate file or paste its contents in the
+              textarea below.
+            </p>
+            <p>
+              If you have a bundled certificate chain, drag and drop all of the
+              certificate files or paste their contents in the textarea below.
+            </p>
+            {{file-textarea value=model.certificateBody name="body" rows=10 autofocus=true}}
           </div>
 
           <div class="form-group">
             <label>Private Key</label>
-            {{textarea class="form-control" value=model.privateKey name="private-key" rows=10}}
+            <p>
+              Drag and drop your private key file or paste its contents in the
+              textarea below.
+            </p>
+            {{file-textarea value=model.privateKey name="private-key" rows=10}}
           </div>
 
         </div>

--- a/app/components/file-textarea/component.js
+++ b/app/components/file-textarea/component.js
@@ -1,0 +1,36 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNameBindings: ['dropTargetActive'],
+
+  dropTargetActive: false,
+
+  doneReading: function(event) {
+    let file = event.target;
+    this.set('value', Ember.getWithDefault(this, 'value', '') + file.result);
+  },
+
+  dragEnter: function() {
+    this.set('dropTargetActive', true);
+  },
+
+  dragLeave: function() {
+    this.set('dropTargetActive', false);
+  },
+
+  drop: function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    this.set('dropTargetActive', false);
+    for (var i in event.dataTransfer.files) {
+      try {
+        let reader = new FileReader();
+        let file = event.dataTransfer.files[i];
+
+        reader.onload = Ember.run.bind(this, this.doneReading);
+        reader.readAsText(file);
+      }
+      catch(error) {}
+    }
+  }
+});

--- a/app/components/file-textarea/template.hbs
+++ b/app/components/file-textarea/template.hbs
@@ -1,0 +1,6 @@
+{{textarea
+    class="form-control"
+    value=value
+    name=name
+    rows=rows
+    autofocus=autofocus}}

--- a/tests/integration/components/file-textarea-test.js
+++ b/tests/integration/components/file-textarea-test.js
@@ -1,0 +1,78 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('file-textarea', { integration: true });
+
+test('renders a textarea', function(assert) {
+  this.render(hbs('{{file-textarea value="" name="body" rows=10 autofocus=true}}'));
+  assert.equal(this.$('textarea').length, 1);
+});
+
+test('sets a class when drag events are triggered', function(assert) {
+  this.render(hbs('{{file-textarea value="" name="body" rows=10 autofocus=true}}'));
+  let $elem = this.$('textarea').parent();
+
+  $elem.trigger('dragenter');
+  assert.ok($elem.is('.drop-target-active'));
+  $elem.trigger('drageleave');
+  assert.ok($elem.not('.drop-target-active'));
+});
+
+test('unsets drop target class on drop', function(assert) {
+  let dropEvent = {
+    type: 'drop',
+    stopPropagation: function() {},
+    preventDefault: function(){},
+    dataTransfer: {
+      files: [{
+        lastModified: 1457470091000,
+        name: 'test.txt',
+        size: 1675,
+        type: ''
+      }]
+    }
+  };
+  this.render(hbs('{{file-textarea value="" name="body" rows=10 autofocus=true}}'));
+  let $elem = this.$('textarea').parent();
+
+  $elem.trigger('dragenter');
+  assert.ok($elem.is('.drop-target-active'));
+  $elem.trigger(dropEvent);
+  assert.ok($elem.not('.drop-target-active'));
+});
+
+test('appends file contents to the textarea', function(assert) {
+  let txt1 = 'I love deadlines. I like the whooshing sound they make as they\n';
+  let txt2 = 'fly by. -- Douglas Adams';
+  let dropEvent = {
+    type: 'drop',
+    stopPropagation: function() {},
+    preventDefault: function(){},
+    dataTransfer: {
+      files: [{
+        name: 'test1.txt',
+        result: txt1
+      }, {
+        name: 'test2.txt',
+        result: txt2
+      }]
+    }
+  };
+
+  // Overwrite the FileReader class for testing
+  window.FileReader = class {
+    constructor() { }
+    readAsText(file) {
+      if (file.hasOwnProperty('result')) {
+        this.onload({ type: 'load', target: file });
+      }
+    }
+  };
+
+  this.render(hbs('{{file-textarea value="" name="body" rows=10}}'));
+  let $elem = this.$('textarea').parent();
+  let $textarea = this.$('textarea');
+
+  $elem.trigger(dropEvent);
+  assert.equal($textarea.val(), txt1 + txt2);
+});


### PR DESCRIPTION
Closes https://github.com/aptible/dashboard.aptible.com/issues/532

I did a bit of hallway user testing (thanks @shahkader & @wcpines ) in hopes this is an improved user experience. You can drop multiple files on the textarea and that makes it tricky to order bundled cert chains, but with https://github.com/aptible/api.aptible.com/pull/327, the ordering will be taken care of on the server and the user will not need to worry about it.

Currently we don’t notify users of ordering problems and they end up seeing them in a browser
(https://support.aptible.com/topics/paas/how-to-order-certs/).

We may be better served by a traditional file upload button. Will watch for feedback.

More thanks: feedback / input from @fancyremarker and ember help from @sandersonet

![drag-n-drop-certs](https://cloud.githubusercontent.com/assets/94830/13648934/1a382d5e-e5f0-11e5-8bc4-bb394e7d1b78.gif)
