### PR TITLE
Reopening #625: Add UI for creating and browsing database backups

### DIFF
--- a/app/app/activity/route.js
+++ b/app/app/activity/route.js
@@ -2,18 +2,5 @@ import Ember from 'ember';
 import PaginatedOperations from 'diesel/mixins/routes/paginated-operations';
 
 export default Ember.Route.extend(PaginatedOperations, {
-  paginatedResourceOwnerType: 'app',
-
-  model: function(params){
-    var app = this.modelFor('app');
-    var page = params.currentPage;
-
-    return this.store.find('operation', {app:app, page:page});
-  },
-
-  setupController: function(controller, model){
-    controller.set('model', model);
-
-    this.setPaginationMeta('operation', this.store, controller);
-  }
+  getPaginatedResourceOwnerType: () => 'app'
 });

--- a/app/components/backup-item/component.js
+++ b/app/components/backup-item/component.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  classNameBindings: [':panel', ':panel-default', ':resource-list-item']
+});

--- a/app/components/backup-item/template.hbs
+++ b/app/components/backup-item/template.hbs
@@ -1,0 +1,19 @@
+<div class="panel-heading">
+  <i class="fa fa-hdd-o" aria-hidden="true"></i>
+  {{format-utc-timestamp backup.createdAt }}
+</div>
+
+<div class="panel-body">
+  <ul class="resource-metadata">
+    <li class="resource-metadata-item">
+      <h5 class="resource-metadata-title">Location</h5>
+      <h3 class="resource-metadata-value">{{backup.awsRegion}}</h3>
+    </li>
+    <li class="resource-metadata-item">
+      <h5 class="resource-metadata-title">Actions</h5>
+      <h3 class="resource-metadata-value">
+        {{backup-restore-link backup=backup}}
+      </h3>
+    </li>
+  </ul>
+</div>

--- a/app/components/backup-item/template.hbs
+++ b/app/components/backup-item/template.hbs
@@ -12,7 +12,7 @@
     <li class="resource-metadata-item">
       <h5 class="resource-metadata-title">Actions</h5>
       <h3 class="resource-metadata-value">
-        {{backup-restore-link backup=backup}}
+        {{backup-restore-link backup=backup bindPopover=bindPopovers}}
       </h3>
     </li>
   </ul>

--- a/app/components/backup-restore-link/component.js
+++ b/app/components/backup-restore-link/component.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  // classNameBindings: [':operation-item'],
+  content: Ember.computed("backup.copiedFrom", "backup.database", function() {
+    // TODO: Link to CLI install instructions?
+    // Restoring from a copy is equivalent to restoring from the original,
+    // except it's slower, so we offer the original's ID if there's one.
+    const restoreId = this.get("backup.copiedFrom.id") || this.get("backup.id");
+    const bits = [];
+    bits.push('<p>Use the Aptible CLI to restore this backup to a new database:</p>');
+    bits.push(`<p><code>aptible backup:restore ${restoreId}</code></p>`);
+    return bits.join(" ");
+  })
+});

--- a/app/components/backup-restore-link/template.hbs
+++ b/app/components/backup-restore-link/template.hbs
@@ -1,6 +1,6 @@
 {{#bs-popover
   bs-trigger="click"
-  bs-container=".ember-view.application-wrapper"
+  bs-container=bindPopover
   bs-html=true
   title="Aptible CLI"
   content=content}}

--- a/app/components/backup-restore-link/template.hbs
+++ b/app/components/backup-restore-link/template.hbs
@@ -1,0 +1,8 @@
+{{#bs-popover
+  bs-trigger="click"
+  bs-container=".ember-view.application-wrapper"
+  bs-html=true
+  title="Aptible CLI"
+  content=content}}
+  <a>Restore to a New Database</a>
+{{/bs-popover}}

