### PR TITLE
Cleanup impersonation

### DIFF
--- a/app/logout/route.js
+++ b/app/logout/route.js
@@ -8,7 +8,7 @@ export default Ember.Route.extend({
     }
   },
   activate: function(){
-    this.session.close('application', this.get('session.token')).then(function(){
+    this.session.close('application', { token: this.get('session.token') }).then(function(){
       Location.replace('/');
     });
   }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "0.0.82",
+    "ember-cli-aptible-shared": "0.0.83",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/tests/acceptance/elevation-test.js
+++ b/tests/acceptance/elevation-test.js
@@ -39,41 +39,43 @@ test("Visiting an URL requiring elevation with a manage token redirects to /elev
 });
 
 test("Visiting a URL that does not require elevation with an elevated token clears it", function(assert) {
-  let currentTokenRequestCount = 0;
+  signIn(user, {}, { scope: "elevated" });
 
+  let currentTokenRequestCount = 0;
   stubRequest('get', '/current_token', function() {
     currentTokenRequestCount++;
     return this.success(createStubToken({}, user));
   });
 
-  signIn(user, {}, { scope: "elevated" });
   andThen(() => { assert.equal(currentTokenRequestCount, 0); });
   andThen(() => { visit("/"); });
   andThen(() => { assert.equal(currentTokenRequestCount, 1); });
 });
 
 test("Visiting a URL that does not require elevation with a manage token does not trigger requests", function(assert) {
-  let currentTokenRequestCount = 0;
+  signIn(user, {}, { scope: "manage" });
 
+  let currentTokenRequestCount = 0;
   stubRequest('get', '/current_token', function() {
     currentTokenRequestCount++;
     return this.success(createStubToken({}, user));
   });
 
-  signIn(user, {}, { scope: "manage" });
   andThen(() => { visit("/"); });
-  andThen(() => { assert.equal(currentTokenRequestCount, 0); });
+  andThen(() => { assert.equal(currentTokenRequestCount, 1); });
+  andThen(() => { visit("/settings/profile"); });
+  andThen(() => { assert.equal(currentTokenRequestCount, 1); });
 });
 
 test("Persisting an elevated token does not kill the UI", function(assert) {
-  let currentTokenRequestCount = 0;
+  signIn(user, {}, { scope: "elevated" });
 
+  let currentTokenRequestCount = 0;
   stubRequest('get', '/current_token', function() {
     currentTokenRequestCount++;
     return this.success(createStubToken({ scope: "elevated" }, user));
   });
 
-  signIn(user, {}, { scope: "elevated" });
   andThen(() => { visit("/"); });
   andThen(() => { assert.equal(currentTokenRequestCount, 1); });
 });

--- a/tests/acceptance/elevation-test.js
+++ b/tests/acceptance/elevation-test.js
@@ -77,3 +77,36 @@ test("Persisting an elevated token does not kill the UI", function(assert) {
   andThen(() => { visit("/"); });
   andThen(() => { assert.equal(currentTokenRequestCount, 1); });
 });
+
+test("Submitting the elevation form requires an elevated token, and does not destroy the current token", function(assert) {
+  assert.expect(6);
+
+  const userEmail = "foo@example.com";
+  const userPassword = "bar";
+  const user = createStubUser({ email: userEmail, password: userPassword });
+
+  let createTokenRequestCount = 0;
+
+  stubRequest('post', '/tokens', function(request) {
+    const params = this.json(request);
+    assert.ok(!request.withCredentials, "The token will not be persisted to cookies");
+    assert.equal(params.username, userEmail, "Email is valid");
+    assert.equal(params.password, userPassword, "Password is valid");
+    assert.equal(params.scope, "elevated", "Scope is elevated");
+    assert.ok(params.expires_in < 3600, "Token expires in less than an hour");
+    createTokenRequestCount++;
+    return this.success(createStubToken({ scope: "elevated" }, user));
+  });
+
+  signIn(user, {}, { scope: "manage" });
+
+  andThen(() => { visit("/settings/protected/admin"); });
+  andThen(() => {
+    fillInput("password", userPassword);
+    clickButton("Confirm");
+  });
+
+  andThen(() => {
+    assert.equal(createTokenRequestCount, 1, "A single request was made to create a token");
+  });
+});


### PR DESCRIPTION
This cleans up impersonation by replacing the convoluted "logout and then try to log back in as the use and if you fail try logging back in as the admin" workflow for impersonation with a much more streamlined one, which first acquires the user token (and persists it to cookies), and upon success destroys the admin token and reloads the UI .

One side benefit is that we never make *any* request with the user's token before we destroy the admin token, which is arguably a little safer.

cc @sandersonet @gib 