### PR TITLE
Minor CSS fix to restore white BG to grid of panels

### DIFF
--- a/app/styles/_dashboard-global.scss
+++ b/app/styles/_dashboard-global.scss
@@ -8,7 +8,6 @@ button > i.fa-spinner {
 }
 
 .main-wrapper .layout-content {
-  background: #fff;
   min-width: 970px;
   -webkit-flex: 1;
   flex: 1;
@@ -19,6 +18,6 @@ header.resource-header {
   background: #fff;
 }
 
-.panel-link .panel {
-  border: 1px solid #fff;
+.flex-wrapper .layout-content {
+  background-color: #fff;
 }

--- a/app/styles/components/user-gravatars.scss
+++ b/app/styles/components/user-gravatars.scss
@@ -12,3 +12,6 @@
     }
   }
 }
+.user-gravatar-remainder {
+  line-height: 24px;
+}


### PR DESCRIPTION
Some CSS collisions from the sheriff / diesel merge. Closes https://github.com/aptible/dashboard.aptible.com/issues/591, described here in pictures:

### Unintended CSS
<img width="1317" alt="screen shot 2016-05-13 at 8 53 37 am" src="https://cloud.githubusercontent.com/assets/94830/15251854/94fd8b94-18e8-11e6-9bd0-2d01040c4ca0.png">

### Restored CSS
<img width="1319" alt="screen shot 2016-05-13 at 8 52 57 am" src="https://cloud.githubusercontent.com/assets/94830/15251862/9f23e0aa-18e8-11e6-96f5-8bb6910203ab.png">

**Note** - This keeps the intended CSS for grid panels in Sheriff. All should be well in style-landia.