### PR TITLE
Fix more activating tabs

### DIFF
--- a/app/templates/stack/-nav.hbs
+++ b/app/templates/stack/-nav.hbs
@@ -1,17 +1,17 @@
 <ul class="nav nav-pills resource-navigation">
-  {{#with-active-class route='dashboard.stack.apps' tagName='li'}}
+  {{#activating-item tagName="li" currentWhen="stack.apps"}}
     {{link-to 'Apps' 'apps.index'}}
-  {{/with-active-class}}
+  {{/activating-item}}
 
-  {{#with-active-class route='dashboard.stack.databases' tagName='li'}}
+  {{#activating-item tagName="li" currentWhen="stack.databases"}}
     {{link-to 'Databases' 'databases.index'}}
-  {{/with-active-class}}
+  {{/activating-item}}
 
-  {{#with-active-class route='dashboard.stack.log-drains' tagName='li'}}
+  {{#activating-item tagName="li" currentWhen="stack.log-drains"}}
     {{link-to 'Logging' 'stack.log-drains'}}
-  {{/with-active-class}}
+  {{/activating-item}}
 
-  {{#with-active-class route='dashboard.stack.certificates' tagName='li'}}
+  {{#activating-item tagName="li" currentWhen="stack.certificates"}}
     {{link-to 'Certificates' 'certificates.index'}}
-  {{/with-active-class}}
+  {{/activating-item}}
 </ul>

--- a/tests/acceptance/stack/show-test.js
+++ b/tests/acceptance/stack/show-test.js
@@ -69,6 +69,8 @@ test(`visit ${url} shows basic stack info`, function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.ok(find('ul.resource-navigation li.active a:contains(Apps)').length,
+              'Has active apps link');
 
     expectLink(`stacks/${stackId}/databases`);
     expectLink(`stacks/${stackId}/logging`);


### PR DESCRIPTION
Follow up to ember-cli-aptible-shared#123, which fixed the
`activating-item` component, but that component isn't being used here.

cc @gib @sandersonet 