--- a/app/database/activity/route.js
+++ b/app/database/activity/route.js
@@ -2,18 +2,5 @@ import Ember from 'ember';
 import PaginatedOperations from 'diesel/mixins/routes/paginated-operations';
 
 export default Ember.Route.extend(PaginatedOperations, {
-  paginatedResourceOwnerType: 'database',
-
-  model: function(params){
-    var database = this.modelFor('database');
-    var page = params.currentPage;
-
-    return this.store.find('operation', {database:database, page:page});
-  },
-
-  setupController: function(controller, model){
-    controller.set('model', model);
-
-    this.setPaginationMeta('operation', this.store, controller);
-  }
+  getPaginatedResourceOwnerType: () => 'database'
 });

--- a/app/database/backups/controller.js
+++ b/app/database/backups/controller.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+import Paginated from 'diesel/mixins/controllers/paginated';
+
+export default Ember.Controller.extend(Paginated);

--- a/app/database/backups/route.js
+++ b/app/database/backups/route.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+import Paginated from 'diesel/mixins/routes/paginated';
+
+export default Ember.Route.extend(Paginated, {
+  getPaginatedResourceType: () => 'backup',
+
+  composeQuery(page) {
+    return {
+      database: this.modelFor('database'),
+      page: page
+    };
+  },
+
+  actions: {
+    createBackup: function() {
+      const database = this.modelFor('database');
+
+      return this.get("store").createRecord('operation', {
+        type: 'backup',
+        database: database
+      }).save()
+        .then((operation) => {
+          this.get("flashMessages").success("Backup scheduled");
+          return operation;
+        })
+        .then((operation) => operation.reloadUntilStatusChanged(1000 * 60 * 60 /* minutes */))
+        .then(() => this.refresh());
+    }
+  }
+});

