### PR TITLE
Tests are failing when dependencies update (ember-cli-fake-server 0.2.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
 - npm install
 - bower install
 script:
+- npm list
+- bower list
 - npm test
 - script/travis-deploy.sh
 env: # IAM: travis-s3


### PR DESCRIPTION
I'm trying to troubleshoot an interesting issue with CI.

The exact same code [passes all tests when run in the `dasboard.aptible.com` repo](https://travis-ci.org/aptible/dashboard.aptible.com/builds/115142047) but essentially [fails them all when run in my repository](https://travis-ci.org/krallin/dashboard.aptible.com/builds/115297370).

Tests are also all failing for me locally. Considering that: 

- aptible/dashboard.aptible.com caches node_modules
- krallin/dashboard.aptible.com doesn't have the cache (I set it up today)
- I recreated node_modules yesterday when I wasn't able to make a release

I'm starting to think the problem is with a new version of the modules we pull in.

This PR just dumps what's installed. I'm hoping to be able to spot the offender by using dashboard's cache and diffing the two caches.