### PR TITLE
Do not set service container count on scale

### DIFF
--- a/app/app/services/route.js
+++ b/app/app/services/route.js
@@ -21,16 +21,12 @@ export default Ember.Route.extend({
 
   actions: {
     scaleService: function(service, containerCount, deferred){
-      service.set('containerCount', containerCount);
-      service.save().then( () => {
-        let op = this.store.createRecord('operation', {
-          type: 'scale',
-          containerCount: containerCount,
-          service: service
-        });
-        return op.save();
-      }).then(deferred.resolve, deferred.reject);
+      let op = this.store.createRecord('operation', {
+        type: 'scale',
+        containerCount: containerCount,
+        service: service
+      });
+      op.save().then(deferred.resolve, deferred.reject);
     }
   }
-
 });

--- a/tests/acceptance/apps/services-test.js
+++ b/tests/acceptance/apps/services-test.js
@@ -99,7 +99,7 @@ test(`visit ${url} lists services`, function(assert) {
 });
 
 test(`visit ${url} allows scaling of services`, function(assert) {
-  assert.expect(5);
+  assert.expect(4);
 
   let serviceId = 1;
   let services = [{id: serviceId, container_count: 2}];
@@ -112,13 +112,6 @@ test(`visit ${url} allows scaling of services`, function(assert) {
   });
 
   stubStack({id: stackId});
-
-  stubRequest('put', `/services/${serviceId}`, function(request){
-    assert.ok(true, 'PUTs to services');
-    let json = this.json(request);
-    json.id = serviceId;
-    return this.success(json);
-  });
 
   stubRequest('post', `/services/${serviceId}/operations`, function(request){
     let json = this.json(request);


### PR DESCRIPTION
Found this while I was working through some mismatches between our old permissions model and our new permissions model (see: https://github.com/aptible/auth.aptible.com/pull/203) as reported by Scientist.

It looks like Dashboard currently sets the `container_count` property on a service when scaling it (before it creates the operation. However, I'm not sure that this is expected:

- according to @fancyremarker, users should not be allowed to touch *any* attributes of services
- it definitely looks like Sweetness expects the container count to be the original one when running a service scale operation: https://github.com/aptible/sweetness/blob/5012f50999a108f1ccec4865c45af93422ea3267/lib/sweetness/jobs/multi_instance_scale_service.rb#L7

Am I missing anything? If not, is this the right way to go about fixing this?

--

cc @fancyremarker @sandersonet @gib