### PR TITLE
Restore intercom div

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -23,5 +23,7 @@
     <script src="assets/diesel.js"></script>
 
     {{content-for 'body-footer'}}
+
+    <div id="IntercomDefaultWidget"></div>
   </body>
 </html>


### PR DESCRIPTION
Restores the intercom widget div so that it can be turned on via segment.

I had removed this as part of our support updates. It was premature. https://github.com/aptible/dashboard.aptible.com/pull/521