### PR TITLE
Metrics: Bring back memory limits in graph

### DIFF
--- a/app/components/container-memory-metrics/component.js
+++ b/app/components/container-memory-metrics/component.js
@@ -54,6 +54,6 @@ export default Ember.Component.extend(ContainerMetricsComponentMixin, {
   allMemoryLimits: Ember.computed.mapBy("containers", "memoryLimit"),
   applicableMemoryLimits: Ember.computed.filter("allMemoryLimits", (memoryLimit) => (!Ember.isEmpty(memoryLimit)) && memoryLimit > 0),
 
-  minMemoryLimit: Infinity,
+  minMemoryLimit: Ember.computed.min("applicableMemoryLimits"),
   noMemoryLimit: Ember.computed.equal("minMemoryLimit", Infinity)
 });

--- a/app/components/container-memory-metrics/template.hbs
+++ b/app/components/container-memory-metrics/template.hbs
@@ -14,6 +14,7 @@
 
 <p>
 {{#if noMemoryLimit}}
+  Note: this app has no memory limit.
 {{else}}
   {{input
   type="checkbox"

--- a/tests/acceptance/apps/service-metrics-test.js
+++ b/tests/acceptance/apps/service-metrics-test.js
@@ -182,6 +182,33 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
   });
 });
 
+test("it shows memory limit checkbox and memory limit line if limit exists", function (assert) {
+  stubRequest("get", `/releases/${releaseId}/containers`, function() {
+    let containers = makeContainers();
+    containers[2].memory_limit = 999;
+    return this.success({_embedded: {containers: containers}});
+  });
+
+  stubRequest("get", "/proxy/:containers", function() {
+    return this.success(makeValidMetricData());
+  });
+
+  signInAndVisit(serviceMetricsUrl);
+
+  andThen(() => {
+    let checkbox = find("input[name$='show-memory-limit']");
+    checkbox.prop('checked', true);
+    checkbox.change();
+  });
+
+  andThen(() => {
+    assert.equal(find("input[name$='show-memory-limit']").length, 1, "Show memory limit button is not shown!");
+    let chart = findWithAssert("div.c3-chart-component");
+    assert.ok(chart.text().indexOf("Memory limit (999 MB)") > -1, "Memory limit not shown!");
+    assert.ok(chart.text().indexOf("1000 MB") > -1, "Chart did not resize!");
+  });
+});
+
 test("it can change the horizon", function (assert) {
   let expectedHorizons = ["1d", "1d", "1h", "1h"];
 

--- a/tests/acceptance/databases/database-metrics-test.js
+++ b/tests/acceptance/databases/database-metrics-test.js
@@ -172,6 +172,34 @@ test("it reloads and redraws data when reload is clicked", function(assert) {
   });
 });
 
+test("it shows memory limit checkbox and memory limit line if limit exists", function (assert) {
+  stubRequest("get", `/releases/${releaseId}/containers`, function() {
+    let containers = makeContainers();
+    containers[1].memory_limit = 999;
+    return this.success({_embedded: {containers: containers}});
+  });
+
+  stubRequest("get", "/proxy/:containers", function() {
+    return this.success(makeValidMetricData());
+  });
+
+  signInAndVisit(databaseMetricsUrl);
+
+  andThen(() => {
+    let checkbox = find("input[name$='show-memory-limit']");
+    checkbox.prop('checked', true);
+    checkbox.change();
+  });
+
+  andThen(() => {
+    assert.equal(find("input[name$='show-memory-limit']").length, 1, "Show memory limit button is not shown!");
+    let chart = findWithAssert("div.c3-chart-component");
+    console.log(chart.text());
+    assert.ok(chart.text().indexOf("Memory limit (999 MB)") > -1, "Memory limit not shown!");
+    assert.ok(chart.text().indexOf("1000 MB") > -1, "Chart did not resize!");
+  });
+});
+
 test("it can change the horizon", function (assert) {
   // Expected requests (right to left)
   let expectedHorizons = ["1d", "1d", "1d", "1h", "1h", "1h"];


### PR DESCRIPTION
This brings back memory limits in metrics graphs:

![image](https://cloud.githubusercontent.com/assets/1737686/15507088/1d816e42-2198-11e6-8b66-ee5630b12677.png)

We had removed them in https://github.com/aptible/dashboard.aptible.com/pull/564 because some apps were missing their limits, but AFAIK this should be fixed now.

cc @fancyremarker @sandersonet @gib 