### PR TITLE
More verbose notice when missing metrics

### DIFF
--- a/app/services/metrics-api.js
+++ b/app/services/metrics-api.js
@@ -9,7 +9,7 @@ function errorToMessage(e) {
     case 400:
       return "Metrics server declined to serve the request";
     case 404:
-      return "No data available; please try again later or contact support if this condition persists";
+      return "No data available. If you just launched your containers, please try again later. Otherwise, please contact support (metrics are not available on some Aptible legacy stacks)";
     case 500:
       return "Metrics server is unavailable; please try again later";
     default:


### PR DESCRIPTION
Following up on our discussion in Slack earlier today; do we want this, @fancyremarker @blakepettersson ?