### PR TITLE
Adjust RAM slider range to 512-8192 MB

### DIFF
--- a/app/components/service-scaler/template.hbs
+++ b/app/components/service-scaler/template.hbs
@@ -61,13 +61,13 @@
           {{no-ui-slider didSlide="setContainerSize"
                          didSet="finishSliding"
                          start=containerSize
-                         rangeMin=256
+                         rangeMin=512
                          rangeMax=8192
                          snap=true
                          disabled=shouldDisable
-                         range="256,512,1024,2048,4096"}}
+                         range="512,1024,2048,4096"}}
           <div class="label-wrapper">
-            <div class="label pull-left">256</div>
+            <div class="label pull-left">512</div>
             <div class="label pull-right">8192</div>
           </div>
         </div>


### PR DESCRIPTION
Opening this PR to increase the minimum RAM size from 256 MB to 512 MB, per [a Slack discussion](https://aptible.slack.com/archives/ops/p1461096869000006).
