### PR TITLE
Make coupon usage label like credit section

### DIFF
--- a/app/organization/billing/index/template.hbs
+++ b/app/organization/billing/index/template.hbs
@@ -60,7 +60,7 @@
           </div>
           <ul class="usage-quote-items">
             <li class="usage-quote-item">
-              <div class="usage-label">{{billingDetail.coupon.id}}</div>
+              <div class="usage-label">Any discounts or coupons applied to your subscription</div>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
Add a little context for what you're looking at instead of just repeating the coupon ID