### PR TITLE
Show 2FA enrollment status

### DIFF
--- a/app/components/otp-status/component.js
+++ b/app/components/otp-status/component.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+const makeComputedToggle = function(enabledValue, disabledValue) {
+  return Ember.computed('otpEnabled', function() {
+    const otpEnabled = this.get("otpEnabled");
+    return otpEnabled ? enabledValue : disabledValue;
+  });
+};
+
+export default Ember.Component.extend({
+  tagName: '',
+
+  label: makeComputedToggle('Enabled', 'Disabled'),
+  color: makeComputedToggle('success', 'danger')
+});

--- a/app/components/otp-status/template.hbs
+++ b/app/components/otp-status/template.hbs
@@ -1,0 +1,1 @@
+<div class="text-{{color}}"> {{label}} <i class="fa fa-circle"></i> </div>

--- a/app/templates/organization/-user.hbs
+++ b/app/templates/organization/-user.hbs
@@ -16,6 +16,10 @@
         <h5 class="resource-metadata-title">Roles</h5>
         <h3 class="resource-metadata-value">{{format-list (filter-by-organization user.roles organization) 'name' ', '}}</h3>
       </li>
+      <li class="resource-metadata-item">
+        <h5 class="resource-metadata-title">2-Factor Authentication</h5>
+        <h3 class="resource-metadata-value">{{otp-status otpEnabled=user.otpEnabled}}</h3>
+      </li>
     </ul>
   </div>
 </div>

--- a/tests/acceptance/organization/members-test.js
+++ b/tests/acceptance/organization/members-test.js
@@ -62,6 +62,7 @@ test(`visiting ${url} shows users`, function(assert) {
     name: 'Bob',
     verified: true,
     email: 'bob@bob.com',
+    otpEnabled: true,
     _links: { roles: {href: '/users/bob/roles'} }
   }];
 
@@ -77,7 +78,7 @@ test(`visiting ${url} shows users`, function(assert) {
     return this.success(users);
   });
 
-  assert.expect(5 + 1*users.length);
+  assert.expect(5 + 2*users.length);
 
   stubRequest('get', membersUrl, function(){
     assert.ok(true, 'Request for members is made');
@@ -102,5 +103,10 @@ test(`visiting ${url} shows users`, function(assert) {
     users.forEach((user) => {
       expectLink(`/organizations/${orgId}/members/${user.id}`);
     });
+
+    assert.ok(find('.user:contains(Mike) .resource-metadata-value:contains(Disabled)').length,
+                   '2FA status disabled is shown for Mike');
+    assert.ok(find('.user:contains(Bob) .resource-metadata-value:contains(Enabled)').length,
+                   '2FA status enabled is shown for Bob');
   });
 });


### PR DESCRIPTION
We probably want to display whether users have enabled 2FA on the users page. I don't have a very good design for it, so perhaps @gib and @sandersonet have better ideas, but here's at least a starting point:

![image](https://cloud.githubusercontent.com/assets/1737686/15421243/6cd2e0d0-1e72-11e6-9496-396f6434f174.png)

If this works, I'll also add tests for the component / page. Just let me know.

cc @fancyremarker @chasballew 