### PR TITLE
Use "endpoints" instead of "domains" or "Vhosts"

### DIFF
--- a/app/app/vhosts/edit/route.js
+++ b/app/app/vhosts/edit/route.js
@@ -65,7 +65,7 @@ export default Ember.Route.extend({
 
         return op.save();
       }).then( () => {
-        let message = `Domain ${vhost.get('virtualDomain')} updated.`;
+        let message = `Endpoint ${vhost.get('virtualDomain')} updated.`;
         Ember.get(this, 'flashMessages').success(message);
 
         return vhost.reload();
@@ -74,7 +74,7 @@ export default Ember.Route.extend({
       }).catch( (e) => {
         let message = Ember.get(e, 'responseJSON.message') ||
                       Ember.get(e, 'message') ||
-                      `There was an error updating ${vhost.get('virtualDomain')}`;
+                      `There was an error updating the ${vhost.get('virtualDomain')} endpoint`;
         Ember.get(this, 'flashMessages').danger(message);
       });
     },

--- a/app/app/vhosts/edit/template.hbs
+++ b/app/app/vhosts/edit/template.hbs
@@ -40,7 +40,7 @@
     {{#if model.isSaving}}
       <i class='fa fa-spin fa-spinner'></i> Saving...
     {{else}}
-      Save VHost
+      Save Endpoint
     {{/if}}
   </button>
 </div>

--- a/app/app/vhosts/index/route.js
+++ b/app/app/vhosts/index/route.js
@@ -3,7 +3,7 @@ import Ember from "ember";
 export default Ember.Route.extend({
   titleToken: function(){
     var app = this.modelFor('app');
-    return `${app.get('handle')} Domains`;
+    return `${app.get('handle')} Endpoints`;
   },
   redirect: function(model) {
     if(model.get('length') === 0) {
@@ -16,7 +16,7 @@ export default Ember.Route.extend({
       this.controller.set('error', null);
     },
     failDeletion: function(/* e */){
-      this.controller.set('error', 'There was an error deleting the VHost.');
+      this.controller.set('error', 'There was an error deleting the endpoint.');
     },
     completeDeletion: function(){
       this.controller.set('error', null);

--- a/app/app/vhosts/index/template.hbs
+++ b/app/app/vhosts/index/template.hbs
@@ -11,7 +11,7 @@
 {{#if hasActive}}
   <div class="sort-group active-domains">
     {{#if showSortableHeader}}
-      <h5 class="sort-header">Provisioned Domains</h5>
+      <h5 class="sort-header">Provisioned Endpoints</h5>
     {{/if}}
     {{#each provisionedDomains as |vhost|}}
       <div class="row">
@@ -25,7 +25,7 @@
 
 {{#if hasPending}}
   <div class="sort-group pending-domains">
-    <h5 class="sort-header">Provisioning Domains</h5>
+    <h5 class="sort-header">Provisioning Endpoints</h5>
     {{#each pendingDomains as |vhost|}}
       <div class="row">
         <div class="col-xs-12">
@@ -39,7 +39,7 @@
 
 {{#if hasDeprovisioned}}
   <div class="sort-group deprovisioned-domains">
-    <h5 class="sort-header">Deprovisioned Domains</h5>
+    <h5 class="sort-header">Deprovisioned Endpoints</h5>
     {{#each deprovisionedDomains as |vhost|}}
       <div class="row">
         <div class="col-xs-12">
@@ -51,5 +51,5 @@
 {{/if}}
 
 <div class="resource-list-actions">
-  {{link-to 'Add Domain' 'app.vhosts.new' class="btn btn-primary"}}
+  {{link-to 'Add Endpoint' 'app.vhosts.new' class="btn btn-primary"}}
 </div>

--- a/app/app/vhosts/new/route.js
+++ b/app/app/vhosts/new/route.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   titleToken() {
     var app = this.modelFor('app');
-    return `Add a domain - ${app.get('handle')}`;
+    return `Add an endpoint - ${app.get('handle')}`;
   },
 
   model() {
@@ -71,14 +71,14 @@ export default Ember.Route.extend({
 
         return op.save();
       }).then(() => {
-        let message = `Domain ${vhost.get('virtualDomain')} created`;
+        let message = `Endpoint created: ${vhost.get('virtualDomain')}`;
 
         this.transitionTo('app.vhosts');
         Ember.get(this, 'flashMessages').success(message);
       }).catch( (e) => {
         let message = Ember.get(e, 'responseJSON.message') ||
                       Ember.get(e, 'message') ||
-                      `There was an error updating ${vhost.get('virtualDomain')}`;
+                      `There was an error updating endpoint ${vhost.get('virtualDomain')}`;
         Ember.get(this, 'flashMessages').danger(message);
       });
     },

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -3,7 +3,7 @@
     <div class="col-xs-8">
       <div class="panel panel-default ">
         <div class="panel-heading">
-            <h3>Create a new VHost</h3>
+            <h3>Create a new endpoint</h3>
         </div>
         <div class="panel-body">
           {{#unless model.isValid}}
@@ -22,19 +22,19 @@
 
           {{#unless serviceHasDefaultVhost}}
               <div class="form-group">
-                <label class="block" for="domain-type">Domain type</label>
+                <label class="block" for="domain-type">Endpoint type:</label>
                 <div class="radio">
                   <div>
                     {{#radio-button value=true groupValue=model.isDefault name="domain-type"}}
-                      {{#bs-tooltip placement="bottom" title='A default domain is simply a domain in the format app-${id}.on-aptible.com.' bs-container=false}}
-                          Use app-{{ model.app.id }}.on-aptible.com default domain name
+                      {{#bs-tooltip placement="bottom" title='A default endpoint has an endpoint address in the format app-${id}.on-aptible.com.' bs-container=false}}
+                          Use app-{{ model.app.id }}.on-aptible.com default endpoint address
                       {{/bs-tooltip}}
                     {{/radio-button}}
                   </div>
                     <div>
                       {{#radio-button value=false groupValue=model.isDefault name="domain-type"}}
-                        {{#bs-tooltip placement="bottom" title='With a custom domain you can use a custom certificate and domain name.' bs-container=false}}
-                            Use a custom domain name
+                        {{#bs-tooltip placement="bottom" title='Custom endpoints let you use your own certificate and domain name.' bs-container=false}}
+                            Use a custom endpoint address
                         {{/bs-tooltip}}
                       {{/radio-button}}
                     </div>
@@ -47,14 +47,14 @@
               <div class="radio">
                 <div>
                   {{#radio-button value=false groupValue=model.internal name="vhost-type"}}
-                    {{#bs-tooltip placement="bottom" title='External Domains are accessible from the outside internet.' bs-container=false}}
+                    {{#bs-tooltip placement="bottom" title='External endpoints are accessible from the outside internet.' bs-container=false}}
                         External
                     {{/bs-tooltip}}
                   {{/radio-button}}
                 </div>
                 <div>
                   {{#radio-button value=true groupValue=model.internal name="vhost-type"}}
-                    {{#bs-tooltip placement="bottom" title='Internal Domains are only accessible from other apps in your environment.' bs-container=false}}
+                    {{#bs-tooltip placement="bottom" title='Internal endpoints are only accessible from other apps in your stack.' bs-container=false}}
                         Internal
                     {{/bs-tooltip}}
                   {{/radio-button}}
@@ -76,7 +76,7 @@
       {{#if model.isSaving}}
           <i class='fa fa-spin fa-spinner'></i> Saving...
       {{else}}
-          Save VHost
+          Save Endpoint
       {{/if}}
     </button>
   </div>

--- a/app/components/plan-description/template.hbs
+++ b/app/components/plan-description/template.hbs
@@ -42,7 +42,7 @@
   <ul class="plan-feature-list">
     <li><i class="fa fa-check-circle"></i> 1 virtual private cloud</li>
     <li><i class="fa fa-check-circle"></i> Unlimited PHI-Ready and Dev environments</li>
-    <li><i class="fa fa-check-circle"></i> 6 containers, 1TB of storage, and 4 domains</li>
+    <li><i class="fa fa-check-circle"></i> 6 containers, 1TB of storage, and 4 endpoints</li>
     <li><i class="fa fa-check-circle"></i> Use your included resources across all environments</li>
     <li><i class="fa fa-check-circle"></i> 24/7 Technical Support</li>
     <li><i class="fa fa-check-circle"></i> Signed Business Associate Agreement</li>

--- a/app/components/stack-metadata/template.hbs
+++ b/app/components/stack-metadata/template.hbs
@@ -27,7 +27,7 @@
     </li>
 
     <li class="resource-metadata-item">
-      <h5 class="resource-metadata-title">{{model.persistedVhosts.length}} {{plural-string "Domain" model.persistedVhosts.length}}</h5>
+      <h5 class="resource-metadata-title">{{model.persistedVhosts.length}} {{plural-string "Endpoint" model.persistedVhosts.length}}</h5>
       <h3 class="resource-metadata-value">
         {{#if showVhostTooltip}}
           {{vhostNamesSnippet}}

--- a/app/components/usage-quote-by-resource/component.js
+++ b/app/components/usage-quote-by-resource/component.js
@@ -2,13 +2,23 @@ import Ember from 'ember';
 
 export const HOURS_PER_MONTH = 730;
 
+const RESOURCE_LABELS = {
+  'domain': 'endpoint',
+  'disk': 'disk',
+  'container': 'container'
+};
+
 export default Ember.Component.extend({
-  resourceLabel: Ember.computed('resource', function() {
-    if(this.get('resource') === 'domain') {
-      return 'Endpoints';
-    } else {
-      return this.get('resource').capitalize().pluralize();
-    }
+  resourceHandle: Ember.computed('resource', function() {
+    return this.get('resource').toLowerCase();
+  }),
+
+  resourceTitle: Ember.computed('resourceHandle', function() {
+    return RESOURCE_LABELS[this.get('resourceHandle')].capitalize().pluralize();
+  }),
+
+  resourceLabel: Ember.computed('resourceHandle', function() {
+    return RESOURCE_LABELS[this.get('resourceHandle')];
   }),
 
   diskUsage: Ember.computed.mapBy('stacks', 'totalDiskSize'),

--- a/app/components/usage-quote-by-resource/component.js
+++ b/app/components/usage-quote-by-resource/component.js
@@ -4,7 +4,11 @@ export const HOURS_PER_MONTH = 730;
 
 export default Ember.Component.extend({
   resourceLabel: Ember.computed('resource', function() {
-    return this.get('resource').capitalize().pluralize();
+    if(this.get('resource') === 'domain') {
+      return 'Endpoints';
+    } else {
+      return this.get('resource').capitalize().pluralize();
+    }
   }),
 
   diskUsage: Ember.computed.mapBy('stacks', 'totalDiskSize'),

--- a/app/components/usage-quote-by-resource/template.hbs
+++ b/app/components/usage-quote-by-resource/template.hbs
@@ -1,12 +1,12 @@
 <div class="panel panel-default resource-usage">
   <div class="panel-heading with-actions">
     <h3>
-      <span class="resource-label">{{resourceLabel}}</span>
+      <span class="resource-label">{{resourceTitle}}</span>
       <small class="resource-rate">{{rate}}</small>
     </h3>
     <div class="resource-usage-total">
       <span class="usage-label">
-        Total monthly {{resource}} cost:
+        Total monthly {{resourceLabel}} cost:
       </span>
       <span class="usage-value">
         {{format-currency totalUsageCost}}

--- a/app/organization/billing/index/template.hbs
+++ b/app/organization/billing/index/template.hbs
@@ -18,8 +18,8 @@
         <li class="usage-quote-item">
           <div class="usage-label">
             Includes
-            {{billingDetail.containersInPlan}} containers,
-            {{billingDetail.domainsInPlan}} domains, and
+            {{billingDetail.containersInPlan}} GBs of containers,
+            {{billingDetail.domainsInPlan}} endpoints, and
             {{gb-to-tb billingDetail.diskSpaceInPlan}}TB of disk
           </div>
         </li>

--- a/app/organization/billing/plan/template.hbs
+++ b/app/organization/billing/plan/template.hbs
@@ -53,7 +53,7 @@
                 {{fa-icon "check" classNames="primary"}} {{gb-to-tb 1000}}TB Disk, Encryption &amp; Backups included
               </li>
               <li>
-                {{fa-icon "check" classNames="primary"}} 4 Domains included
+                {{fa-icon "check" classNames="primary"}} 4 Endpoints included
               </li>
             {{else}}
               <li>
@@ -63,7 +63,7 @@
                 {{fa-icon "check" classNames="primary"}} {{gb-to-tb (if model.diskAllowance model.diskAllowance 1000)}}TB Disk, Encryption &amp; Backups included
               </li>
               <li>
-                {{fa-icon "check" classNames="primary"}} {{if model.domainAllowance model.domainAllowance 4}} Domains included
+                {{fa-icon "check" classNames="primary"}} {{if model.domainAllowance model.domainAllowance 4}} Endpoints included
               </li>
             {{/if}}
             <li>

--- a/app/templates/app/-nav.hbs
+++ b/app/templates/app/-nav.hbs
@@ -5,7 +5,7 @@
     {{/activating-item}}
 
     {{#activating-item tagName="li" currentWhen="app.vhosts"}}
-      {{link-to "Domains" "app.vhosts"}}
+      {{link-to "Endpoints" "app.vhosts"}}
     {{/activating-item}}
   {{else}}
     {{#activating-item tagName="li" currentWhen="app.deploy"}}

--- a/tests/acceptance/apps/services-test.js
+++ b/tests/acceptance/apps/services-test.js
@@ -123,8 +123,8 @@ test(`visit ${url} allows scaling of services`, function(assert) {
 
   stubRequest('post', `/services/${serviceId}/operations`, function(request){
     let json = this.json(request);
-    assert.equal(json.type, 'scale');
-    assert.equal(json.container_count, newContainerCount);
+    assert.equal(json.type, 'scale', 'is of scale type');
+    assert.equal(json.container_count, newContainerCount, 'has correct container count');
     json.id = serviceId;
     return this.success(json);
   });
@@ -139,11 +139,12 @@ test(`visit ${url} allows scaling of services`, function(assert) {
 
   signInAndVisit(url);
   andThen(() => {
-    assert.equal($('.btn:contains("Scale")').css('visibility'), 'hidden');
+    assert.equal($('.btn:contains("Scale")').css('visibility'), 'hidden', 'Scale button is hidden');
     triggerSlider('.slider', newContainerCount);
   });
+
   andThen(() => {
-    assert.equal($('.btn:contains("Scale")').css('visibility'), 'visible');
+    assert.equal($('.btn:contains("Scale")').css('visibility'), 'visible', 'Scale button is visible');
     clickButton('Scale');
   });
 });

--- a/tests/acceptance/apps/show-empty-test.js
+++ b/tests/acceptance/apps/show-empty-test.js
@@ -93,7 +93,7 @@ test(`visit ${url} when app has not been deployed`, function(assert){
 
     // hidden tabs
     //expectNoTab('Services');
-    //expectNoTab('Domains');
+    //expectNoTab('Endpoints');
 
     // displayed steps
 

--- a/tests/acceptance/apps/show-test.js
+++ b/tests/acceptance/apps/show-test.js
@@ -127,12 +127,12 @@ test(`visit /apps/app-id shows current tab with active class`, function(assert) 
 
   andThen(() => {
     assert.equal(find('li.active a:contains(Services)').length, 1, 'Services is active');
-    assert.equal(find('li.active a:contains(Domains)').length, 0, 'Domains is inactive');
-    clickButton('Domains');
+    assert.equal(find('li.active a:contains(Endpoints)').length, 0, 'Endpoints is inactive');
+    clickButton('Endpoints');
   });
 
   andThen(() => {
     assert.equal(find('li.active a:contains(Services)').length, 0, 'Services is inactive');
-    assert.equal(find('li.active a:contains(Domains)').length, 1, 'Domains is active');
+    assert.equal(find('li.active a:contains(Endpoints)').length, 1, 'Endpoints is active');
   });
 });

--- a/tests/acceptance/apps/vhost-edit-test.js
+++ b/tests/acceptance/apps/vhost-edit-test.js
@@ -18,7 +18,7 @@ let vhostsUrl = `/apps/${appId}/vhosts`;
 
 let url = `/apps/${appId}/vhosts/${vhostId}/edit`;
 
-module('Acceptance: App Vhost Edit', {
+module('Acceptance: App Endpoint Edit', {
   beforeEach: function() {
     App = startApp();
     stubStacks();
@@ -109,7 +109,7 @@ test(`visit ${url} shows form with certificates`, function(assert) {
     assert.ok(!findInput('certificate-body').length, 'has no certificate body field');
     assert.ok(!findInput('private-key').length, 'has no private key field');
 
-    expectButton('Save VHost');
+    expectButton('Save Endpoint');
     expectButton('Cancel');
   });
 });
@@ -148,7 +148,7 @@ test(`visit ${url} shows form without certificates`, function(assert) {
     assert.equal(findInput('private-key').val(), '',
           'private key is empty');
 
-    expectButton('Save VHost');
+    expectButton('Save Endpoint');
     expectButton('Cancel');
   });
 });
@@ -169,7 +169,7 @@ test(`visit ${url} click save`, function(assert) {
   });
 
   stubRequest('put', `/vhosts/${vhostId}`, function(request){
-    assert.ok(true, 'posts to create vhost');
+    assert.ok(true, 'posts to create endpoint');
     let json = this.json(request);
     assert.equal(json.certificate, certificateHref);
 
@@ -177,14 +177,14 @@ test(`visit ${url} click save`, function(assert) {
   });
 
   stubRequest('get', `/vhosts/${vhostId}`, function(request){
-    assert.ok(true, 'reloads the updated vhost');
+    assert.ok(true, 'reloads the updated endpoint');
     let json = this.json(request);
     return this.success(Ember.merge(json, {id:vhostId, status: 'provisioned' }));
   });
 
 
   stubRequest('post', `/vhosts/${vhostId}/operations`, function(request){
-    assert.ok(true, 'posts to create vhost operation');
+    assert.ok(true, 'posts to create endpoint operation');
     let json = this.json(request);
 
     assert.equal(json.type, 'provision');
@@ -202,20 +202,20 @@ test(`visit ${url} click save`, function(assert) {
     fillIn(findInput('certificate-body'), newCert);
     fillIn(findInput('private-key'), newPk);
 
-    click(findButton('Save VHost'));
+    click(findButton('Save Endpoint'));
   });
 
   andThen( () => {
     assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.index');
 
     assert.ok( find(`.vhost .vhost-virtualdomain:contains(health.io)`).length,
-        'shows new virtual domain health.io');
+        'shows new endpoint health.io');
   });
 });
 
 test(`visit ${url} click save and error`, function(assert) {
   let stackId = 'stubbed-stack';
-  let errorMsg = 'There was an error with this domain';
+  let errorMsg = 'There was an error with this endpoint';
 
   stubRequest('get', `/accounts/${stackId}/certificates`, function(){
     return this.success({ _embedded: { certificates: [] } });
@@ -239,7 +239,7 @@ test(`visit ${url} click save and error`, function(assert) {
   signInAndVisit(url);
 
   andThen( () => {
-    click(findButton('Save VHost'));
+    click(findButton('Save Endpoint'));
   });
 
   andThen( () => {

--- a/tests/acceptance/apps/vhost-new-test.js
+++ b/tests/acceptance/apps/vhost-new-test.js
@@ -10,7 +10,7 @@ let appVhostsUrl = '/apps/' + appId + '/vhosts';
 let appVhostsApiUrl = '/apps/' + appId + '/vhosts';
 let appVhostsNewUrl = '/apps/' + appId + '/vhosts/new';
 
-module('Acceptance: App Vhost New', {
+module('Acceptance: App Endpoint New', {
   beforeEach: function() {
     App = startApp();
     stubStacks();
@@ -26,7 +26,7 @@ test('visit ' + appVhostsNewUrl + ' requires authentication', function() {
   expectRequiresAuthentication(appVhostsNewUrl);
 });
 
-test(`visiting ${appVhostsUrl} without any Vhosts redirects to ${appVhostsNewUrl}`, function(assert) {
+test(`visiting ${appVhostsUrl} without any endpoints redirects to ${appVhostsNewUrl}`, function(assert) {
   stubStacks();
   stubApp({ id: appId });
   stubStack({ id: 'stubbed-stack' });
@@ -67,16 +67,16 @@ test(`visit ${appVhostsNewUrl} shows creation form`, function(assert) {
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new VHost)').length,
+    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
        'has header');
     expectInput('service', {input:'select'});
     expectFocusedInput('service', {input:'select'});
     expectInput('domain-type', {input:'radio'});
     expectInput('certificate-body', {input:'textarea'});
     expectInput('private-key', {input:'textarea'});
-    expectButton('Save VHost');
+    expectButton('Save Endpoint');
     expectButton('Cancel');
-    expectTitle(`Add a domain - ${appHandle} - ${stackHandle}`);
+    expectTitle(`Add an endpoint - ${appHandle} - ${stackHandle}`);
   });
 });
 
@@ -139,18 +139,18 @@ test(`visit ${appVhostsNewUrl} shows creation form with existing certificates`, 
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new VHost)').length,
+    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
        'has header');
     expectInput('domain-type', {input:'radio'});
     expectInput('service', {input:'select'});
     expectFocusedInput('service', {input:'select'});
     expectInput('certificate', { input: 'select'});
-    expectButton('Save VHost');
+    expectButton('Save Endpoint');
     expectButton('Cancel');
 
     assert.ok(!find('textarea[name="certificate-body"]').length, 'has no certificate body field');
     assert.ok(!find('textarea[name="private-key"]').length, 'has no private key field');
-    expectTitle(`Add a domain - ${appHandle} - ${stackHandle}`);
+    expectTitle(`Add an endpoint - ${appHandle} - ${stackHandle}`);
 
     let toggle = find('.toggle-new-certificate');
     toggle.click();
@@ -219,20 +219,20 @@ test(`visit ${appVhostsNewUrl} shows creation form without certificates`, functi
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new VHost)').length,
+    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
        'has header');
     expectInput('domain-type', {input:'radio'});
     expectInput('service', {input:'select'});
     expectFocusedInput('service', {input:'select'});
     expectInput('certificate-body', {input:'textarea'});
     expectInput('private-key', {input:'textarea'});
-    expectButton('Save VHost');
+    expectButton('Save Endpoint');
     expectButton('Cancel');
-    expectTitle(`Add a domain - ${appHandle} - ${stackHandle}`);
+    expectTitle(`Add an endpoint - ${appHandle} - ${stackHandle}`);
   });
 });
 
-test(`visit ${appVhostsNewUrl} should remove certificate form if default vhost is clicked`, function(assert) {
+test(`visit ${appVhostsNewUrl} should remove certificate form if default endpoint is clicked`, function(assert) {
   let appId = 1;
   let appHandle = 'my-app';
   let serviceId = 'the-service-id';
@@ -286,7 +286,7 @@ test(`visit ${appVhostsNewUrl} should remove certificate form if default vhost i
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new VHost)').length,
+    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
       'has header');
 
     expectInput('domain-type', {input:'radio'});
@@ -294,13 +294,13 @@ test(`visit ${appVhostsNewUrl} should remove certificate form if default vhost i
     expectFocusedInput('service', {input:'select'});
     expectInput('certificate-body', {input:'textarea'});
     expectInput('private-key', {input:'textarea'});
-    expectButton('Save VHost');
+    expectButton('Save Endpoint');
     expectButton('Cancel');
-    expectTitle(`Add a domain - ${appHandle} - ${stackHandle}`);
+    expectTitle(`Add an endpoint - ${appHandle} - ${stackHandle}`);
   });
 
   andThen(function(){
-    click( find('label:contains(default domain name)'));
+    click( find('label:contains(default endpoint name)'));
   });
 
   andThen(function(){
@@ -309,7 +309,7 @@ test(`visit ${appVhostsNewUrl} should remove certificate form if default vhost i
   });
 });
 
-test(`visit ${appVhostsNewUrl} shows creation form for service with existing default vhost`, function(assert) {
+test(`visit ${appVhostsNewUrl} shows creation form for service with existing default endpoint`, function(assert) {
   let appId = 1;
   let appHandle = 'my-app';
   let serviceId = 'the-service-id';
@@ -367,7 +367,7 @@ test(`visit ${appVhostsNewUrl} shows creation form for service with existing def
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new VHost)').length,
+    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
       'has header');
 
     expectInput('service', {input:'select'});
@@ -375,9 +375,9 @@ test(`visit ${appVhostsNewUrl} shows creation form for service with existing def
     expectNoInput('domain-type', {input:'radio'});
     expectInput('certificate-body', {input:'textarea'});
     expectInput('private-key', {input:'textarea'});
-    expectButton('Save VHost');
+    expectButton('Save Endpoint');
     expectButton('Cancel');
-    expectTitle(`Add a domain - ${appHandle} - ${stackHandle}`);
+    expectTitle(`Add an endpoint - ${appHandle} - ${stackHandle}`);
   });
 });
 
@@ -465,7 +465,7 @@ test(`visit ${appVhostsNewUrl} and create vhost with existing certificates`, fun
 
   visit(appVhostsNewUrl);
   andThen(function(){
-    clickButton('Save VHost');
+    clickButton('Save Endpoint');
   });
 });
 
@@ -529,11 +529,11 @@ test(`visit ${appVhostsNewUrl} and create vhost with new certificate`, function(
   andThen(function(){
     fillInput('certificate-body', 'my long cert');
     fillInput('private-key', 'my long pk');
-    clickButton('Save VHost');
+    clickButton('Save Endpoint');
   });
 });
 
-test(`visit ${appVhostsNewUrl} and create default vhost`, function(assert) {
+test(`visit ${appVhostsNewUrl} and create default endpoint`, function(assert) {
   assert.expect(6);
 
   let appId = 1;
@@ -582,6 +582,6 @@ test(`visit ${appVhostsNewUrl} and create default vhost`, function(assert) {
   visit(appVhostsNewUrl);
   andThen(function(){
     fillInput('domain-type', true);
-    clickButton('Save VHost');
+    clickButton('Save Endpoint');
   });
 });

--- a/tests/acceptance/apps/vhost-new-test.js
+++ b/tests/acceptance/apps/vhost-new-test.js
@@ -285,6 +285,8 @@ test(`visit ${appVhostsNewUrl} should remove certificate form if default endpoin
 
   signInAndVisit(appVhostsNewUrl);
 
+
+  Error.stackTraceLimit = 1000;
   andThen(function(){
     assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
       'has header');
@@ -300,7 +302,8 @@ test(`visit ${appVhostsNewUrl} should remove certificate form if default endpoin
   });
 
   andThen(function(){
-    click( find('label:contains(default endpoint name)'));
+    let button = findWithAssert('label:contains(default endpoint address)');
+    click(button);
   });
 
   andThen(function(){

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -12,7 +12,7 @@ var appVhostsUrl = '/apps/' + appId + '/vhosts';
 var appVhostsApiUrl = '/apps/' + appId + '/vhosts';
 var appVhostsNewUrl = '/apps/' + appId + '/vhosts/new';
 
-module('Acceptance: App Vhosts', {
+module('Acceptance: App Endpoints', {
   beforeEach: function() {
     App = startApp();
     stubStacks();
@@ -91,11 +91,11 @@ test(`visit ${appVhostsUrl} has link to ${appVhostsNewUrl}`, function() {
 
   andThen(function(){
     expectLink(appVhostsNewUrl);
-    expectTitle(`${appHandle} Domains - ${stackHandle}`);
+    expectTitle(`${appHandle} Endpoints - ${stackHandle}`);
   });
 });
 
-test(`visit ${appVhostsUrl} lists active vhosts`, function(assert) {
+test(`visit ${appVhostsUrl} lists active endpoints`, function(assert) {
   var vhosts = [{
     id: 1,
     virtual_domain: 'www.health1.io',
@@ -126,7 +126,7 @@ test(`visit ${appVhostsUrl} lists active vhosts`, function(assert) {
     vhosts.forEach(function(vhost, index){
       let vhostEl = find(`.vhost:eq(${index})`);
       assert.ok(vhostEl.find(`:contains(${vhost.virtual_domain})`).length,
-         `has virtual domain "${vhost.virtual_domain}"`);
+         `has endpoint "${vhost.virtual_domain}"`);
 
       assert.ok(vhostEl.find(`:contains(${vhost.external_host})`).length,
          `has external host "${vhost.external_host}"`);
@@ -173,7 +173,7 @@ test(`visit ${appVhostsUrl} lists pending vhosts`, function(assert) {
     vhosts.forEach(function(vhost, index){
       let vhostEl = find(`.vhost:eq(${index})`);
       assert.ok(vhostEl.find(`:contains(${vhost.virtual_domain})`).length,
-         `has virtual domain "${vhost.virtual_domain}"`);
+         `has endpoint "${vhost.virtual_domain}"`);
 
       assert.ok(vhostEl.find(`:contains(${vhost.external_host})`).length,
          `has external host "${vhost.external_host}"`);
@@ -224,7 +224,7 @@ test(`visit ${appVhostsUrl} lists deprovisioning`, function(assert) {
     vhosts.forEach(function(vhost, index){
       let vhostEl = find(`.vhost:eq(${index})`);
       assert.ok(vhostEl.find(`:contains(${vhost.virtual_domain})`).length,
-         `has virtual domain "${vhost.virtual_domain}"`);
+         `has endpoint "${vhost.virtual_domain}"`);
 
       assert.ok(vhostEl.find(`:contains(${vhost.external_host})`).length,
          `has external host "${vhost.external_host}"`);
@@ -235,7 +235,7 @@ test(`visit ${appVhostsUrl} lists deprovisioning`, function(assert) {
   });
 });
 
-test(`visit ${appVhostsUrl} allows deleting vhost`, function(assert) {
+test(`visit ${appVhostsUrl} allows deleting endpoint`, function(assert) {
   assert.expect(2);
 
   let vhostId = 'vhost-1';
@@ -263,11 +263,11 @@ test(`visit ${appVhostsUrl} allows deleting vhost`, function(assert) {
   });
   andThen(function(){
     assert.equal(find('.vhost').length, 0,
-          'the vhost is no longer shown in the UI');
+          'the endpoint is no longer shown in the UI');
   });
 });
 
-test(`visit ${appVhostsUrl} and delete vhost has error`, function(assert) {
+test(`visit ${appVhostsUrl} and delete endpoint has error`, function(assert) {
   assert.expect(2);
 
   let vhostId = 'vhost-1';
@@ -293,7 +293,7 @@ test(`visit ${appVhostsUrl} and delete vhost has error`, function(assert) {
     click(findButton('Delete'));
   });
   andThen(function(){
-    let errorMessage = 'error deleting the VHost';
+    let errorMessage = 'error deleting the endpoint';
     let alert = find(`.alert`);
     assert.ok(alert.length, 'displays error div');
     assert.ok(alert.text().indexOf(errorMessage) > -1,

--- a/tests/acceptance/organization/billing/overview-test.js
+++ b/tests/acceptance/organization/billing/overview-test.js
@@ -45,7 +45,7 @@ test(`visiting ${url} shows current plan and resource usage`, (assert) => {
     assert.notOk(find('.sort-header:contains(Discounts)').length, 'has a discounts section');
     assert.ok(find('.resource-label:contains(Containers)').length, 'has a containers quote');
     assert.ok(find('.resource-label:contains(Disk)').length, 'has a disk quote');
-    assert.ok(find('.resource-label:contains(Domains)').length, 'has a domains quote');
+    assert.ok(find('.resource-label:contains(Endpoints)').length, 'has an endpoints quote');
   });
 });
 

--- a/tests/acceptance/organization/billing/plan-test.js
+++ b/tests/acceptance/organization/billing/plan-test.js
@@ -93,7 +93,7 @@ test(`on plan "development": shows default allowances for "platform" upgrade`, (
 
     assert.equal(containers.text().trim(), '6 x 1GB Containers included');
     assert.equal(diskSpace.text().trim(), '1TB Disk, Encryption & Backups included');
-    assert.equal(domains.text().trim(), '4 Domains included');
+    assert.equal(domains.text().trim(), '4 Endpoints included');
   });
 });
 
@@ -110,7 +110,7 @@ test(`on plan "platform": shows custom allowances`, (assert) => {
 
     assert.equal(containers.text().trim(), '15 x 1GB Containers included');
     assert.equal(diskSpace.text().trim(), '2.5TB Disk, Encryption & Backups included');
-    assert.equal(domains.text().trim(), '10 Domains included');
+    assert.equal(domains.text().trim(), '10 Endpoints included');
   });
 });
 
@@ -127,7 +127,7 @@ test(`on plan "production": shows custom allowances`, (assert) => {
 
     assert.equal(containers.text().trim(), '15 x 1GB Containers included');
     assert.equal(diskSpace.text().trim(), '2.5TB Disk, Encryption & Backups included');
-    assert.equal(domains.text().trim(), '10 Domains included');
+    assert.equal(domains.text().trim(), '10 Endpoints included');
   });
 });
 

--- a/tests/integration/components/total-monthly-estimate-test.js
+++ b/tests/integration/components/total-monthly-estimate-test.js
@@ -14,7 +14,7 @@ test('sums usage correctly', function(assert) {
                                             domainCentsPerHour: 5, diskCentsPerHour: 0.0507, planRate: 0 });
 
   // Net container rate: (11 + 3 - 6) * 8 * 730 = 46720
-  // Net domain rate: (8 + 1 - 4) * 5 * 730 = 18250
+  // Net endpoint rate: (8 + 1 - 4) * 5 * 730 = 18250
   // Net disk rate: (2000 + 1000 - 1000) * .0507 * 730 = 74022
   // Net cents: 138992
   // net dollars: $1,389.92
@@ -34,7 +34,7 @@ test('sums usage with base plan rate correctly', function(assert) {
                                             domainCentsPerHour: 5, diskCentsPerHour: 0.0507, planRate: 349900 });
 
   // Net container rate: (11 + 3 - 6) * 8 * 730 = 46720
-  // Net domain rate: (8 + 1 - 4) * 5 * 730 = 18250
+  // Net endpoint rate: (8 + 1 - 4) * 5 * 730 = 18250
   // Net disk rate: (2000 + 1000 - 1000) * .0507 * 730 = 74022
   // Net plan rate 349900
   // Net cents: 488892

--- a/tests/unit/components/usage-quote-by-resource/component-test.js
+++ b/tests/unit/components/usage-quote-by-resource/component-test.js
@@ -54,7 +54,7 @@ test('if resource equals disk then grossUsage should equal the sum of stack tota
   }, 0));
 });
 
-test('if resource equals domain then grossUsage should equal the sum of stack domainCount', function(assert) {
+test('if resource equals endpoint then grossUsage should equal the sum of stack domainCount', function(assert) {
   assert.expect(2);
 
   // creates the component instance


### PR DESCRIPTION
The intent is to update only the user-facing components, leaving the internal code for now.

This terminology change is also reflected in aptible/www.aptible.com#218 and aptible/support#268

@sandersonet - We can discuss, but I wasn't able to get a local environment running properly to test the UI. There is still one test failure:

```
not ok 72 PhantomJS 2.1 - Acceptance: App Endpoint New: visit /apps/1/vhosts/new should remove certificate form if default endpoint is clicked
    ---
        actual: >
            false
        expected: >
            true
        stack: >
            http://localhost:7357/assets/test-support.js:3830:18
            exception@http://localhost:7357/assets/vendor.js:53385:9
            onerrorDefault@http://localhost:7357/assets/vendor.js:44082:33
            trigger@http://localhost:7357/assets/vendor.js:68351:19
            _onerror@http://localhost:7357/assets/vendor.js:69317:29
            publishRejection@http://localhost:7357/assets/vendor.js:67624:23
            http://localhost:7357/assets/vendor.js:44051:15
            invoke@http://localhost:7357/assets/vendor.js:11571:20
            flush@http://localhost:7357/assets/vendor.js:11635:17
            flush@http://localhost:7357/assets/vendor.js:11436:22
            end@http://localhost:7357/assets/vendor.js:10725:30
            run@http://localhost:7357/assets/vendor.js:10847:21
            run@http://localhost:7357/assets/vendor.js:31688:32
            http://localhost:7357/assets/vendor.js:53624:39
        message: >
            Error: Element [object Object] not found.
        Log: |
    ...
```