### PR TITLE
Disable memory slider on v1 stacks

### DIFF
--- a/app/components/service-scaler/component.js
+++ b/app/components/service-scaler/component.js
@@ -8,14 +8,12 @@ export default Ember.Component.extend({
 
   isSliding: false,
 
-  shouldDisable: Ember.computed('isV1Stack', 'isSaving', function() {
-    return this.get('isV1Stack') || this.get('isSaving');
+  shouldDisable: Ember.computed('isv1Stack', 'isSaving', function() {
+    return this.get('isv1Stack') || this.get('isSaving');
   }),
 
-  isv1Stack: function() {
-    let sweetnessVersion = this.get('service.stack.sweetnessStackVersion');
-    return !(sweetnessVersion && sweetnessVersion === "v2");
-  }.property('service.stack.sweetnessStackVersion'),
+  isv2Stack: Ember.computed.equal('service.stack.sweetnessStackVersion', 'v2'),
+  isv1Stack: Ember.computed.not('isv2Stack'),
 
   showActionButtons: function(){
     if (this.get('isSliding')) { return false; }

--- a/tests/unit/components/service-scaler-test.js
+++ b/tests/unit/components/service-scaler-test.js
@@ -39,3 +39,53 @@ test('it renders', function(assert) {
   this.render();
   assert.equal(component._state, 'inDOM');
 });
+
+test('it should set shouldDisable to true for v1 stacks', function(assert) {
+  assert.expect(1);
+
+  // creates the component instance
+  var component = this.subject({
+    service: Ember.Object.create({
+      containerSize: 1024,
+      containerCount: 1,
+      stack: Ember.Object.create({})
+    })
+  });
+
+  assert.equal(true, component.get('shouldDisable'));
+});
+
+test('it should set shouldDisable to false for v2 stacks', function(assert) {
+  assert.expect(1);
+
+  // creates the component instance
+  var component = this.subject({
+    service: Ember.Object.create({
+      containerSize: 1024,
+      containerCount: 1,
+      stack: Ember.Object.create({
+        sweetnessStackVersion: 'v2'
+      })
+    })
+  });
+
+  assert.equal(false, component.get('shouldDisable'));
+});
+
+test('it should set shouldDisable to true when component is saving', function(assert) {
+  assert.expect(1);
+
+  // creates the component instance
+  var component = this.subject({
+    isSaving: true,
+    service: Ember.Object.create({
+      containerSize: 1024,
+      containerCount: 1,
+      stack: Ember.Object.create({
+        sweetnessStackVersion: 'v2'
+      })
+    })
+  });
+
+  assert.equal(true, component.get('shouldDisable'));
+});


### PR DESCRIPTION
Fix typo where memory slider will always be enabled on a v1 stack.

cc @fancyremarker @sandersonet 