### PR TITLE
Add disk metrics

### DIFF
--- a/app/components/container-disk-metrics/component.js
+++ b/app/components/container-disk-metrics/component.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import ContainerMetricsComponentMixin from "diesel/mixins/components/container-metrics";
+
+export default Ember.Component.extend(ContainerMetricsComponentMixin, {
+  metric: "fs",
+  axisLabel: "Disk usage",
+  axisFormatter: (v) => `${v} GB`,
+  axisBottomPadding: 0  // Disk usage is always > 0, no need for extra padding
+});

--- a/app/components/container-disk-metrics/template.hbs
+++ b/app/components/container-disk-metrics/template.hbs
@@ -1,0 +1,1 @@
+{{partial 'mixins/container-metrics'}}

--- a/app/database/metrics/controller.js
+++ b/app/database/metrics/controller.js
@@ -2,5 +2,6 @@ import Ember from 'ember';
 import ServiceMetricsControllerMixin from 'diesel/mixins/controllers/service-metrics';
 
 export default Ember.Controller.extend(ServiceMetricsControllerMixin, {
-  getTargetLayer: () => "database"
+  getTargetLayer: () => "database",
+  showDiskMetrics: true
 });

--- a/app/mixins/controllers/service-metrics.js
+++ b/app/mixins/controllers/service-metrics.js
@@ -23,4 +23,7 @@ export default Ember.Mixin.create({
   setHorizon: function(horizon) {
     this.set("model.uiState.dataHorizon", horizon);
   },
+
+  /* Defaults */
+  showDiskMetrics: false
 });

--- a/app/templates/service/-metrics.hbs
+++ b/app/templates/service/-metrics.hbs
@@ -48,6 +48,24 @@
           containers=targetContainers
           horizon=model.uiState.dataHorizon
           lastReload=model.uiState.lastReload}}
+
+        {{#if showDiskMetrics}}
+          <h4>
+            Disk Usage
+            {{more-info-icon
+              title="Understanding Disk Usage"
+              body="This metric represents the amount of disk space your database is using vs. the available
+                    space. Available space will usually be a little lower than the space you provisioned: a
+                    small amount of disk space is reserved for usage by the filesystem itself.
+                    <br><br>
+                    If you anticipate that your database will run out of space, please contact Aptible
+                    support to have the volume resized."}}
+          </h4>
+          {{container-disk-metrics
+          containers=targetContainers
+          horizon=model.uiState.dataHorizon
+          lastReload=model.uiState.lastReload}}
+        {{/if}}
       </div>
     </div>
   </div>

--- a/tests/acceptance/databases/database-metrics-test.js
+++ b/tests/acceptance/databases/database-metrics-test.js
@@ -131,9 +131,10 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
     return this.success({_embedded: {containers: makeContainers()}});
   });
 
-  let laMetricResponses = [makeValidMetricData(), makeValidMetricData()];
   let memoryMetricResponses = [makeValidMetricData(), makeValidMetricData()];
   memoryMetricResponses[0].columns[1].push(99999);
+  let laMetricResponses = [makeValidMetricData(), makeValidMetricData()];
+  let fsMetricResponses = [makeValidMetricData(), makeValidMetricData()];
 
   stubRequest("get", "/proxy/:containers", function(request) {
     if (request.queryParams.metric === "memory") {
@@ -142,6 +143,10 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
 
     if (request.queryParams.metric === "la") {
       return this.success(laMetricResponses.pop());
+    }
+
+    if (request.queryParams.metric === "fs") {
+      return this.success(fsMetricResponses.pop());
     }
 
     assert.ok(false, `Received invalid metric: ${request.queryParams.metric}`);
@@ -160,6 +165,7 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
   andThen(() => {
     assert.equal(memoryMetricResponses.length, 0, "Not enough requests!");
     assert.equal(laMetricResponses.length, 0, "Not enough requests!");
+    assert.equal(fsMetricResponses.length, 0, "Not enough requests!");
     let chart = findWithAssert("div.c3-chart-component");
     // Expect the chart to resize to show the new data point
     assert.ok(chart.text().indexOf("10000 MB") > -1, "Memory not shown!");
@@ -167,7 +173,8 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
 });
 
 test("it can change the horizon", function (assert) {
-  let expectedHorizons = ["1d", "1d", "1h", "1h"];
+  // Expected requests (right to left)
+  let expectedHorizons = ["1d", "1d", "1d", "1h", "1h", "1h"];
 
   stubRequest("get", `/releases/${releaseId}/containers`, function() {
     return this.success({_embedded: {containers: makeContainers()}});


### PR DESCRIPTION
This adds support for disk metrics. The metrics are included for DBs at the bottom of the metrics tab, and look like this:

![image](https://cloud.githubusercontent.com/assets/1737686/14436159/ab41a9de-001b-11e6-8d30-fe86044a8022.png)

A few notes here:

- First: this isn't ready for merging yet (I need to make the PRs in https://github.com/aptible/metrictunnel and https://github.com/aptible/cadvisor-factory)
- Second: the numbers reported aren't *exactly* the same as the numbers requested (i.e. someone asks for a 10GB volume, this reports 9.7GB). AFAICT, the numbers reported here are actually correct — the space that's "missing" being space that's used for accounting by the filesystem (and perhaps a little space reserved for root as well). 

cc @fancyremarker @gib @sandersonet 