### PR TITLE
Fix log drain count header

### DIFF
--- a/app/components/stack-metadata/component.js
+++ b/app/components/stack-metadata/component.js
@@ -24,5 +24,11 @@ export default Ember.Component.extend({
   vhostNamesTooltip: Ember.computed('model.vhostNames', function() {
     let names = this.model.get('vhostNames');
     return names.slice(this.get('maxVisibleDomainNames')).join(', ');
-  })
+  }),
+
+  logDrainsForSnippet: Ember.computed.filter("model.logDrains", (o) => {
+    return !(o.get("isLogTail"));
+  }),
+
+  hasLogDrains: Ember.computed.notEmpty("model.logDrains")
 });

--- a/app/components/stack-metadata/template.hbs
+++ b/app/components/stack-metadata/template.hbs
@@ -44,11 +44,13 @@
     <li class="resource-metadata-item">
       <h5 class="resource-metadata-title">{{model.logDrains.length }} Log {{plural-string "Drain" model.logDrains.length}}</h5>
       <h3 class="resource-metadata-value">
-        {{#with model.logDrains.firstObject as |logDrain|}}
-          {{logDrain.drainHost}}:{{logDrain.drainPort}}
+        {{#if hasLogDrains}}
+          {{#with logDrainsForSnippet.firstObject as |logDrain|}}
+            {{logDrain.drainHost}}:{{logDrain.drainPort}}
+          {{/with}}
         {{else}}
-          None configured
-        {{/with}}
+            None configured
+        {{/if}}
       </h3>
     </li>
   {{else}}

--- a/tests/acceptance/stack/show-test.js
+++ b/tests/acceptance/stack/show-test.js
@@ -86,6 +86,9 @@ test(`visit ${url} shows basic stack info`, function(assert) {
     assert.ok(find(`h5:contains(2 Databases)`).length,
        'Header that contains db length');
 
+    assert.ok(find('h5:contains(0 Log Drains)').length,
+        'Header contains log drain length');
+
     // 2 + 3
     assert.ok(find(`h3:contains(Using 5 containers)`).length,
        'has containers count');
@@ -93,5 +96,8 @@ test(`visit ${url} shows basic stack info`, function(assert) {
     // 4 + 2
     assert.ok(find(`h3:contains(Using 6GB of disk)`).length,
        'has disk size header');
+
+    assert.ok(find(`h3:contains(None configured)`).length,
+        'has log drain header');
   });
 });


### PR DESCRIPTION
We show host:port for one log drain in the stack header, but if the log
drain is a log tail, that breaks down (because it does not have those).

This updates the logic to prefer showing a log drain that's not a log
tail, and shows nothing if the log drain is a log tail.

---

This fixes one of the issues reported in https://github.com/aptible/dashboard.aptible.com/issues/598