### PR TITLE
Show timestamps in UTC, limit number of ticks

### DIFF
--- a/app/mixins/components/container-metrics.js
+++ b/app/mixins/components/container-metrics.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { formatUtcTimestamp } from 'diesel/helpers/format-utc-timestamp';
 
 export default Ember.Mixin.create({
   metricsApi: Ember.inject.service(),
@@ -47,7 +48,10 @@ export default Ember.Mixin.create({
       x: {
         type: 'timeseries',
         tick: {
-          format: '%H:%M:%S'
+          format: formatUtcTimestamp,
+          culling: {
+            max: 4
+          }
         }
       },
       y: {


### PR DESCRIPTION
This is a last minute tweak to show timestamps in UTC, which should result in superior readability of the timestamps being reported:

Before:

![image](https://cloud.githubusercontent.com/assets/1737686/14184926/e26bc6e4-f777-11e5-8c86-75a8d58b7021.png)

After:

![image](https://cloud.githubusercontent.com/assets/1737686/14185221/3ba3d548-f779-11e5-9a5b-282e9328b630.png)


This needs https://github.com/aptible/metrictunnel/pull/7 to work properly (otherwise c3.js is improperly interpreting the incoming timestamp as a localtime).

cc @sandersonet @gib 