--- a/app/database/backups/template.hbs
+++ b/app/database/backups/template.hbs
@@ -1,0 +1,37 @@
+<div class="row">
+  <div class="col-xs-8">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3>Create a New Database Backup</h3>
+      </div>
+      <div class="panel-body">
+        <p>
+        You can initiate the creation of a new backup at any time. Existing
+        backups are shown below. Note that if you schedule a manual backup,
+        Aptible won't schedule an automated backup for another 24 hours.
+        </p>
+        <button class="btn btn-success btn-lg" {{action 'createBackup'}}>
+          Create New Backup
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<hr>
+
+<div>
+  <div class="row">
+    {{#each model as |backup|}}
+      <div class="col-xs-4">
+        {{backup-item backup=backup}}
+      </div>
+    {{/each}}
+  </div>
+</div>
+
+{{aptible-pagination currentPage=currentPage
+  totalCount=totalCount
+  perPage=perPage
+  nextPage="nextPage"
+  prevPage="prevPage"}}

--- a/app/database/backups/template.hbs
+++ b/app/database/backups/template.hbs
@@ -20,11 +20,12 @@
 
 <hr>
 
-<div>
+{{!-- Don't change backup-list without altering .../backup-restore-link/template.hbs accordingly --}}
+<div class="backup-list">
   <div class="row">
     {{#each model as |backup|}}
       <div class="col-xs-4">
-        {{backup-item backup=backup}}
+        {{backup-item backup=backup bindPopovers=".backup-list"}}
       </div>
     {{/each}}
   </div>

--- a/app/router.js
+++ b/app/router.js
@@ -76,9 +76,10 @@ Router.map(function() {
         path: "databases/:database_id"
       }, function() {
         this.route("activity");
+        this.route("metrics");
+        this.route("backups");
         this.route("replicate");
         this.route("cluster");
-        this.route("metrics");
         this.route("deprovision");
       });
 

--- a/app/templates/database/-nav.hbs
+++ b/app/templates/database/-nav.hbs
@@ -7,6 +7,10 @@
     {{link-to "Metrics" "database.metrics"}}
   {{/activating-item}}
 
+  {{#activating-item currentWhen="database.backups" tagName="li"}}
+    {{link-to "Backups" "database.backups"}}
+  {{/activating-item}}
+
   {{#if model.supportsReplication}}
     {{#activating-item currentWhen="database.replicate" tagName="li"}}
       {{link-to "Replicate" "database.replicate"}}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "0.0.89",
+    "ember-cli-aptible-shared": "0.0.90",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/tests/acceptance/databases/backups-test.js
+++ b/tests/acceptance/databases/backups-test.js
@@ -188,3 +188,42 @@ test(`visit ${backupsPage} shows restore instructions`, function(assert) {
     assert.ok(find(restorePopover).length, 'Restore popover is shown for copy');
   });
 });
+
+test(`navigating away from ${backupsPage} dismisses tooltips`, function(assert) {
+  assert.expect(2);
+
+  const backups = [
+    { id: 0, created_at: '2016-06-12T12:12:12.005Z', aws_region: 'us-east-1',
+      _links: { self: { href: '/backups/0' }}}
+  ];
+
+  stubRequest("get", backupsIndexUrl, function() {
+    return this.success({
+      current_page: 1,
+      per_page: backups.length,
+      total: backups.length,
+      _embedded: { backups: backups }
+    });
+  });
+
+  signInAndVisit(backupsPage);
+
+
+  const restorePopover = '.popover:contains(aptible backup:restore 0)';
+
+  andThen(() => {
+    clickButton("Restore to a New Database");
+  });
+
+  andThen(() => {
+    assert.ok(find(restorePopover).length, 'Restore popover is present');
+  });
+
+  andThen(() => {
+    visit('/');
+  });
+
+  andThen(() => {
+    assert.ok(!find(restorePopover).length, 'Restore popover is gone');
+  });
+});

--- a/tests/acceptance/databases/backups-test.js
+++ b/tests/acceptance/databases/backups-test.js
@@ -1,0 +1,190 @@
+import Ember from 'ember';
+import startApp from '../../helpers/start-app';
+import { stubRequest } from 'diesel/tests/helpers/fake-server';
+
+let App;
+let jqTransitionSupport;
+
+const databaseId = "1",
+      databaseHandle = "my-db-handle",
+      stackHandle = "my-stack-handle",
+      stackId = "my-stack-id",
+      backupsPage = `/databases/${databaseId}/backups`,
+      databaseUrl = `/databases/${databaseId}`,
+      backupsIndexUrl = `${databaseUrl}/backups`;
+
+const stack = {
+  id: stackId,
+  handle: stackHandle
+};
+
+const database = {
+  id: databaseId,
+  handle: databaseHandle,
+  _links: {
+    account: { href: `/accounts/${stackId}` } 
+  }
+};
+
+module('Acceptance: Databases Backups', {
+  beforeEach: function() {
+    // TODO: Should we disable jQuery transitions for all tests (in test-helper.js)?
+    jqTransitionSupport = $.support.transition;
+    $.support.transition = false;
+    App = startApp();
+    stubStacks();
+    stubOrganizations();
+    stubStack(stack);
+    stubDatabase(database);
+  },
+  afterEach: function() {
+    Ember.run(App, 'destroy');
+    $.support.transition = jqTransitionSupport;
+  }
+});
+
+test(`visit ${backupsPage} requires authentication`, function() {
+  expectRequiresAuthentication(backupsPage);
+});
+
+test(`visit ${backupsPage} shows a paginated list of backups`, function(assert) {
+  assert.expect(6);
+
+  const backups = [
+    { id: 3, created_at: '2016-06-13T13:13:13.005Z', aws_region: 'us-east-1' },
+    { id: 2, created_at: '2016-06-12T12:12:12.005Z', aws_region: 'us-east-1' },
+    { id: 1, created_at: '2016-06-11T11:11:11.005Z', aws_region: 'us-east-1' },
+    { id: 0, created_at: '2016-06-10T10:10:10.005Z', aws_region: 'us-east-1' }  // TODO - Copies
+  ];
+  const apiResponses = { 1: [backups[0], backups[1]], 2: [backups[2], backups[3]] };
+
+  stubRequest("get", backupsIndexUrl, function(request) {
+    const page = request.queryParams.page;
+    const apiResponse = apiResponses[page];
+    assert.ok(apiResponse, `Query for page ${page} is valid`);
+
+    return this.success({
+      current_page: parseInt(page, 10),  // page is otherwise a string
+      per_page: 2,
+      total_count: backups.length,
+      _embedded: {
+        backups: apiResponse
+      }
+    });
+  });
+
+  // TODO: Check why copies trigger a reload..
+  signInAndVisit(backupsPage);
+
+  andThen(() => {
+    const firstBackupCell = find('.panel-heading:contains(June 13, 2016 1:13PM UTC)');
+    assert.ok(firstBackupCell.length, 'First backup is shown');
+
+    const secondBackupCell = find('.panel-heading:contains(June 12, 2016 12:12PM UTC)');
+    assert.ok(secondBackupCell.length, 'Second backup is shown');
+  });
+
+  andThen(() => {
+    clickButton("Older items");
+  });
+
+  andThen(() => {
+    const thirdBackupCell = find('.panel-heading:contains(June 11, 2016 11:11AM UTC)');
+    assert.ok(thirdBackupCell.length, 'Third backup is shown');
+
+    const fourthBackupCell = find('.panel-heading:contains(June 10, 2016 10:10AM UTC)');
+    assert.ok(fourthBackupCell.length, 'Fourth backup is shown');
+  });
+});
+
+test(`visit ${backupsPage} allows creating a new backup`, function(assert) {
+  assert.expect(4);
+
+  let operationGetHits = 0;
+  const operationId = 'my-op-id';
+
+  stubRequest("post", `${databaseUrl}/operations`, function(request) {
+    const json = this.json(request);
+    assert.equal(json.type, "backup");
+
+    return this.success({
+      id: operationId,
+      type: json.type,
+      status: 'queued'
+    });
+  });
+
+  stubRequest("get", `/operations/${operationId}`, function() {
+    return this.success({
+      id: operationId,
+      status: ++operationGetHits > 1 ? 'succeeded' : 'running'
+    });
+  });
+
+  let backupGetHits = 0;
+
+  stubRequest("get", backupsIndexUrl, function() {
+    backupGetHits++;
+    return this.success({ _embedded: { backups: [] }});
+  });
+
+  signInAndVisit(backupsPage);
+
+  andThen(() => {
+    assert.equal(backupGetHits, 1, 'Backups are hit once before creating a new backup');
+    clickButton("Create New Backup");
+  });
+
+  andThen(() => {
+    assert.equal(operationGetHits, 2, 'Operation reloads until succeeded');
+    assert.equal(backupGetHits, 2, 'Backups are reloaded once operation succeeds');
+  });
+});
+
+test(`visit ${backupsPage} shows restore instructions`, function(assert) {
+  assert.expect(3);
+
+  const backups = [
+    { id: 1, created_at: '2016-06-13T13:13:13.005Z', aws_region: 'us-west-1',
+      _links: { copied_from: { href: '/backups/0' }}},
+    { id: 0, created_at: '2016-06-12T12:12:12.005Z', aws_region: 'us-east-1',
+      _links: { self: { href: '/backups/0' }}}
+  ];
+
+  stubRequest("get", backupsIndexUrl, function() {
+    return this.success({
+      current_page: 1,
+      per_page: backups.length,
+      total: backups.length,
+      _embedded: { backups: backups }
+    });
+  });
+
+  signInAndVisit(backupsPage);
+
+  let original;
+  let copy;
+  const restoreLabel = "Restore to a New Database";
+  const restorePopover = '.popover:contains(aptible backup:restore 0)';
+
+  andThen(() => {
+    original = find('.panel:contains(June 12, 2016 12:12PM UTC)');
+    copy = find('.panel:contains(June 13, 2016 1:13PM UTC)');
+    clickButton(restoreLabel, { context: original });
+  });
+
+  andThen(() => {
+    assert.ok(find(restorePopover).length, 'Restore popover is shown for original');
+    clickButton(restoreLabel, { context: original });
+  });
+
+  andThen(() => {
+    assert.ok(!find(restorePopover).length, 'Restore popover is hidden');
+    clickButton(restoreLabel, { context: copy });
+  });
+
+  andThen(() => {
+    // This should still show the original's ID because the copy is a copy!
+    assert.ok(find(restorePopover).length, 'Restore popover is shown for copy');
+  });
+});


### PR DESCRIPTION
This reopens #625 with an additional commit to bump the ember-cli-aptible-shared dependency.