### PR TITLE
UI tweaks to #580

### DIFF
--- a/app/components/disk-resource-usage/component.js
+++ b/app/components/disk-resource-usage/component.js
@@ -5,7 +5,7 @@ export const HOURS_PER_MONTH = 730;
 export default Ember.Component.extend({
   tagName: 'tr',
 
-  hasDisk: Ember.computed.notEmpty('database.disk'),
+  hasDisk: Ember.computed.notEmpty('database.disk.size'),
 
   total: Ember.computed('database.disk.size', 'hourlyRate', function () {
     return this.get('database.disk.size') * this.get('hourlyRate') * HOURS_PER_MONTH;

--- a/app/components/stack-resource-usage/component.js
+++ b/app/components/stack-resource-usage/component.js
@@ -2,10 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   tagName: 'li',
-
-  resources: Ember.computed('stack', 'resource', function() {
-    let firstLevel = { container: 'apps', disk: 'databases',
-      domain: 'apps' }[this.get('resource')];
-    return this.get('stack').get(firstLevel);
-  })
+  isDisk: Ember.computed.equal('resource', 'disk'),
+  isDomain: Ember.computed.equal('resource', 'domain'),
+  isContainer: Ember.computed.equal('resource', 'container')
 });

--- a/app/components/stack-resource-usage/template.hbs
+++ b/app/components/stack-resource-usage/template.hbs
@@ -3,10 +3,9 @@
 </div>
 
 <table class="usage-value stack-usage-value">
-  {{#if (eq resource 'container')}}
+  {{#if isContainer}}
     <tr><th>App containers</th></tr>
-    {{#each resources as |app|}}
-
+    {{#each stack.apps as |app|}}
       {{#each app.services as |service|}}
         {{ service-resource-usage handle=app.handle service=service release=service.currentRelease hourlyRate=hourlyRate }}
       {{/each}}
@@ -18,16 +17,16 @@
     {{/each}}
   {{/if}}
 
-  {{#if (eq resource 'disk')}}
-    {{#each resources as |database|}}
+  {{#if isDisk}}
+    {{#each stack.databases as |database|}}
       {{ disk-resource-usage handle=database.handle service=database.service database=database hourlyRate=hourlyRate }}
     {{/each}}
   {{/if}}
 
-  {{#if (eq resource 'domain')}}
-    {{#each resources as |app|}}
+  {{#if isDomain}}
+    {{#each stack.apps as |app|}}
       {{#each app.vhosts as |vhost|}}
-        {{ vhost-resource-usage vhost=vhost handle=vhost.displayHost hourlyRate=hourlyRate }}
+        {{ vhost-resource-usage status=vhost.status handle=vhost.displayHost hourlyRate=hourlyRate }}
       {{/each}}
     {{/each}}
   {{/if}}

--- a/app/components/usage-quote-by-resource/component.js
+++ b/app/components/usage-quote-by-resource/component.js
@@ -7,19 +7,23 @@ export default Ember.Component.extend({
     return this.get('resource').capitalize().pluralize();
   }),
 
-  containerUsage: Ember.computed.mapBy('stacks', 'containerUsage'),
+  diskUsage: Ember.computed.mapBy('stacks', 'totalDiskSize'),
+  domainUsage: Ember.computed.mapBy('stacks', 'domainCount'),
+  containerUsage: Ember.computed.mapBy('services', 'usage'),
+
+  totalDiskUsage: Ember.computed.sum('diskUsage'),
+  totalDomainUsage: Ember.computed.sum('domainUsage'),
   totalContainerUsage: Ember.computed.sum('containerUsage'),
 
-  grossUsage: Ember.computed('resource', 'totalContainerUsage', function() {
-    if(this.get('resource') === 'container') {
-      return this.get('totalContainerUsage');
+  grossUsage: Ember.computed('resource', function() {
+    switch(this.get('resource')) {
+      case 'container':
+        return this.get('totalContainerUsage');
+      case 'disk':
+        return this.get('totalDiskUsage');
+      case 'domain':
+        return this.get('totalDomainUsage');
     }
-
-    let total = 0;
-    this.get('stacks').forEach((stack) => {
-      total += stack.getUsageByResourceType(this.get('resource'));
-    });
-    return total;
   }),
 
   rate: Ember.computed('resource', 'hourlyRate', function() {

--- a/app/components/vhost-resource-usage/component.js
+++ b/app/components/vhost-resource-usage/component.js
@@ -4,12 +4,7 @@ export const HOURS_PER_MONTH = 730;
 
 export default Ember.Component.extend({
   tagName: 'tr',
-
-  hasRelease: Ember.computed.notEmpty('vhost.service.currentRelease'),
-
-  hasContainers: Ember.computed.notEmpty('vhost.service.currentRelease.containers'),
-
-  hasReleaseAndContainers: Ember.computed.and('hasRelease', 'hasContainers'),
+  isProvisioned: Ember.computed.equal('status', 'provisioned'),
 
   total: Ember.computed('hourlyRate', function () {
     return this.get('hourlyRate') * HOURS_PER_MONTH;

--- a/app/components/vhost-resource-usage/template.hbs
+++ b/app/components/vhost-resource-usage/template.hbs
@@ -1,4 +1,4 @@
-{{#if hasReleaseAndContainers}}
+{{#if isProvisioned}}
   <td>{{handle}}</td>
   <td></td><td>{{format-currency total}}</td>
 {{/if}}

--- a/app/organization/billing/index/route.js
+++ b/app/organization/billing/index/route.js
@@ -1,15 +1,47 @@
 import Ember from 'ember';
 
+function arrayReduce(arr) {
+return arr.reduce((prev, curr) => {
+    if(curr) {
+      return prev.toArray().concat(curr.toArray());
+    }
+
+    return prev;
+  }, Ember.A([]));
+}
+
 export default Ember.Route.extend({
   model() {
-    return this.modelFor('organization.billing').stacks;
+    let stacks = this.modelFor('organization.billing').stacks;
+
+    let databases = Ember.RSVP.all(stacks.map((stack) => stack.get('databases'))).then((dbs) => arrayReduce(dbs));
+
+    let apps = Ember.RSVP.all(stacks.map((stack) => stack.get('apps'))).then((apps) => arrayReduce(apps));
+
+    let appServices = apps.then((app) => arrayReduce(app.map((a) => a.get('services'))));
+
+    let dbServices = databases.then((dbs) => {
+      return Ember.RSVP.all(dbs.map((db) => db.get('service')).filter((service) => service));
+    });
+
+    let services = Ember.RSVP.all([appServices, dbServices]).then((s) => arrayReduce(s));
+
+    return Ember.RSVP.hash({
+      apps: apps,
+      stacks: stacks,
+      services: services,
+      databases: databases
+    });
   },
 
   setupController(controller, model) {
     let organization = this.modelFor('organization');
     let billingDetail = this.modelFor('organization.billing').billingDetail;
 
-    controller.set('model', model);
+    controller.set('model', model.stacks);
+    controller.set('apps', model.apps);
+    controller.set('services', model.services.filter((service) => service !== null));
+    controller.set('databases', model.databases);
     controller.set('organization', organization);
     controller.set('billingDetail', billingDetail);
   }

--- a/app/organization/billing/index/template.hbs
+++ b/app/organization/billing/index/template.hbs
@@ -75,6 +75,9 @@
     <h5 class="sort-header">Current Platform Usage</h5>
 
     {{usage-quote-by-resource
+      apps=apps
+      databases=databases
+      services=services
       stacks=model
       allowance=billingDetail.containersInPlan
       hourlyRate=billingDetail.containerCentsPerHour

--- a/tests/integration/components/usage-quote-by-resource-test.js
+++ b/tests/integration/components/usage-quote-by-resource-test.js
@@ -23,8 +23,11 @@ test('basic attributes are set', function(assert) {
 test('container usage less than allowance results in 0 billing', function(assert) {
   let stack1 = Ember.Object.create({ handle: 'stack1', apps: [], containerUsage: 2 });
   let stack2 = Ember.Object.create({ handle: 'stack2', apps: [], containerUsage: 3 });
+  let service1 = Ember.Object.create({ usage: 2 });
+  let service2 = Ember.Object.create({ usage: 3 });
   this.set('stacks', [stack1, stack2]);
-  this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
+  this.set('services', [service1, service2]);
+  this.render(hbs('{{usage-quote-by-resource stacks=stacks services=services allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
 
   let total = this.$('.resource-usage-total .usage-value');
   let allowance = this.$('.allowance');
@@ -40,8 +43,11 @@ test('container usage less than allowance results in 0 billing', function(assert
 test('container usage equal to allowance results in 0 billing', function(assert) {
   let stack1 = Ember.Object.create({ handle: 'stack1', apps: [], containerUsage: 3 });
   let stack2 = Ember.Object.create({ handle: 'stack2', apps: [], containerUsage: 3 });
+  let service1 = Ember.Object.create({ usage: 3 });
+  let service2 = Ember.Object.create({ usage: 3 });
   this.set('stacks', [stack1, stack2]);
-  this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
+  this.set('services', [service1, service2]);
+  this.render(hbs('{{usage-quote-by-resource stacks=stacks services=services allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
 
   let total = this.$('.resource-usage-total .usage-value');
   let allowance = this.$('.allowance');
@@ -55,8 +61,11 @@ test('container usage equal to allowance results in 0 billing', function(assert)
 test('container usage exceeding allowance results in overage billing', function(assert) {
   let stack1 = Ember.Object.create({ handle: 'stack1', apps: [], containerUsage: 8 });
   let stack2 = Ember.Object.create({ handle: 'stack2', apps: [], containerUsage: 9 });
+  let service1 = Ember.Object.create({ usage: 8 });
+  let service2 = Ember.Object.create({ usage: 9 });
   this.set('stacks', [stack1, stack2]);
-  this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
+  this.set('services', [service1, service2]);
+  this.render(hbs('{{usage-quote-by-resource stacks=stacks services=services allowance=6 hourlyRate=8 plan="platform" resource="container"}}'));
 
   let total = this.$('.resource-usage-total .usage-value');
   let allowance = this.$('.allowance');
@@ -68,8 +77,8 @@ test('container usage exceeding allowance results in overage billing', function(
 });
 
 test('disk usage less than allowance results in 0 billing', function(assert) {
-  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], getUsageByResourceType: function() { return 200; } });
-  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], getUsageByResourceType: function() { return 300; } });
+  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], totalDiskSize: 200 });
+  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], totalDiskSize: 300 });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=1000 hourlyRate=0.0507 plan="platform" resource="disk"}}'));
 
@@ -85,8 +94,8 @@ test('disk usage less than allowance results in 0 billing', function(assert) {
 });
 
 test('disk usage equal to allowance results in 0 billing', function(assert) {
-  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], getUsageByResourceType: function() { return 200; } });
-  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], getUsageByResourceType: function() { return 800; } });
+  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], totalDiskSize: 200 });
+  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], totalDiskSize: 800 });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=1000 hourlyRate=0.0507 plan="platform" resource="disk"}}'));
 
@@ -100,8 +109,8 @@ test('disk usage equal to allowance results in 0 billing', function(assert) {
 });
 
 test('disk usage exceeding allowance results in overage billing', function(assert) {
-  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], getUsageByResourceType: function() { return 800; } });
-  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], getUsageByResourceType: function() { return 900; } });
+  let stack1 = Ember.Object.create({ handle: 'stack1', databases: [], totalDiskSize: 800 });
+  let stack2 = Ember.Object.create({ handle: 'stack2', databases: [], totalDiskSize: 900 });
   this.set('stacks', [stack1, stack2]);
   this.render(hbs('{{usage-quote-by-resource stacks=stacks allowance=1000 hourlyRate=0.0507 plan="platform" resource="disk"}}'));
 

--- a/tests/unit/components/disk-resource-usage/component-test.js
+++ b/tests/unit/components/disk-resource-usage/component-test.js
@@ -1,0 +1,53 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('disk-resource-usage', {
+  unit: true,
+  needs: ['helper:format-currency']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+test('it does render table cells if disk is present', function(assert) {
+  assert.expect(3);
+
+  // creates the component instance
+  var component = this.subject({
+    handle: 'test',
+    hourlyRate: 10,
+    service: { processType: 'web' },
+    database: { disk: { size: 1 } }
+  });
+
+  // renders the component to the page
+  this.render();
+  let element = component.$();
+  equal(element.find('td:first-child').text(), 'test:web');
+  equal(element.find('td:nth-child(2)').text(), '1GB');
+  equal(element.find('td:last-child').text(), '$73.00');
+});
+
+test('it does not render table cells if disk is not present', function(assert) {
+  assert.expect(1);
+
+  // creates the component instance
+  var component = this.subject({database: {
+    disk: {}
+  }});
+
+  // renders the component to the page
+  this.render();
+  equal(component.$().text(), '');
+});

--- a/tests/unit/components/usage-quote-by-resource/component-test.js
+++ b/tests/unit/components/usage-quote-by-resource/component-test.js
@@ -1,0 +1,74 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('usage-quote-by-resource', {
+  needs: ['helper:format-currency', 'component:stack-resource-usage'],
+  unit: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject({
+    resource: 'container'
+  });
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+test('if resource equals container then grossUsage should equal sum of service usage', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject({
+    resource: 'container',
+    services: [{usage: 5},{usage: 5}]
+  });
+
+  // renders the component to the page
+  this.render();
+  assert.equal(10, component.get('grossUsage'));
+  assert.equal(component.get('grossUsage'), component.get('totalContainerUsage'));
+});
+
+test('if resource equals disk then grossUsage should equal the sum of stack totalDiskSize', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject({
+    resource: 'disk',
+    stacks: [{ totalDiskSize: 5 },{ totalDiskSize: 5 }]
+  });
+
+  // renders the component to the page
+  this.render();
+  assert.equal(10, component.get('grossUsage'));
+  assert.equal(component.get('grossUsage'), component.get('stacks').reduce((prev, curr) => {
+    return prev + curr.totalDiskSize;
+  }, 0));
+});
+
+test('if resource equals domain then grossUsage should equal the sum of stack domainCount', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject({
+    resource: 'domain',
+    stacks: [{ domainCount: 5 },{ domainCount: 5 }]
+  });
+
+  // renders the component to the page
+  this.render();
+  assert.equal(10, component.get('grossUsage'));
+  assert.equal(component.get('grossUsage'), component.get('stacks').reduce((prev, curr) => {
+    return prev + curr.domainCount;
+  }, 0));
+});
+
+

--- a/tests/unit/components/vhost-resource-usage/component-test.js
+++ b/tests/unit/components/vhost-resource-usage/component-test.js
@@ -1,0 +1,45 @@
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('vhost-resource-usage', {
+  unit: true,
+  needs: ['helper:format-currency']
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // renders the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+test('it does render table cells if vhost is provisioned', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject({status: 'provisioned', hourlyRate: 10, handle: 'www.google.com'});
+
+  // renders the component to the page
+  this.render();
+  let element = component.$();
+  equal(element.find('td:first-child').text(), 'www.google.com');
+  equal(element.find('td:last-child').text(), '$73.00');
+});
+
+test('it does not render table cells if vhost is not provisioned', function(assert) {
+  assert.expect(1);
+
+  // creates the component instance
+  var component = this.subject({status: 'failed'});
+
+  // renders the component to the page
+  this.render();
+  equal(component.$().text(), '');
+});


### PR DESCRIPTION
This is a PR that adjusts some issues with #580. In some cases the promises were never fully resolved in the UI, which led to some calculations being incorrect. I refactored the promise resolving so that it all happens within the route instead of trying to rely on computed properties to resolve the promises.

The rest is pretty much simply refactoring so that the affected components are easier to test, as well as changing the rendering of vhost rows to only render if its `status` is `provisioned`, and only rendering disk rows if the disk has a non empty `size`.

cc @sandersonet @gib 