### PR TITLE
V2 aptible logs

### DIFF
--- a/app/templates/stack/-log-drain.hbs
+++ b/app/templates/stack/-log-drain.hbs
@@ -37,12 +37,21 @@
       </li>
 
       <li class="resource-metadata-item">
-        <h5 class="resource-metadata-title">
-          Host
-        </h5>
-        <h3 class="resource-metadata-value">
-          {{logDrain.drainHost}}:{{logDrain.drainPort}}
-        </h3>
+        {{#if logDrain.isLogTail}}
+          <h5 class="resource-metadata-title">
+            About
+          </h5>
+          <h3 class="resource-metadata-value">
+            This log drain was automatically provisioned to support `aptible logs` on your stack.
+          </h3>
+        {{else}}
+          <h5 class="resource-metadata-title">
+            Host
+          </h5>
+          <h3 class="resource-metadata-value">
+            {{logDrain.drainHost}}:{{logDrain.drainPort}}
+          </h3>
+        {{/if}}
       </li>
     </ul>
   </div>

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "0.0.79",
+    "ember-cli-aptible-shared": "0.0.80",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -142,7 +142,27 @@ test(`visit ${url} shows pending and provisioning`, function(assert){
     assert.equal( logDrainEls.length, logDrains.length );
 
     assert.ok(find('h5:contains(Provisioning Log Drains)').length, 'has a pending header');
+    assert.ok(find('h5:contains(Host)').length, 'has host section');
     assert.equal(find('.pending-log-drains .log-drain').length, 2, 'has one pending log drain');
+  });
+});
+
+test(`visit ${url} shows log tail explanation`, function(assert) {
+  let logDrains = [{
+    id: 'drain-1',
+    handle: 'first-drain',
+    drain_type: 'tail',
+    status: 'pending'
+  }];
+
+  this.prepareStubs({logDrains});
+
+  signInAndVisit(url);
+
+  andThen(function(){
+    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.ok(!find('h5:contains(Host)').length, 'has no host section');
+    assert.ok(find('h3:contains(log drain was automatically provisioned)').length, 'has tail explanation');
   });
 });
 


### PR DESCRIPTION
This is a minor, visual-only change to ensure log tails (which are needed to support `aptible logs` on v2 stacks) don't weird out customers:

![image](https://cloud.githubusercontent.com/assets/1737686/15188062/2e592f00-17a4-11e6-862f-209a1ec6badc.png)

Without this change, it just shows the host as being `:`:

![image](https://cloud.githubusercontent.com/assets/1737686/15188121/7caf7d62-17a4-11e6-909a-261c9da62a54.png)


cc @sandersonet @gib 