### PR TITLE
Update contact support link when creating environments

### DIFF
--- a/app/templates/environment/-form.hbs
+++ b/app/templates/environment/-form.hbs
@@ -38,7 +38,7 @@
             {{else}}
               {{! FIXME Once billing.plans is ready for primetime, update this
               to link there }}
-              {{#link-to-aptible app='support' path='contact'}}
+              {{#link-to-aptible app='contact'}}
                 Contact support to upgrade to PHI ready plan.
               {{/link-to-aptible}}
             {{/if}}


### PR DESCRIPTION
Closes #597 

![](https://cloud.githubusercontent.com/assets/884151/15294030/72b62a74-1b3f-11e6-8b55-862d46671935.png)

Was linking to `support.aptible.com/contact`, corrected to `contact.aptible.com` with test.