### PR TITLE
Add RSS vs + cache/buffers metrics

### DIFF
--- a/app/components/c3-chart/component.js
+++ b/app/components/c3-chart/component.js
@@ -70,12 +70,13 @@ export default Ember.Component.extend({
 
   dataDidChange: Ember.observer('data', function() {
     ensurePromise(this.get('data')).then((data) => {
-      if (Ember.isEmpty(data)) {
+      if (Ember.isEmpty(data) || Ember.keys(data).length === 0) {
         return;
       }
 
       let chart = this.get('_chart');
       if (chart) {
+        data.unload = true;
         chart.load(data);
       } else {
         this.get('_submitInitialData')(data);

--- a/app/components/container-memory-metrics/component.js
+++ b/app/components/container-memory-metrics/component.js
@@ -5,9 +5,9 @@ export default Ember.Component.extend(ContainerMetricsComponentMixin, {
   init() {
     this._super(...arguments);
     this.set("uiState.showMemoryLimit", false);
+    this.set("uiState.showCaches", false);
   },
 
-  metric: "memory",
   axisLabel: "Memory usage",
 
   axisFormatter: (v) => {
@@ -18,6 +18,14 @@ export default Ember.Component.extend(ContainerMetricsComponentMixin, {
   },
 
   axisBottomPadding: 0,  // Memory is always > 0, we don't need padding on top of it.
+
+  metric: Ember.computed("uiState.showCaches", function() {
+    if (this.get("uiState.showCaches")) {
+      return "memory_all";
+    } else {
+      return "memory";
+    }
+  }),
 
   gridLines: Ember.computed("minMemoryLimit" , function () {
     let minMemoryLimit = this.get("minMemoryLimit"),

--- a/app/components/container-memory-metrics/component.js
+++ b/app/components/container-memory-metrics/component.js
@@ -9,7 +9,14 @@ export default Ember.Component.extend(ContainerMetricsComponentMixin, {
 
   metric: "memory",
   axisLabel: "Memory usage",
-  axisFormatter: (v) => `${v} MB`,
+
+  axisFormatter: (v) => {
+    if (v > 1000) {
+      return `${v / 1000} GB`;
+    }
+    return `${v} MB`;
+  },
+
   axisBottomPadding: 0,  // Memory is always > 0, we don't need padding on top of it.
 
   gridLines: Ember.computed("minMemoryLimit" , function () {

--- a/app/components/container-memory-metrics/template.hbs
+++ b/app/components/container-memory-metrics/template.hbs
@@ -1,6 +1,18 @@
 {{partial 'mixins/container-metrics'}}
 
 <p>
+  {{input
+  type="checkbox"
+    name=(concat elementId '-show-caches')
+    id=(concat elementId '-show-caches')
+    checked=uiState.showCaches}}
+
+  <label for="{{concat elementId '-show-caches'}}">
+    Compare RSS and RSS + buffers / caches
+  </label>
+</p>
+
+<p>
 {{#if noMemoryLimit}}
 {{else}}
   {{input

--- a/app/templates/service/-metrics.hbs
+++ b/app/templates/service/-metrics.hbs
@@ -20,8 +20,13 @@
             title="Understanding Memory Usage"
             body="This metric represents the amount of memory your container has requested from the host system.
                   <br><br>
+                  If your container approaches its memory limit, the host system will attempt to reclaim some memory
+                  from your container, or terminate it if that's not possible. Memory used for caches and buffers can
+                  usually be reclaimed, whereas anonymous memory and memory-mapped files (RSS) usually cannot. Use
+                  the toggle below the chart to compare those metrics.
+                  <br><br>
                   If this number approaches the memory limit, you should upgrade to a bigger container or reduce the memory
-                  footprint of your app: apps that exceed their memory limit may be terminated."}}
+                  footprint of your container."}}
         </h4>
         {{container-memory-metrics
           containers=targetContainers
@@ -35,7 +40,7 @@
             body="This metric represents the number of runnable tasks (threads) in your container.
                   <br><br>
                   If this number is consistently high, and appears to be hitting a ceiling,
-                  you should upgrade to a bigger container or investigate your app for performance
+                  you should upgrade to a bigger container or investigate your container for performance
                   bottlenecks."}}
         </h4>
         {{container-la-metrics

--- a/tests/acceptance/apps/service-metrics-test.js
+++ b/tests/acceptance/apps/service-metrics-test.js
@@ -174,7 +174,7 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
     assert.equal(laMetricResponses.length, 0, "Not enough requests!");
     let chart = findWithAssert("div.c3-chart-component");
     // Expect the chart to resize to show the new data point
-    assert.ok(chart.text().indexOf("100000 MB") > -1, "Memory not shown!");
+    assert.ok(chart.text().indexOf("10 GB") > -1, "Memory not shown!");
   });
 });
 

--- a/tests/acceptance/apps/service-metrics-test.js
+++ b/tests/acceptance/apps/service-metrics-test.js
@@ -170,6 +170,10 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
   });
 
   andThen(() => {
+    Ember.run.later(() => {}, 500);
+  });
+
+  andThen(() => {
     assert.equal(memoryMetricResponses.length, 0, "Not enough requests!");
     assert.equal(laMetricResponses.length, 0, "Not enough requests!");
     let chart = findWithAssert("div.c3-chart-component");
@@ -196,6 +200,44 @@ test("it can change the horizon", function (assert) {
   });
 
   andThen(() => {
+    Ember.run.later(() => {}, 500);
+  });
+
+  andThen(() => {
     assert.equal(expectedHorizons.length, 0, "Not enough requests!");
+  });
+});
+
+test("it includes a functional toggle for memory metrics (cache / buffers)", function(assert) {
+  let metricsRequested = [];
+
+  stubRequest("get", `/releases/${releaseId}/containers`, function() {
+    return this.success({_embedded: {containers: makeContainers()}});
+  });
+
+  stubRequest("get", "/proxy/:containers", function(request) {
+    metricsRequested.push(request.queryParams.metric);
+    var data = makeValidMetricData();
+    data.columns[1][0] = request.queryParams.metric;
+    return this.success(data);
+  });
+
+  signInAndVisit(serviceMetricsUrl);
+
+  andThen(() => {
+    let checkbox = find("input[name$='show-caches']");
+    checkbox.prop('checked', true);
+    checkbox.change();
+  });
+
+  andThen(() => {
+    Ember.run.later(() => {}, 500);
+  });
+
+  andThen(() => {
+    assert.equal(metricsRequested.length, 3);
+    assert.ok(metricsRequested[0] === 'memory' || metricsRequested[1] === 'memory');
+    assert.ok(metricsRequested[0] === 'la' || metricsRequested[1] === 'la');
+    assert.ok(metricsRequested[2] === 'memory_all');
   });
 });

--- a/tests/acceptance/apps/service-metrics-test.js
+++ b/tests/acceptance/apps/service-metrics-test.js
@@ -200,10 +200,6 @@ test("it can change the horizon", function (assert) {
   });
 
   andThen(() => {
-    Ember.run.later(() => {}, 500);
-  });
-
-  andThen(() => {
     assert.equal(expectedHorizons.length, 0, "Not enough requests!");
   });
 });
@@ -228,10 +224,6 @@ test("it includes a functional toggle for memory metrics (cache / buffers)", fun
     let checkbox = find("input[name$='show-caches']");
     checkbox.prop('checked', true);
     checkbox.change();
-  });
-
-  andThen(() => {
-    Ember.run.later(() => {}, 500);
   });
 
   andThen(() => {

--- a/tests/acceptance/databases/database-metrics-test.js
+++ b/tests/acceptance/databases/database-metrics-test.js
@@ -158,7 +158,7 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
     assert.equal(laMetricResponses.length, 0, "Not enough requests!");
     let chart = findWithAssert("div.c3-chart-component");
     // Expect the chart to resize to show the new data point
-    assert.ok(chart.text().indexOf("100000 MB") > -1, "Memory not shown!");
+    assert.ok(chart.text().indexOf("10 GB") > -1, "Memory not shown!");
   });
 });
 

--- a/tests/acceptance/databases/database-metrics-test.js
+++ b/tests/acceptance/databases/database-metrics-test.js
@@ -154,6 +154,10 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
   });
 
   andThen(() => {
+    Ember.run.later(() => {}, 500);
+  });
+
+  andThen(() => {
     assert.equal(memoryMetricResponses.length, 0, "Not enough requests!");
     assert.equal(laMetricResponses.length, 0, "Not enough requests!");
     let chart = findWithAssert("div.c3-chart-component");
@@ -177,6 +181,10 @@ test("it can change the horizon", function (assert) {
   signInAndVisit(databaseMetricsUrl);
   andThen(() => {
     clickButton("1 day");
+  });
+
+  andThen(() => {
+    Ember.run.later(() => {}, 500);
   });
 
   andThen(() => {

--- a/tests/acceptance/databases/database-metrics-test.js
+++ b/tests/acceptance/databases/database-metrics-test.js
@@ -184,10 +184,6 @@ test("it can change the horizon", function (assert) {
   });
 
   andThen(() => {
-    Ember.run.later(() => {}, 500);
-  });
-
-  andThen(() => {
     assert.equal(expectedHorizons.length, 0, "Not enough requests!");
   });
 });

--- a/tests/unit/components/c3-chart-test.js
+++ b/tests/unit/components/c3-chart-test.js
@@ -152,3 +152,20 @@ test('it accepts grid line updates', function(assert) {
     assert.ok(this.$().text().indexOf('someLineOnChart') > -1);
   });
 });
+
+test('it unloads old data when when updated', function(assert) {
+  this.subject({
+    data: {columns: [["someDataOnChart", 1, 2, 3]]},
+    axis: {},
+    grid: {}
+  });
+  assert.ok(this.$().text().indexOf('someDataOnChart') > -1, "newData is absent!");
+
+  Ember.run(() => {
+    this.subject().set('data', { columns: [] });
+  });
+
+  andThen(() => {
+    assert.ok(this.$().text().indexOf('someDataOnChart') === -1, "someData is still present!");
+  });
+});


### PR DESCRIPTION
This updates the container memory graph to show RSS (which is memory that usually cannot be reclaimed and *will* result in the container being terminated if it exceeds its allocation) by default instead of RSS + caches / buffers:

![image](https://cloud.githubusercontent.com/assets/1737686/14211019/13b326de-f82c-11e5-8163-aafea04772a6.png)

This also adds a toggle to let the user visualize RSS vs. RSS + caches / buffers:

![image](https://cloud.githubusercontent.com/assets/1737686/14210972/d3d5aa78-f82b-11e5-8a19-776dc9d66f3f.png)

This can get a little crowded with a lot of containers:

![image](https://cloud.githubusercontent.com/assets/1737686/14210977/e0420ebe-f82b-11e5-8d7a-397d4329eaae.png)

But it's of course possible to hide some containers to drill down:

![image](https://cloud.githubusercontent.com/assets/1737686/14210989/eebf0276-f82b-11e5-8b98-cb147b18a137.png)

I also updated the guidance to give a few explanations about those metrics:

![image](https://cloud.githubusercontent.com/assets/1737686/14211013/0695e266-f82c-11e5-84fa-e4945ed8da2c.png)


(This is dependent on deploying https://github.com/aptible/metrictunnel/pull/8 to expose the `memory_rss` and `memory_all` metrics).


cc @fancyremarker: let me know if this is what you had in mind when we discussed yesterday.
cc @sandersonet the last commit has a message that explains the issue I was running into (and why I'm trying to mock the `{{c3-chart}}` component). Looks like the CI tests might fail with  the same reason too.