### PR TITLE
Impersonation improvements

### DIFF
--- a/app/settings/impersonate/route.js
+++ b/app/settings/impersonate/route.js
@@ -44,7 +44,7 @@ export default Ember.Route.extend({
       .then(() => {
         return this.transitionTo('index');
       }, (e) => {
-        this.currentModel.set('error', `Error: ${e.message || JSON.stringify()}`);
+        this.currentModel.set('error', `Error: ${e.message || JSON.stringify(e)}`);
       })
       .finally(() => {
         this.controller.set('inProgress', false);

--- a/app/settings/impersonate/route.js
+++ b/app/settings/impersonate/route.js
@@ -3,10 +3,27 @@ import Location from "diesel/utils/location";
 import ajax from "diesel/utils/ajax";
 import config from 'diesel/config/environment';
 
+function prepareSubjectParameters(email, organizationHref) {
+  if (email) {
+    return {
+      subject_token: email,
+      subject_token_type: 'aptible:user:email',
+    };
+  } else if (organizationHref) {
+    return {
+      subject_token: organizationHref,
+      subject_token_type: 'aptible:organization:href',
+    };
+  } else {
+    return {};
+  }
+}
+
 export default Ember.Route.extend({
   model: function() {
     return Ember.Object.create({
       email: '',
+      organizationHref: '',
       manage: false
     });
   },
@@ -19,10 +36,10 @@ export default Ember.Route.extend({
           grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
           actor_token: adminToken.get('accessToken'),
           actor_token_type: 'urn:ietf:params:oauth:token-type:jwt',
-          subject_token: authAttempt.get('email'),
-          subject_token_type: 'aptible:user:email',
           scope: authAttempt.get('manage') ? 'manage' : 'read'
       };
+
+      Ember.merge(credentials, prepareSubjectParameters(authAttempt.email, authAttempt.organizationHref));
 
       this.controller.set('inProgress', true);
       this.currentModel.set('error', null);

--- a/app/settings/impersonate/route.js
+++ b/app/settings/impersonate/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Location from "diesel/utils/location";
 import ajax from "diesel/utils/ajax";
 import config from 'diesel/config/environment';
 
@@ -42,7 +43,11 @@ export default Ember.Route.extend({
         return this.session.open('application', {token: adminToken}).then(() => {throw e;});
       })
       .then(() => {
-        return this.transitionTo('index');
+        // At this point we know impersonation has succeeded. Merely transitioning to 'index'
+        // may or may not work, depending on whether some data has been loaded as the superuser
+        // and has stuck around in the store. We can't really clear out the store either, considering
+        // our session data is stored in there. So: we just reload the page to get a clean slate.
+        return Location.replaceAndWait('/');
       }, (e) => {
         this.currentModel.set('error', `Error: ${e.message || JSON.stringify(e)}`);
       })

--- a/app/settings/impersonate/template.hbs
+++ b/app/settings/impersonate/template.hbs
@@ -11,14 +11,25 @@
           {{/bs-alert}}
         {{/if}}
         <div class="panel-body">
+          <p>Choose one impersonation method:</p>
           <div class="form-group">
             <label>User email </label>
             {{input type="email"
             name="email"
             value=model.email
+            disabled=model.organizationHref
             autofocus=true
             class="form-control"}}
           </div>
+          <div class="form-group">
+            <label>Organization HREF</label>
+            {{input type="url"
+            name="organizationHref"
+            value=model.organizationHref
+            disabled=model.email
+            class="form-control"}}
+          </div>
+          <p>Choose your level of access:</p>
           <div class="form-group">
             <label>Read-write access</label>
             {{input type="checkbox"

--- a/tests/acceptance/impersonate-test.js
+++ b/tests/acceptance/impersonate-test.js
@@ -102,7 +102,7 @@ test('Impersonation succeeds with RO access', function(assert) {
   andThen(() => {
     assert.ok(deletedAdminToken, 'admin token was deleted');
     findWithAssert(`header.navbar:contains('${adminUserName} (as ${targetUserName})')`);
-    assert.equal(currentPath(), 'dashboard.stack.apps.index', 'redirected to index');
+    expectReplacedLocation('/');
   });
 });
 
@@ -123,7 +123,7 @@ test('Impersonation succeeds with R/W access', function(assert) {
   clickButton('Impersonate');
   andThen(() => {
     findWithAssert(`header.navbar:contains('${adminUserName} (as ${targetUserName})')`);
-    assert.equal(currentPath(), 'dashboard.stack.apps.index', 'redirected to index');
+    expectReplacedLocation('/');
   });
 });
 

--- a/tests/acceptance/impersonate-test.js
+++ b/tests/acceptance/impersonate-test.js
@@ -18,6 +18,8 @@ let adminUserId = 'admin-user-id';
 let adminUserName = 'Admin User';
 let adminUserUrl = `/users/${adminUserId}`;
 
+let organizationHref = 'http://test/organizations/1';
+
 let adminUserData = {
   id: adminUserId,
   name: adminUserName,
@@ -120,6 +122,31 @@ test('Impersonation succeeds with R/W access', function(assert) {
   signInAndVisit(impersonateUrl, adminUserData, {}, adminTokenData);
   fillInput('email', targetUserEmail);
   check('read-write');
+  clickButton('Impersonate');
+  andThen(() => {
+    findWithAssert(`header.navbar:contains('${adminUserName} (as ${targetUserName})')`);
+    expectReplacedLocation('/');
+  });
+});
+
+test('Impersonation succeeds with an organization target', function(assert) {
+  stubRequest('post', '/tokens', function(request) {
+    let params = this.json(request);
+    assert.equal(params.grant_type, 'urn:ietf:params:oauth:grant-type:token-exchange');
+    assert.equal(params.actor_token, adminTokenValue);
+    assert.equal(params.actor_token_type, 'urn:ietf:params:oauth:token-type:jwt');
+    assert.equal(params.subject_token, organizationHref);
+    assert.equal(params.subject_token_type, 'aptible:organization:href');
+    assert.equal(params.scope, 'read', 'Token is read-only');
+    return this.success(userTokenData);
+  });
+
+  stubRequest('delete', `/tokens/${adminTokenId}`, function() {
+    return this.success();
+  });
+
+  signInAndVisit(impersonateUrl, adminUserData, {}, adminTokenData);
+  fillInput('organizationHref', organizationHref);
   clickButton('Impersonate');
   andThen(() => {
     findWithAssert(`header.navbar:contains('${adminUserName} (as ${targetUserName})')`);


### PR DESCRIPTION
A few things here:

- Fist, fixed a typo I introduced in the last impersonation PR.
- Second, changed how we redirect to the index after impersonation (to be consistent with how login and logout do it). In practice I noticed the `transitionTo` redirect wasn't always succeeding, which according to the network logs was usually because the app was trying to access data it knew existed (because the store hadn't been cleared after changing users), but was no longer able to access (because its user no longer had privileged).
- Third, Added support for organization-href impersonation, which delegates finding who you want to impersonate to auth.aptible.com: you just tell it the organization href, and you'll get logged in as a privileged user within that organization (though it will sometimes fail to find such a user until https://github.com/aptible/auth.aptible.com/pull/206 is merged in).

--

cc @gib @sandersonet for review

cc @wcpines: this should fit your workflow better. Once you have located the organization, just dump its href with https://github.com/aptible/dangerzone/pull/61, and use that to impersonate.