### PR TITLE
Use correct calculation for MB -> GB

### DIFF
--- a/app/components/container-memory-metrics/component.js
+++ b/app/components/container-memory-metrics/component.js
@@ -11,8 +11,9 @@ export default Ember.Component.extend(ContainerMetricsComponentMixin, {
   axisLabel: "Memory usage",
 
   axisFormatter: (v) => {
-    if (v > 1000) {
-      return `${v / 1000} GB`;
+    if (v > 10240) {
+      // Show GBs above 10GB of usage.
+      return `${v / 1024} GB`;
     }
     return `${v} MB`;
   },

--- a/tests/acceptance/apps/service-metrics-test.js
+++ b/tests/acceptance/apps/service-metrics-test.js
@@ -178,7 +178,7 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
     assert.equal(laMetricResponses.length, 0, "Not enough requests!");
     let chart = findWithAssert("div.c3-chart-component");
     // Expect the chart to resize to show the new data point
-    assert.ok(chart.text().indexOf("10 GB") > -1, "Memory not shown!");
+    assert.ok(chart.text().indexOf("10000 MB") > -1, "Memory not shown!");
   });
 });
 

--- a/tests/acceptance/databases/database-metrics-test.js
+++ b/tests/acceptance/databases/database-metrics-test.js
@@ -162,7 +162,7 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
     assert.equal(laMetricResponses.length, 0, "Not enough requests!");
     let chart = findWithAssert("div.c3-chart-component");
     // Expect the chart to resize to show the new data point
-    assert.ok(chart.text().indexOf("10 GB") > -1, "Memory not shown!");
+    assert.ok(chart.text().indexOf("10000 MB") > -1, "Memory not shown!");
   });
 });
 


### PR DESCRIPTION
Same as https://github.com/aptible/metrictunnel/pull/10, not sure what I was thinking with my 1 GB = 1000 MB "conversion".

This also update the graph to show MBs all the way to 10GB. Otherwise,
the graph uses weird units (e.g. `2.9296875 GB`), which aren't very
eye-pleasing, and arguably not that useful anyway so long as you only
have 4 digits.