### PR TITLE
Temporarily remove memory limits from graphs

### DIFF
--- a/app/components/container-memory-metrics/component.js
+++ b/app/components/container-memory-metrics/component.js
@@ -38,6 +38,6 @@ export default Ember.Component.extend(ContainerMetricsComponentMixin, {
   allMemoryLimits: Ember.computed.mapBy("containers", "memoryLimit"),
   applicableMemoryLimits: Ember.computed.filter("allMemoryLimits", (memoryLimit) => (!Ember.isEmpty(memoryLimit)) && memoryLimit > 0),
 
-  minMemoryLimit: Ember.computed.min("applicableMemoryLimits"),
+  minMemoryLimit: Infinity,
   noMemoryLimit: Ember.computed.equal("minMemoryLimit", Infinity)
 });

--- a/app/components/container-memory-metrics/template.hbs
+++ b/app/components/container-memory-metrics/template.hbs
@@ -2,7 +2,6 @@
 
 <p>
 {{#if noMemoryLimit}}
-  Note: this app has no memory limit.
 {{else}}
   {{input
   type="checkbox"

--- a/tests/acceptance/apps/service-metrics-test.js
+++ b/tests/acceptance/apps/service-metrics-test.js
@@ -178,35 +178,6 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
   });
 });
 
-test("it shows memory limit checkbox and memory limit line if limit exists", function (assert) {
-  stubRequest("get", `/releases/${releaseId}/containers`, function() {
-    let containers = makeContainers();
-    containers[2].memory_limit = 99999;
-    return this.success({_embedded: {containers: containers}});
-  });
-
-  stubRequest("get", "/proxy/:containers", function() {
-    return this.success(makeValidMetricData());
-  });
-
-  signInAndVisit(serviceMetricsUrl);
-
-  andThen(() => {
-    let checkbox = find("input[name$='show-memory-limit']");
-    checkbox.prop('checked', true);
-    checkbox.change();
-  });
-
-  andThen(() => {
-    // Check that we don't show the memory limit since none is set
-    assert.equal(find("input[name$='show-memory-limit']").length, 1, "Show memory limit button is not shown!");
-
-    let chart = findWithAssert("div.c3-chart-component");
-    assert.ok(chart.text().indexOf("Memory limit (99999 MB)") > -1, "Memory limit not shown!");
-    assert.ok(chart.text().indexOf("100000 MB") > -1, "Chart did not resize!");
-  });
-});
-
 test("it can change the horizon", function (assert) {
   let expectedHorizons = ["1d", "1d", "1h", "1h"];
 

--- a/tests/acceptance/databases/database-metrics-test.js
+++ b/tests/acceptance/databases/database-metrics-test.js
@@ -162,35 +162,6 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
   });
 });
 
-test("it shows memory limit checkbox and memory limit line if limit exists", function (assert) {
-  stubRequest("get", `/releases/${releaseId}/containers`, function() {
-    let containers = makeContainers();
-    containers[1].memory_limit = 99999;
-    return this.success({_embedded: {containers: containers}});
-  });
-
-  stubRequest("get", "/proxy/:containers", function() {
-    return this.success(makeValidMetricData());
-  });
-
-  signInAndVisit(databaseMetricsUrl);
-
-  andThen(() => {
-    let checkbox = find("input[name$='show-memory-limit']");
-    checkbox.prop('checked', true);
-    checkbox.change();
-  });
-
-  andThen(() => {
-    // Check that we don't show the memory limit since none is set
-    assert.equal(find("input[name$='show-memory-limit']").length, 1, "Show memory limit button is not shown!");
-
-    let chart = findWithAssert("div.c3-chart-component");
-    assert.ok(chart.text().indexOf("Memory limit (99999 MB)") > -1, "Memory limit not shown!");
-    assert.ok(chart.text().indexOf("100000 MB") > -1, "Chart did not resize!");
-  });
-});
-
 test("it can change the horizon", function (assert) {
   let expectedHorizons = ["1d", "1d", "1h", "1h"];
 


### PR DESCRIPTION
As discussed with @fancyremarker, most (all) of our app memory limit metadata is invalid, so showing it might be confusing / not helpful.

This commit is meant to be reverted once we have valid memory limit metadata across the board.