### PR TITLE
Add container size in billing overview

### DIFF
--- a/app/components/disk-resource-usage/component.js
+++ b/app/components/disk-resource-usage/component.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export const HOURS_PER_MONTH = 730;
+
+export default Ember.Component.extend({
+  tagName: 'tr',
+
+  hasDisk: Ember.computed.notEmpty('database.disk'),
+
+  total: Ember.computed('database.disk.size', 'hourlyRate', function () {
+    return this.get('database.disk.size') * this.get('hourlyRate') * HOURS_PER_MONTH;
+  })
+});

--- a/app/components/disk-resource-usage/template.hbs
+++ b/app/components/disk-resource-usage/template.hbs
@@ -1,0 +1,4 @@
+{{#if hasDisk}}
+  <td>{{handle}}:{{service.processType}}</td>
+  <td>{{database.disk.size}}GB</td><td>{{format-currency total}}</td>
+{{/if}}

--- a/app/components/service-resource-usage/component.js
+++ b/app/components/service-resource-usage/component.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export const HOURS_PER_MONTH = 730;
+
+export default Ember.Component.extend({
+  tagName: 'tr',
+
+  hasContainers: Ember.computed.gt('release.containers.length', 0),
+
+  total: Ember.computed('service.usage', 'hourlyRate', function () {
+    return this.get('service.usage') * this.get('hourlyRate') * HOURS_PER_MONTH;
+  })
+});

--- a/app/components/service-resource-usage/template.hbs
+++ b/app/components/service-resource-usage/template.hbs
@@ -1,0 +1,4 @@
+{{#if hasContainers}}
+  <td>{{handle}}:{{service.processType}}</td>
+  <td>{{service.containerCount}}x{{service.containerSize}}MB</td><td>{{format-currency total}}</td>
+{{/if}}

--- a/app/components/stack-resource-usage/component.js
+++ b/app/components/stack-resource-usage/component.js
@@ -2,8 +2,10 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'li',
-  usage: Ember.computed('stack', 'resource', function() {
-    let stack = this.get('stack');
-    return stack.getUsageByResourceType(this.get('resource'));
+
+  resources: Ember.computed('stack', 'resource', function() {
+    let firstLevel = { container: 'apps', disk: 'databases',
+      domain: 'apps' }[this.get('resource')];
+    return this.get('stack').get(firstLevel);
   })
 });

--- a/app/components/stack-resource-usage/template.hbs
+++ b/app/components/stack-resource-usage/template.hbs
@@ -2,6 +2,33 @@
   {{stack.handle}}
 </div>
 
-<div class="usage-value stack-usage-value">
-  {{usage}}
-</div>
+<table class="usage-value stack-usage-value">
+  {{#if (eq resource 'container')}}
+    <tr><th>App containers</th></tr>
+    {{#each resources as |app|}}
+
+      {{#each app.services as |service|}}
+        {{ service-resource-usage handle=app.handle service=service release=service.currentRelease hourlyRate=hourlyRate }}
+      {{/each}}
+    {{/each}}
+
+    <tr><th>Database containers</th></tr>
+    {{#each stack.databases as |database|}}
+      {{ service-resource-usage handle=database.handle service=database.service release=database.service.currentRelease hourlyRate=hourlyRate }}
+    {{/each}}
+  {{/if}}
+
+  {{#if (eq resource 'disk')}}
+    {{#each resources as |database|}}
+      {{ disk-resource-usage handle=database.handle service=database.service database=database hourlyRate=hourlyRate }}
+    {{/each}}
+  {{/if}}
+
+  {{#if (eq resource 'domain')}}
+    {{#each resources as |app|}}
+      {{#each app.vhosts as |vhost|}}
+        {{ vhost-resource-usage vhost=vhost handle=vhost.displayHost hourlyRate=hourlyRate }}
+      {{/each}}
+    {{/each}}
+  {{/if}}
+</table>

--- a/app/components/usage-quote-by-resource/component.js
+++ b/app/components/usage-quote-by-resource/component.js
@@ -7,7 +7,14 @@ export default Ember.Component.extend({
     return this.get('resource').capitalize().pluralize();
   }),
 
-  grossUsage: Ember.computed('stacks.[]', function() {
+  containerUsage: Ember.computed.mapBy('stacks', 'containerUsage'),
+  totalContainerUsage: Ember.computed.sum('containerUsage'),
+
+  grossUsage: Ember.computed('resource', 'totalContainerUsage', function() {
+    if(this.get('resource') === 'container') {
+      return this.get('totalContainerUsage');
+    }
+
     let total = 0;
     this.get('stacks').forEach((stack) => {
       total += stack.getUsageByResourceType(this.get('resource'));
@@ -24,11 +31,11 @@ export default Ember.Component.extend({
     }
   }),
 
-  netUsage: Ember.computed('grossUsage', 'allowance', function() {
+  netUsage: Ember.computed('grossUsage', 'allowance', 'resource', function() {
     return Math.max(this.get('grossUsage') - this.get('allowance'), 0);
   }),
 
-  totalUsageCost: Ember.computed('netUsage', 'hourlyRate', function() {
+  totalUsageCost: Ember.computed('resource', 'netUsage', 'hourlyRate', function() {
     return this.get('netUsage') * this.get('hourlyRate') * HOURS_PER_MONTH;
   })
 });

--- a/app/components/usage-quote-by-resource/template.hbs
+++ b/app/components/usage-quote-by-resource/template.hbs
@@ -16,7 +16,7 @@
 
   <ul class="usage-quote-items">
     {{#each stacks as |stack|}}
-      {{stack-resource-usage stack=stack resource=resource classNames="usage-quote-item"}}
+      {{stack-resource-usage stack=stack resource=resource classNames="usage-quote-item" hourlyRate=hourlyRate}}
     {{/each}}
 
     {{#if allowance}}

--- a/app/components/vhost-resource-usage/component.js
+++ b/app/components/vhost-resource-usage/component.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export const HOURS_PER_MONTH = 730;
+
+export default Ember.Component.extend({
+  tagName: 'tr',
+
+  hasRelease: Ember.computed.notEmpty('vhost.service.currentRelease'),
+
+  hasContainers: Ember.computed.notEmpty('vhost.service.currentRelease.containers'),
+
+  hasReleaseAndContainers: Ember.computed.and('hasRelease', 'hasContainers'),
+
+  total: Ember.computed('hourlyRate', function () {
+    return this.get('hourlyRate') * HOURS_PER_MONTH;
+  })
+});

--- a/app/components/vhost-resource-usage/template.hbs
+++ b/app/components/vhost-resource-usage/template.hbs
@@ -1,0 +1,4 @@
+{{#if hasReleaseAndContainers}}
+  <td>{{handle}}</td>
+  <td></td><td>{{format-currency total}}</td>
+{{/if}}

--- a/app/styles/components/usage-quote-by-resource.scss
+++ b/app/styles/components/usage-quote-by-resource.scss
@@ -42,6 +42,20 @@
         color: $color-light;
       }
 
+      table.usage-value {
+        float: left;
+        clear: left;
+        width: 100%;
+      }
+
+      table.usage-value tr td:first-child {
+        text-align: left;
+      }
+
+      table.usage-value tr td:last-child {
+        width: 80px;
+      }
+
       &.total-item {
         .usage-label, .usage-value {
           font-weight: $weight-semibold;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "0.0.73",
+    "ember-cli-aptible-shared": "0.0.77",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/tests/integration/components/usage-quote-by-resource-test.js
+++ b/tests/integration/components/usage-quote-by-resource-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -6,7 +7,7 @@ moduleForComponent('usage-quote-by-resource', {
 });
 
 test('basic attributes are set', function(assert) {
-  let stack = { handle: 'stack1', getUsageByResourceType: function() { return 10; } };
+  let stack = Ember.Object.create({ handle: 'stack1', apps: [], containerUsage: 10 });
   this.set('stacks', [stack]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
 
@@ -20,8 +21,8 @@ test('basic attributes are set', function(assert) {
 });
 
 test('container usage less than allowance results in 0 billing', function(assert) {
-  let stack1 = { handle: 'stack1', getUsageByResourceType: function() { return 2; } };
-  let stack2 = { handle: 'stack2', getUsageByResourceType: function() { return 3; } };
+  let stack1 = Ember.Object.create({ handle: 'stack1', apps: [], containerUsage: 2 });
+  let stack2 = Ember.Object.create({ handle: 'stack2', apps: [], containerUsage: 3 });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
 
@@ -37,8 +38,8 @@ test('container usage less than allowance results in 0 billing', function(assert
 });
 
 test('container usage equal to allowance results in 0 billing', function(assert) {
-  let stack1 = { handle: 'stack1', getUsageByResourceType: function() { return 3; } };
-  let stack2 = { handle: 'stack2', getUsageByResourceType: function() { return 3; } };
+  let stack1 = Ember.Object.create({ handle: 'stack1', apps: [], containerUsage: 3 });
+  let stack2 = Ember.Object.create({ handle: 'stack2', apps: [], containerUsage: 3 });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
 
@@ -52,8 +53,8 @@ test('container usage equal to allowance results in 0 billing', function(assert)
 });
 
 test('container usage exceeding allowance results in overage billing', function(assert) {
-  let stack1 = { handle: 'stack1', getUsageByResourceType: function() { return 8; } };
-  let stack2 = { handle: 'stack2', getUsageByResourceType: function() { return 9; } };
+  let stack1 = Ember.Object.create({ handle: 'stack1', apps: [], containerUsage: 8 });
+  let stack2 = Ember.Object.create({ handle: 'stack2', apps: [], containerUsage: 9 });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
 
@@ -67,8 +68,8 @@ test('container usage exceeding allowance results in overage billing', function(
 });
 
 test('disk usage less than allowance results in 0 billing', function(assert) {
-  let stack1 = { handle: 'stack1', getUsageByResourceType: function() { return 200; } };
-  let stack2 = { handle: 'stack2', getUsageByResourceType: function() { return 300; } };
+  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], getUsageByResourceType: function() { return 200; } });
+  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], getUsageByResourceType: function() { return 300; } });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=1000 hourlyRate=0.0507 plan="platform" resource="disk"}}'));
 
@@ -84,8 +85,8 @@ test('disk usage less than allowance results in 0 billing', function(assert) {
 });
 
 test('disk usage equal to allowance results in 0 billing', function(assert) {
-  let stack1 = { handle: 'stack1', getUsageByResourceType: function() { return 200; } };
-  let stack2 = { handle: 'stack2', getUsageByResourceType: function() { return 800; } };
+  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], getUsageByResourceType: function() { return 200; } });
+  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], getUsageByResourceType: function() { return 800; } });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=1000 hourlyRate=0.0507 plan="platform" resource="disk"}}'));
 
@@ -99,8 +100,8 @@ test('disk usage equal to allowance results in 0 billing', function(assert) {
 });
 
 test('disk usage exceeding allowance results in overage billing', function(assert) {
-  let stack1 = { handle: 'stack1', getUsageByResourceType: function() { return 800; } };
-  let stack2 = { handle: 'stack2', getUsageByResourceType: function() { return 900; } };
+  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], getUsageByResourceType: function() { return 800; } });
+  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], getUsageByResourceType: function() { return 900; } });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=1000 hourlyRate=0.0507 plan="platform" resource="disk"}}'));
 


### PR DESCRIPTION
This is still a bit rough around the edges, and the tests needs to be updated but I would like some feedback on the ongoing work to add custom container sizes in the billing overview. The current result can be seen below, and this itemises all entries with the price so that it's more clear for a customer.

cc @gib @fancyremarker @sandersonet 

<img width="1033" alt="screen shot 2016-05-03 at 17 57 37" src="https://cloud.githubusercontent.com/assets/1227954/14989579/cc1ddec2-1158-11e6-9546-4ca36327950e.png">
