### PR TITLE
Fix domain type label for new default vhosts

### DIFF
--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -27,7 +27,7 @@
                   <div>
                     {{#radio-button value=true groupValue=model.isDefault name="domain-type"}}
                       {{#bs-tooltip placement="bottom" title='A default domain is simply a domain in the format app-${id}.on-aptible.com.' bs-container=false}}
-                          Use app-{{ model.app.id }}.aptible.in default domain name
+                          Use app-{{ model.app.id }}.on-aptible.com default domain name
                       {{/bs-tooltip}}
                     {{/radio-button}}
                   </div>


### PR DESCRIPTION
The form' domain type label still had the old `aptible.in` domain. Updated:

<img width="661" alt="screen shot 2016-04-14 at 11 32 34 pm" src="https://cloud.githubusercontent.com/assets/94830/14552219/3fc32946-0299-11e6-9646-444479fcc383.png">


