### PR TITLE
Frame Buster

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -4,6 +4,7 @@ import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 import { RouteExtension, RouterExtension } from 'diesel/utils/title-route-extensions';
 import monkeyPatchRaven from './ext/raven';
+import bustFrames from './ext/bust_frames';
 
 Ember.Route.reopen(RouteExtension);
 Ember.Router.reopen(RouterExtension);
@@ -21,5 +22,7 @@ App = Ember.Application.extend({
 loadInitializers(App, config.modulePrefix);
 
 monkeyPatchRaven();
+
+bustFrames();
 
 export default App;

--- a/app/ext/bust_frames.js
+++ b/app/ext/bust_frames.js
@@ -1,5 +1,6 @@
-import config from '../config/environment';
-
+//
+// Dashboard should not be allowed in frames on other sites
+//
 export default function bustFrames() {
   if (top.location !== location) {
     top.location.href = document.location.href;

--- a/app/ext/bust_frames.js
+++ b/app/ext/bust_frames.js
@@ -1,0 +1,7 @@
+import config from '../config/environment';
+
+export default function bustFrames() {
+  if (top.location !== location) {
+    top.location.href = document.location.href;
+  }
+}


### PR DESCRIPTION
Closes #542

Been working on a larger task, but saw a quick path here and decided to knock it out. `bustFrames` blocks pages from sourcing dashboard in a frame/iframe tag. I smoke tested this locally, but couldn’t think of a reasonable way to include a test in the repo without some shenanigans.

![](http://vignette3.wikia.nocookie.net/marvelcinematicuniverse/images/4/44/AoU_Hulkbuster_01.png/revision/latest?cb=20150309164235)
Bust some frames Tony!