### PR TITLE
Add support for ACME VHOSTs 

### DIFF
--- a/app/app/vhosts/index/controller.js
+++ b/app/app/vhosts/index/controller.js
@@ -2,10 +2,16 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   provisionedDomains: Ember.computed.filterBy('model', 'isProvisioned'),
+
+  activeDomains: Ember.computed.filterBy('provisionedDomains', 'hasActionRequired', false),
+  actionRequiredDomains: Ember.computed.filterBy('provisionedDomains', 'hasActionRequired'),
   pendingDomains: Ember.computed.filterBy('model', 'isProvisioning'),
   deprovisionedDomains: Ember.computed.filterBy('model', 'hasBeenDeprovisioned'),
-  hasActive: Ember.computed.gt('provisionedDomains.length', 0),
+
+  hasActive: Ember.computed.gt('activeDomains.length', 0),
+  hasActionRequired: Ember.computed.gt('actionRequiredDomains.length', 0),
   hasPending: Ember.computed.gt('pendingDomains.length', 0),
   hasDeprovisioned: Ember.computed.gt('deprovisionedDomains.length', 0),
-  showSortableHeader: Ember.computed.or('hasPending', 'hasDeprovisioning')
+
+  showSortableHeader: Ember.computed.or('hasActionRequired', 'hasPending', 'hasDeprovisioning')
 });

--- a/app/app/vhosts/index/template.hbs
+++ b/app/app/vhosts/index/template.hbs
@@ -8,12 +8,27 @@
   {{/bs-alert}}
 {{/if}}
 
+{{#if hasActionRequired}}
+  <div class="sort-group active-domains">
+    {{#if showSortableHeader}}
+      <h5 class="sort-header">Endpoints With Action Required</h5>
+    {{/if}}
+    {{#each actionRequiredDomains as |vhost|}}
+      <div class="row">
+        <div class="col-xs-12">
+          {{partial 'app/domain'}}
+        </div>
+      </div>
+    {{/each}}
+  </div>
+{{/if}}
+
 {{#if hasActive}}
   <div class="sort-group active-domains">
     {{#if showSortableHeader}}
       <h5 class="sort-header">Provisioned Endpoints</h5>
     {{/if}}
-    {{#each provisionedDomains as |vhost|}}
+    {{#each activeDomains as |vhost|}}
       <div class="row">
         <div class="col-xs-12">
           {{partial 'app/domain'}}

--- a/app/app/vhosts/new/controller.js
+++ b/app/app/vhosts/new/controller.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
+  certificatesForNewVhost: Ember.computed.filterBy("certificates", "isAcme", false)
 });

--- a/app/app/vhosts/new/route.js
+++ b/app/app/vhosts/new/route.js
@@ -38,6 +38,7 @@ export default Ember.Route.extend({
 
       let promise;
 
+      // TODO: Allow ACME transitional certificates.
       if (vhost.get("isGeneric")) {
         if (vhost.get('certificateBody')) {
           let certificateBody = vhost.get('certificateBody');
@@ -71,7 +72,11 @@ export default Ember.Route.extend({
 
         return op.save();
       }).then(() => {
-        let message = `Endpoint created: ${vhost.get('virtualDomain')}`;
+        let message = `Endpoint created: ${vhost.get('virtualDomain')}.`;
+
+        if (vhost.get("isAcme")) {
+          message += ' Please wait for next steps.';
+        }
 
         this.transitionTo('app.vhosts');
         Ember.get(this, 'flashMessages').success(message);

--- a/app/app/vhosts/new/route.js
+++ b/app/app/vhosts/new/route.js
@@ -38,8 +38,7 @@ export default Ember.Route.extend({
 
       let promise;
 
-      // TODO: Allow ACME transitional certificates.
-      if (vhost.get("isGeneric")) {
+      if (vhost.get("useCertificate")) {
         if (vhost.get('certificateBody')) {
           let certificateBody = vhost.get('certificateBody');
           let privateKey = vhost.get('privateKey');
@@ -60,7 +59,8 @@ export default Ember.Route.extend({
           return vhost.save();
         });
       } else {
-        vhost.set('service', service);
+        vhost.setProperties({service, certificate: null,
+          certificateBody: null, privateKey: null});
         promise = vhost.save();
       }
 

--- a/app/app/vhosts/new/route.js
+++ b/app/app/vhosts/new/route.js
@@ -13,6 +13,7 @@ export default Ember.Route.extend({
     return Ember.RSVP.hash({
       vhost: this.store.createRecord('vhost', { app }),
       services: app.get('services'),
+      vhosts: app.get('vhosts'),
       certificates: stack.get('certificates'),
       stack: stack
     });
@@ -21,14 +22,13 @@ export default Ember.Route.extend({
   setupController(controller, model) {
     var vhost = model.vhost,
         services = model.services,
+        vhosts = model.vhosts,
         certificates = model.certificates;
-
-    vhost.set('isDefault', false);
 
     controller.set('model', vhost);
     controller.set('services', services);
+    controller.set('vhosts', vhosts);
     controller.set('certificates', certificates);
-    controller.set('vhostService', services.objectAt(0));
   },
 
   actions: {
@@ -38,11 +38,8 @@ export default Ember.Route.extend({
 
       let promise;
 
-      if(vhost.get('isDefault')) {
-        vhost.set('service', service);
-        promise = vhost.save();
-      } else {
-        if(vhost.get('certificateBody')) {
+      if (vhost.get("isGeneric")) {
+        if (vhost.get('certificateBody')) {
           let certificateBody = vhost.get('certificateBody');
           let privateKey = vhost.get('privateKey');
           let newCertificate = this.store.createRecord(
@@ -61,6 +58,9 @@ export default Ember.Route.extend({
 
           return vhost.save();
         });
+      } else {
+        vhost.set('service', service);
+        promise = vhost.save();
       }
 
       promise.then(() => {

--- a/app/app/vhosts/new/template.hbs
+++ b/app/app/vhosts/new/template.hbs
@@ -1,1 +1,8 @@
-{{ create-vhost model=model services=services certificates=certificates vhostService=vhostService cancel="cancel" save="save" willTransition="willTransition" }}
+{{create-vhost
+  model=model
+  certificates=certificatesForNewVhost
+  services=services
+  vhosts=vhosts
+  cancel="cancel"
+  save="save"
+  willTransition="willTransition"}}

--- a/app/certificates/index/route.js
+++ b/app/certificates/index/route.js
@@ -12,5 +12,3 @@ export default Ember.Route.extend({
     }
   }
 });
-
-

--- a/app/components/create-vhost/component.js
+++ b/app/components/create-vhost/component.js
@@ -1,29 +1,83 @@
 import Ember from 'ember';
 
+const VHOST_TYPE_GENERIC = 'generic';
+const VHOST_TYPE_DEFAULT = 'default';
+const VHOST_TYPE_ACME = 'acme';
+
+const VHOST_RESET_PROPERTIES = {};
+
+VHOST_RESET_PROPERTIES[VHOST_TYPE_GENERIC] = {
+  "isDefault": false,
+  "acmeDomain": null
+};
+
+VHOST_RESET_PROPERTIES[VHOST_TYPE_DEFAULT] = {
+  "isDefault": true,
+  "acmeDomain": null
+};
+
+VHOST_RESET_PROPERTIES[VHOST_TYPE_ACME] = {
+  "isDefault": false,
+  "internal": false
+};
+
 export default Ember.Component.extend({
   model: null,
   services: null,
+  vhosts: null,
   certificates: null,
+
+  vhostType: null,
   vhostService: null,
-  hasDefaultVhost: false,
+  acmeDomainValid: false,
 
-  setInitialVhostServiceState: function() {
-    this.setHasDefaultVhost(this.get('vhostService'));
-  }.on('didInsertElement'),
+  TYPE_GENERIC: VHOST_TYPE_GENERIC,
+  TYPE_DEFAULT: VHOST_TYPE_DEFAULT,
+  TYPE_ACME: VHOST_TYPE_ACME,
 
-  vhostServiceObserver: function() {
-    this.setHasDefaultVhost(this.get('vhostService'));
-  }.observes('vhostService'),
+  vhostTypeObserver: function() {
+    const vhost = this.get("model");
+    const vhostType = this.get("vhostType") ;
+    const resets = VHOST_RESET_PROPERTIES[vhostType] || {};
 
-
-  setHasDefaultVhost: function(vhostService) {
-    if(vhostService) {
-      vhostService.get('vhosts').then((vhosts) => {
-        let filtered = vhosts.filter((vhost) => vhost.get('isDefault'));
-        this.set('serviceHasDefaultVhost', filtered.length > 0);
-      });
+    for (let k in resets) {
+      if (!resets.hasOwnProperty(k)) {
+        continue;
+      }
+      vhost.set(k, resets[k]);
     }
+  }.observes('vhostType'),
+
+  didInitAttrs() {
+    // Set up some defaults when this component is instantiated.
+    this.set('vhostType', this.get("defaultVhostAllowed") ? VHOST_TYPE_DEFAULT: VHOST_TYPE_ACME);
+    this.set('vhostService', this.get("services").objectAt(0));
+    this.vhostTypeObserver();
   },
+
+  isGeneric: Ember.computed.equal("vhostType", VHOST_TYPE_GENERIC),
+  isDefault: Ember.computed.equal("vhostType", VHOST_TYPE_DEFAULT),
+  isAcme: Ember.computed.equal("vhostType", VHOST_TYPE_ACME),
+
+  placementNeeded: Ember.computed.not("isAcme"),
+  acmeDomainNeeded: Ember.computed.and("isAcme"),
+  certificateNeeded: Ember.computed.and("isGeneric"),
+  defaultVhostAllowed: Ember.computed("vhosts.[]", function() {
+    return !(this.get("vhosts").any((vhost) => {
+      return vhost.get("isDefault");
+    }));
+  }),
+
+  formValid: Ember.computed("vhostType", "acmeDomainValid", function() {
+    if (this.get("isAcme")) {
+      return this.get("acmeDomainValid");
+    }
+    return true;
+  }),
+
+  formInvalid: Ember.computed.not("formValid"),
+
+  formDisabled: Ember.computed.or("formInvalid", "model.isSaving"),
 
   actions: {
     save(vhost, service) {

--- a/app/components/create-vhost/component.js
+++ b/app/components/create-vhost/component.js
@@ -8,16 +8,19 @@ const VHOST_RESET_PROPERTIES = {};
 
 VHOST_RESET_PROPERTIES[VHOST_TYPE_GENERIC] = {
   "isDefault": false,
-  "acmeDomain": null
+  "isAcme": false,
+  "userDomain": null
 };
 
 VHOST_RESET_PROPERTIES[VHOST_TYPE_DEFAULT] = {
   "isDefault": true,
-  "acmeDomain": null
+  "isAcme": false,
+  "userDomain": null
 };
 
 VHOST_RESET_PROPERTIES[VHOST_TYPE_ACME] = {
   "isDefault": false,
+  "isAcme": true,
   "internal": false
 };
 
@@ -29,7 +32,7 @@ export default Ember.Component.extend({
 
   vhostType: null,
   vhostService: null,
-  acmeDomainValid: false,
+  userDomainValid: false,
 
   TYPE_GENERIC: VHOST_TYPE_GENERIC,
   TYPE_DEFAULT: VHOST_TYPE_DEFAULT,
@@ -68,7 +71,7 @@ export default Ember.Component.extend({
   isAcme: Ember.computed.equal("vhostType", VHOST_TYPE_ACME),
 
   placementNeeded: Ember.computed.not("isAcme"),
-  acmeDomainNeeded: Ember.computed.and("isAcme"),
+  userDomainNeeded: Ember.computed.and("isAcme"),
   certificateNeeded: Ember.computed.and("isGeneric"),
 
   defaultVhostAllowed: Ember.computed("vhosts.[]", function() {
@@ -79,9 +82,9 @@ export default Ember.Component.extend({
 
   acmeVhostAllowed: Ember.computed.equal('vhostService.stack.sweetnessStackVersion', 'v2'),
 
-  formValid: Ember.computed("vhostType", "acmeDomainValid", function() {
+  formValid: Ember.computed("vhostType", "userDomainValid", function() {
     if (this.get("isAcme")) {
-      return this.get("acmeDomainValid");
+      return this.get("userDomainValid");
     }
     return true;
   }),

--- a/app/components/create-vhost/component.js
+++ b/app/components/create-vhost/component.js
@@ -9,19 +9,22 @@ const VHOST_RESET_PROPERTIES = {};
 VHOST_RESET_PROPERTIES[VHOST_TYPE_GENERIC] = {
   "isDefault": false,
   "isAcme": false,
-  "userDomain": null
+  "userDomain": null,
+  "useCertificate": true
 };
 
 VHOST_RESET_PROPERTIES[VHOST_TYPE_DEFAULT] = {
   "isDefault": true,
   "isAcme": false,
-  "userDomain": null
+  "userDomain": null,
+  "useCertificate": false
 };
 
 VHOST_RESET_PROPERTIES[VHOST_TYPE_ACME] = {
   "isDefault": false,
   "isAcme": true,
-  "internal": false
+  "internal": false,
+  "useCertificate": false
 };
 
 export default Ember.Component.extend({
@@ -72,7 +75,6 @@ export default Ember.Component.extend({
 
   placementNeeded: Ember.computed.not("isAcme"),
   userDomainNeeded: Ember.computed.and("isAcme"),
-  certificateNeeded: Ember.computed.and("isGeneric"),
 
   defaultVhostAllowed: Ember.computed("vhosts.[]", function() {
     return !(this.get("vhosts").any((vhost) => {

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -20,51 +20,99 @@
               {{ ultimate-select items=services name="service" itemKey="id" itemValue="handle" update=(action (mut vhostService)) selected=vhostService autofocus=true }}
             </div>
 
-          {{#unless serviceHasDefaultVhost}}
               <div class="form-group">
-                <label class="block" for="domain-type">Endpoint type:</label>
+                <label class="block" for="domain-type">
+                  Endpoint type:
+                    {{more-info-icon
+                    title="Choosing an Endpoint Type"
+                    bs-html=true
+                    body="
+                    <p>
+                    For development apps and non-user facing APIs, choose a
+                    <strong>Default Endpoint</strong>: Aptible takes care of
+                    the domain name and SSL certificate for you.
+                    </p>
+                    <p>
+                    For other use cases, a <strong>custom domain with managed
+                    SSL</strong> is a good option: you use your own domain
+                    name, but Aptible handles provisioning and renewing your SSL
+                    certificate.
+                    </p>
+                    <p>
+                    For more advanced use cases, like using an Extended
+                    Validation SSL certificate, use a <strong>custom domain
+                    with a custom SSL certificate</strong> for complete control.
+                    </p>"}}
+
+                </label>
                 <div class="radio">
+                  {{#if defaultVhostAllowed}}
+                    <div>
+                      {{#radio-button value=TYPE_DEFAULT groupValue=vhostType name="domain-type"}}
+                        Use app-{{ model.app.id }}.on-aptible.com default endpoint.
+                      {{/radio-button}}
+                    </div>
+                  {{/if}}
                   <div>
-                    {{#radio-button value=true groupValue=model.isDefault name="domain-type"}}
-                      {{#bs-tooltip placement="bottom" title='A default endpoint has an endpoint address in the format app-${id}.on-aptible.com.' bs-container=false}}
-                          Use app-{{ model.app.id }}.on-aptible.com default endpoint address
-                      {{/bs-tooltip}}
+                    {{#radio-button value=TYPE_ACME groupValue=vhostType name="domain-type"}}
+                        Use a custom domain with managed SSL.
                     {{/radio-button}}
                   </div>
                     <div>
-                      {{#radio-button value=false groupValue=model.isDefault name="domain-type"}}
-                        {{#bs-tooltip placement="bottom" title='Custom endpoints let you use your own certificate and domain name.' bs-container=false}}
-                            Use a custom endpoint address
-                        {{/bs-tooltip}}
+                      {{#radio-button value=TYPE_GENERIC groupValue=vhostType name="domain-type"}}
+                        Use a custom domain and a custom SSL certificate.
                       {{/radio-button}}
                     </div>
                 </div>
               </div>
-          {{/unless}}
 
             <div class="form-group">
-              <label class="block" for="vhost-type">Type</label>
+              <label class="block" for="vhost-type">
+                Endpoint Placement
+                {{more-info-icon
+                  title="Choosing an Endpoint Placement"
+                  bs-html=true
+                  body="
+                    <p>
+                    <strong>External endpoints</strong> are accessible via the
+                    a public internet. Use them for user-facing applications.
+                    </p>
+                    <p>
+                    <strong>Internal endpoints</strong> are only accessible by
+                    other apps in your private Aptible infrastructure. Use them
+                    for internal APIs.
+                    </p>"}}
+              </label>
+              {{#if placementNeeded}}
               <div class="radio">
                 <div>
                   {{#radio-button value=false groupValue=model.internal name="vhost-type"}}
-                    {{#bs-tooltip placement="bottom" title='External endpoints are accessible from the outside internet.' bs-container=false}}
-                        External
-                    {{/bs-tooltip}}
+                    External
                   {{/radio-button}}
                 </div>
                 <div>
-                  {{#radio-button value=true groupValue=model.internal name="vhost-type"}}
-                    {{#bs-tooltip placement="bottom" title='Internal endpoints are only accessible from other apps in your stack.' bs-container=false}}
-                        Internal
-                    {{/bs-tooltip}}
-                  {{/radio-button}}
+                    {{#radio-button value=true groupValue=model.internal name="vhost-type" }}
+                      Internal
+                    {{/radio-button}}
                 </div>
               </div>
+            {{else}}
+              <p>
+                This Endpoint type does not support internal endpoints. The
+                endpoint will be external.
+              </p>
+            {{/if}}
             </div>
 
-          {{#unless model.isDefault}}
+          {{#if acmeDomainNeeded}}
+            {{domain-input domain=model.acmeDomain valid=acmeDomainValid
+              tip="You'll neeed to be able to create a CNAME from this domain
+                  name to a domain name provided by Aptible."}}
+          {{/if}}
+
+          {{#if certificateNeeded}}
             {{select-or-create-certificate certificates=certificates vhost=model}}
-          {{/unless}}
+          {{/if}}
         </div>
       </div>
     </div>
@@ -72,7 +120,7 @@
 
   <div class="resource-actions">
     <button class="btn btn-default" type="reset" {{action 'cancel'}}>Cancel</button>
-    <button class="btn btn-primary" type="submit" {{action 'save' model vhostService}} disabled={{model.isSaving}}>
+    <button class="btn btn-primary" type="submit" {{action 'save' model vhostService}} disabled={{formDisabled}}>
       {{#if model.isSaving}}
           <i class='fa fa-spin fa-spinner'></i> Saving...
       {{else}}

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -119,12 +119,13 @@
             {{/if}}
             </div>
 
-          {{#if acmeDomainNeeded}}
-            {{domain-input domain=model.acmeDomain valid=acmeDomainValid
+          {{#if userDomainNeeded}}
+            {{domain-input domain=model.userDomain valid=userDomainValid
               tip="You'll need to be able to create a CNAME from this domain
                    name to one provided by Aptible."}}
           {{/if}}
 
+          {{! TODO: Allow ACME transitional certificates}}
           {{#if certificateNeeded}}
             {{select-or-create-certificate certificates=certificates vhost=model}}
           {{/if}}

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -3,7 +3,7 @@
     <div class="col-xs-8">
       <div class="panel panel-default ">
         <div class="panel-heading">
-            <h3>Create a new endpoint</h3>
+            <h3>Create a New Endpoint</h3>
         </div>
         <div class="panel-body">
           {{#unless model.isValid}}
@@ -22,26 +22,26 @@
 
               <div class="form-group">
                 <label class="block" for="domain-type">
-                  Endpoint type:
+                  Endpoint Type:
                     {{more-info-icon
                     title="Choosing an Endpoint Type"
                     bs-html=true
                     body="
                     <p>
                     For development apps and non-user facing APIs, choose a
-                    <strong>Default Endpoint</strong>: Aptible takes care of
-                    the domain name and SSL certificate for you.
+                    <strong>Default Endpoint</strong>: Aptible manages both the
+                    domain name and certificate for you.
                     </p>
                     <p>
-                    For other use cases, a <strong>custom domain with managed
-                    SSL</strong> is a good option: you use your own domain
-                    name, but Aptible handles provisioning and renewing your SSL
+                    For other use cases, a <strong>custom domain with Managed
+                    HTTPS</strong> is a good option: you use your own domain
+                    name, but Aptible handles provisioning and renewing your
                     certificate.
                     </p>
                     <p>
                     For more advanced use cases, like using an Extended
-                    Validation SSL certificate, use a <strong>custom domain
-                    with a custom SSL certificate</strong> for complete control.
+                    Validation certificate, use a <strong>custom domain with a
+                    custom certificate</strong> for complete control.
                     </p>"}}
 
                 </label>
@@ -54,7 +54,7 @@
                     {{else}}
                       <label class="disabled">
                         <input type="radio" class="ember-view" disabled>
-                        Default endpoint unavailable: this app already has one.
+                        Default endpoint unavailable: This app already has a default endpoint.
                       </label>
                     {{/if}}
                   </div>
@@ -62,12 +62,12 @@
                   <div>
                     {{#if acmeVhostAllowed}}
                       {{#radio-button value=TYPE_ACME groupValue=vhostType name="domain-type"}}
-                        Use a custom domain with managed SSL.
+                        Use a custom domain with Managed HTTPS.
                       {{/radio-button}}
                     {{else}}
                       <label class="disabled">
                         <input type="radio" class="ember-view" disabled>
-                        Managed SSL unavailable: this feature is not available
+                        Managed HTTPS unavailable: this feature is not available
                         on Aptible legacy infrastructure.
                       </label>
                     {{/if}}
@@ -75,7 +75,7 @@
 
                     <div>
                       {{#radio-button value=TYPE_GENERIC groupValue=vhostType name="domain-type"}}
-                        Use a custom domain and a custom SSL certificate.
+                        Use a custom domain with a custom certificate
                       {{/radio-button}}
                     </div>
                 </div>
@@ -113,7 +113,7 @@
               </div>
             {{else}}
               <p>
-                This Endpoint type does not support internal endpoints. The
+                This Endpoint type does not support internal placement. The
                 endpoint will be external.
               </p>
             {{/if}}
@@ -121,7 +121,7 @@
 
           {{#if userDomainNeeded}}
             {{domain-input domain=model.userDomain valid=userDomainValid
-              tip="You'll need to be able to create a CNAME from this domain
+              tip="You will need to be able to create a CNAME from this domain
                    name to one provided by Aptible."}}
           {{/if}}
 
@@ -131,12 +131,12 @@
                 Transitional Certificate
               </label>
               <p>
-                Managed SSL provisions a certificate for you, but this process
-                takes a little while. During this time, your application will
-                be unavailable. If you need to avoid downtime, you can provide
-                a transitional certificate, which will let Aptible provision
-                your Managed SSL certificate in the background, while your app
-                is running.
+                Managed HTTPS provisions a certificate for you, but this
+                process takes a little while. During this time, your
+                application will be unavailable. If you need to avoid downtime,
+                you can provide a transitional certificate, which will let
+                Aptible provision your Managed HTTPS certificate in the
+                background, while your app is running.
               </p>
               {{input type="checkbox"
                 name="acme-use-transitional"

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -125,8 +125,30 @@
                    name to one provided by Aptible."}}
           {{/if}}
 
-          {{! TODO: Allow ACME transitional certificates}}
-          {{#if certificateNeeded}}
+          {{#if isAcme}}
+            <div class="form-group">
+              <label class="block">
+                Transitional Certificate
+              </label>
+              <p>
+                Managed SSL provisions a certificate for you, but this process
+                takes a little while. During this time, your application will
+                be unavailable. If you need to avoid downtime, you can provide
+                a transitional certificate, which will let Aptible provision
+                your Managed SSL certificate in the background, while your app
+                is running.
+              </p>
+              {{input type="checkbox"
+                name="acme-use-transitional"
+                id="acme-use-transitional"
+                checked=model.useCertificate}}
+                <label for="acme-use-transitional">
+                  Use a transitional certificate (recommended if your application is already live)
+                </label>
+            </div>
+          {{/if}}
+
+          {{#if model.useCertificate}}
             {{select-or-create-certificate certificates=certificates vhost=model}}
           {{/if}}
         </div>

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -46,18 +46,33 @@
 
                 </label>
                 <div class="radio">
-                  {{#if defaultVhostAllowed}}
-                    <div>
+                  <div>
+                    {{#if defaultVhostAllowed}}
                       {{#radio-button value=TYPE_DEFAULT groupValue=vhostType name="domain-type"}}
                         Use app-{{ model.app.id }}.on-aptible.com default endpoint.
                       {{/radio-button}}
-                    </div>
-                  {{/if}}
-                  <div>
-                    {{#radio-button value=TYPE_ACME groupValue=vhostType name="domain-type"}}
-                        Use a custom domain with managed SSL.
-                    {{/radio-button}}
+                    {{else}}
+                      <label class="disabled">
+                        <input type="radio" class="ember-view" disabled>
+                        Default endpoint unavailable: this app already has one.
+                      </label>
+                    {{/if}}
                   </div>
+
+                  <div>
+                    {{#if acmeVhostAllowed}}
+                      {{#radio-button value=TYPE_ACME groupValue=vhostType name="domain-type"}}
+                        Use a custom domain with managed SSL.
+                      {{/radio-button}}
+                    {{else}}
+                      <label class="disabled">
+                        <input type="radio" class="ember-view" disabled>
+                        Managed SSL unavailable: this feature is not available
+                        on Aptible legacy infrastructure.
+                      </label>
+                    {{/if}}
+                  </div>
+
                     <div>
                       {{#radio-button value=TYPE_GENERIC groupValue=vhostType name="domain-type"}}
                         Use a custom domain and a custom SSL certificate.

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -121,8 +121,8 @@
 
           {{#if acmeDomainNeeded}}
             {{domain-input domain=model.acmeDomain valid=acmeDomainValid
-              tip="You'll neeed to be able to create a CNAME from this domain
-                  name to a domain name provided by Aptible."}}
+              tip="You'll need to be able to create a CNAME from this domain
+                   name to one provided by Aptible."}}
           {{/if}}
 
           {{#if certificateNeeded}}

--- a/app/components/domain-input/component.js
+++ b/app/components/domain-input/component.js
@@ -1,0 +1,26 @@
+import Ember from "ember";
+
+// Intentionally permissive. We don't care about validation as much as
+// preventing obvious mistakes.
+export const BASIC_DOMAIN_REGEXP = /^[a-z0-9\-.]+\.[a-z]+$/i;
+
+export default Ember.Component.extend({
+  domain: null,
+  valid: null,
+  tip: null,
+
+  domainValid: Ember.computed("domain", function() {
+    return BASIC_DOMAIN_REGEXP.test(this.get("domain"));
+  }),
+
+  errorClass: Ember.computed("domainValid", function() {
+    if (this.get("domainValid")) {
+      return "";
+    }
+    return "has-error";
+  }),
+
+  domainValidObserver: function() {
+    this.set("valid", this.get("domainValid"));
+  }.observes("domainValid")
+});

--- a/app/components/domain-input/template.hbs
+++ b/app/components/domain-input/template.hbs
@@ -1,0 +1,11 @@
+<div class="form-group {{ errorClass }}">
+  <label class="block" for={{concat elementId '-domain'}}>Domain Name</label>
+  {{#if tip}}
+    <p>{{tip}}</p>
+  {{/if}}
+  {{input type="text"
+    name=(concat elementId '-domain')
+    value=domain
+    class="form-control"
+    placeholder="www.example.com"}}
+</div>

--- a/app/components/vhost-action-required-acme/component.js
+++ b/app/components/vhost-action-required-acme/component.js
@@ -1,0 +1,84 @@
+import Ember from 'ember';
+
+const RENEW_TIMEOUT = 1000 * 60 * 5; // 5 minutes
+const PROVISION_TIMEOUT = 1000 * 60 * 10; // 10 minutes
+
+export default Ember.Component.extend({
+  store: Ember.inject.service(),
+  flashMessages: Ember.inject.service(),
+
+  actionLabel: "I Created The CNAME",
+  isRenewing: false,
+
+  actions: {
+    renew() {
+      const vhost = this.get("vhost");
+
+      this.get('store').createRecord('operation', {
+        type: 'renew',
+        vhost: vhost
+      }).save().then((operation) => {
+        this.set('isRenewing', true);
+        return operation;
+      }).then((operation) => {
+        return operation.reloadUntilStatusChanged(RENEW_TIMEOUT);
+      }).then(() => {
+        const m = "Certificate generation succeeded; Aptible will finalize " +
+                  "your endpoint set up momentarily.";
+        this.get("flashMessages").success(m);
+
+        // Once the renew operation completes, we'll have to wait for a
+        // provision operation to complete to deploy the cert. Let's find it
+        // and wait for that one.
+        return vhost.reload().then((vhost) => {
+          return vhost.get("operations");
+        }).then((operations) => {
+          const provisionOperation = operations.find((operation) => {
+            return operation.get("type") === "provision";
+          });
+
+          if (!provisionOperation) {
+            throw new Error("Found no provision operation!");
+          }
+
+          const infoMessage = "Your endpoint is ready.";
+
+          if (provisionOperation.get("isDone")) {
+            // If the operation already succeeded, we're done.
+            this.get("flashMessages").success(infoMessage);
+            return vhost.reload();
+          }
+
+          return provisionOperation.reloadUntilStatusChanged(PROVISION_TIMEOUT).then(() => {
+            // Otherwise, let's wait until it completes.
+            this.get("flashMessages").success(infoMessage);
+            return vhost.reload();
+          });
+        });
+      }).catch((e) => {
+        // Default to a generic error message, but be more specific if an
+        // operation is attached.
+        let errorMessage = `An unexpected error occurred: ${e.message}`;
+
+        if (e.operation && e.operation.get("status") === "failed") {
+          if (e.operation.get("type") === "renew") {
+            errorMessage = "Failed to generate certificate. Please verify the CNAME " +
+                           "is set up correctly, and try again in a few minutes.";
+          }
+          if (e.operation.get("type") === "provision") {
+            errorMessage = "Failed to install certificate. Please try again.";
+          }
+        }
+
+        this.get("flashMessages").danger(errorMessage);
+      }).finally(() => {
+        // We need to be a little careful here: if our renewal succeeds, this
+        // component is going to get torn down, and setting isRenewing back to
+        // false could throw an exception.
+        if (!(this.get('isDestroyed') || this.get('isDestroying'))) {
+          this.set('isRenewing', false);
+        }
+      });
+    }
+  }
+});

--- a/app/components/vhost-action-required-acme/template.hbs
+++ b/app/components/vhost-action-required-acme/template.hbs
@@ -20,7 +20,7 @@
 {{#if vhost.acmeIsTransitioning}}
 <p>
 Note: you have provided a transitional certificate. Your app will be available
-once you switch over DNS, and Managed SSL setup will happen in the background.
+once you switch over DNS, and Managed HTTPS setup will happen in the background.
 </p>
 {{/if}}
 

--- a/app/components/vhost-action-required-acme/template.hbs
+++ b/app/components/vhost-action-required-acme/template.hbs
@@ -4,9 +4,25 @@
 </p>
 
 <p>
-  Once you've done so, click <i>{{actionLabel}}</i>, and Aptible will attempt to
-  generate a SSL certificate for your domain.
+  Once you've done so, click <strong>{{actionLabel}}</strong>, and Aptible will
+  attempt to generate a new SSL certificate for your domain.
 </p>
+
+{{#if vhost.acmeIsPending}}
+<p>
+<strong>
+  Note: you have not provided a transitional certificate. Your app will be
+  temporarily unavailable once you switch over DNS.
+</strong>
+</p>
+{{/if}}
+
+{{#if vhost.acmeIsTransitioning}}
+<p>
+Note: you have provided a transitional certificate. Your app will be available
+once you switch over DNS, and Managed SSL setup will happen in the background.
+</p>
+{{/if}}
 
 <button class="btn btn-default btn-xs" href="#" {{action 'renew'}} disabled={{isRenewing}}>
   {{#if isRenewing}}

--- a/app/components/vhost-action-required-acme/template.hbs
+++ b/app/components/vhost-action-required-acme/template.hbs
@@ -1,6 +1,6 @@
 <p>
   You must set up a CNAME via your DNS provider from
-  <code>{{vhost.acmeDomain}}</code> to <code>{{vhost.externalHost}}</code>.
+  <code>{{vhost.userDomain}}</code> to <code>{{vhost.externalHost}}</code>.
 </p>
 
 <p>

--- a/app/components/vhost-action-required-acme/template.hbs
+++ b/app/components/vhost-action-required-acme/template.hbs
@@ -1,0 +1,17 @@
+<p>
+  You must set up a CNAME via your DNS provider from
+  <code>{{vhost.acmeDomain}}</code> to <code>{{vhost.externalHost}}</code>.
+</p>
+
+<p>
+  Once you've done so, click <i>{{actionLabel}}</i>, and Aptible will attempt to
+  generate a SSL certificate for your domain.
+</p>
+
+<button class="btn btn-default btn-xs" href="#" {{action 'renew'}} disabled={{isRenewing}}>
+  {{#if isRenewing}}
+    Please Wait...
+  {{else}}
+    {{actionLabel}}
+  {{/if}}
+</button>

--- a/app/components/vhost-action-required/component.js
+++ b/app/components/vhost-action-required/component.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  actionComponents: Ember.computed("vhost.actionsRequired.[]", function() {
+    return this.get("vhost.actionsRequired").map((action) => {
+      return `vhost-action-required-${action}`;
+    });
+  })
+});

--- a/app/components/vhost-action-required/template.hbs
+++ b/app/components/vhost-action-required/template.hbs
@@ -1,0 +1,9 @@
+{{#each actionComponents as |componentName|}}
+  <p>
+    <strong>
+      <i class="fa fa-warning"></i>
+      Action Required
+    </strong>
+  </p>
+  {{component componentName vhost=vhost}}
+{{/each}}

--- a/app/services/metrics-api.js
+++ b/app/services/metrics-api.js
@@ -9,7 +9,7 @@ function errorToMessage(e) {
     case 400:
       return "Metrics server declined to serve the request";
     case 404:
-      return "No data available. If you just launched your containers, please try again later. Otherwise, please contact support (metrics are not available on some Aptible legacy stacks)";
+      return "No data available. If you just launched your containers, please try again later. Otherwise, please contact support (metrics are partially unavailable on Aptible legacy infrastructure)";
     case 500:
       return "Metrics server is unavailable; please try again later";
     default:

--- a/app/styles/components/_labels.scss
+++ b/app/styles/components/_labels.scss
@@ -6,7 +6,7 @@
   background-color: #2BA4EF;
   border-radius: 3px;
   font-size: 11px;
-  padding: 5px 8px;
+  padding: 7px 8px 8px;
   text-transform: uppercase;
   font-weight: $weight-semibold;
 }

--- a/app/styles/components/_typography.scss
+++ b/app/styles/components/_typography.scss
@@ -24,3 +24,6 @@
   margin-bottom: 5px;
   text-transform: uppercase;
 }
+label.disabled {
+  color: #999;
+}

--- a/app/templates/app/-domain.hbs
+++ b/app/templates/app/-domain.hbs
@@ -30,7 +30,7 @@
       {{/if}}
 
       {{#if vhost.isAcme}}
-        <span class="label label-success">Managed SSL</span>
+        <span class="label label-success">Managed HTTPS</span>
       {{/if}}
 
       {{#if vhost.isProvisioned}}

--- a/app/templates/app/-domain.hbs
+++ b/app/templates/app/-domain.hbs
@@ -19,42 +19,52 @@
     </h3>
 
     <div class="panel-heading-actions">
-      {{#if vhost.isDefault}}
-        <span class="label label-default">Default</span>
-        {{delete-vhost vhost=vhost startDeletion="startDeletion"
-                                  failDeletion="failDeletion"
-                                  completeDeletion="completeDeletion"}}
-      {{else}}
+      {{#if vhost.isGeneric}}
         {{#if vhost.isProvisioned}}
           {{link-to 'Edit' 'app.vhosts.edit' vhost.id class="btn btn-default btn-xs"}}
-          {{delete-vhost vhost=vhost startDeletion="startDeletion"
-                                    failDeletion="failDeletion"
-                                    completeDeletion="completeDeletion"}}
         {{/if}}
+      {{/if}}
+
+      {{#if vhost.isDefault}}
+        <span class="label label-default">Default</span>
+      {{/if}}
+
+      {{#if vhost.isAcme}}
+        <span class="label label-success">Managed SSL</span>
+      {{/if}}
+
+      {{#if vhost.isProvisioned}}
+        {{delete-vhost vhost=vhost startDeletion="startDeletion"
+                                   failDeletion="failDeletion"
+                                   completeDeletion="completeDeletion"}}
       {{/if}}
     </div>
   </div>
 
   <div class="panel-body">
     <div class="resource-metadata-item">
-      {{#if vhost.displayHost}}
-        <h5 class="resource-metadata-title">
-          {{#if vhost.internal}}
-            Internal
-          {{else}}
-            External
-          {{/if}}
-
-          Hostname
-        </h5>
-        <h3 class="resource-metadata-value">
-          <div class="external-host">
-            {{vhost.displayHost}}
-            {{click-to-copy text=vhost.displayHost}}
-          </div>
-        </h3>
+      {{#if vhost.hasActionRequired}}
+        {{vhost-action-required vhost=vhost}}
       {{else}}
-        <h3 class="resource-metadata-value">{{vhost.commonName}} is {{vhost.status}}...</h3>
+        {{#if vhost.displayHost}}
+          <h5 class="resource-metadata-title">
+            {{#if vhost.internal}}
+              Internal
+            {{else}}
+              External
+            {{/if}}
+
+            Hostname
+          </h5>
+          <h3 class="resource-metadata-value">
+            <div class="external-host">
+              {{vhost.displayHost}}
+              {{click-to-copy text=vhost.displayHost}}
+            </div>
+          </h3>
+        {{else}}
+          <h3 class="resource-metadata-value">{{vhost.commonName}} is {{vhost.status}}...</h3>
+        {{/if}}
       {{/if}}
     </div>
   </div>

--- a/app/templates/stack/-certificate.hbs
+++ b/app/templates/stack/-certificate.hbs
@@ -2,12 +2,13 @@
   <div class="panel-heading with-actions">
     <h3>{{certificate.commonName}}</h3>
     <div class="panel-heading-actions">
+      {{#if certificate.isAcme}}
+        <span class="label label-success">Managed SSL</span>
+      {{/if}}
       {{#if certificate.inUse}}
-        {{#bs-tooltip placement="bottom" title="This certificate is currently in use and cannot be deleted." bs-container=false}}
-          <div>
-            <button class="btn btn-default btn-xs" disabled>Delete</button>
-          </div>
-        {{/bs-tooltip}}
+        {{! REVIEW: This used to have a tooltip, but it doesn't work on a
+            disabled object, and breaks layout. Are we OK losing it?}}
+        <button class="btn btn-default btn-xs" disabled>Delete</button>
       {{else}}
         <button class="btn btn-default btn-xs" {{action "delete" certificate}}>Delete</button>
       {{/if}}

--- a/app/templates/stack/-certificate.hbs
+++ b/app/templates/stack/-certificate.hbs
@@ -3,7 +3,7 @@
     <h3>{{certificate.commonName}}</h3>
     <div class="panel-heading-actions">
       {{#if certificate.isAcme}}
-        <span class="label label-success">Managed SSL</span>
+        <span class="label label-success">Managed HTTPS</span>
       {{/if}}
       {{#if certificate.inUse}}
         <button class="btn btn-default btn-xs" disabled>

--- a/app/templates/stack/-certificate.hbs
+++ b/app/templates/stack/-certificate.hbs
@@ -6,9 +6,12 @@
         <span class="label label-success">Managed SSL</span>
       {{/if}}
       {{#if certificate.inUse}}
-        {{! REVIEW: This used to have a tooltip, but it doesn't work on a
-            disabled object, and breaks layout. Are we OK losing it?}}
-        <button class="btn btn-default btn-xs" disabled>Delete</button>
+        <button class="btn btn-default btn-xs" disabled>
+          Delete
+          {{more-info-icon
+            title="In use"
+            body="This certificate is currently in use and cannot be deleted."}}
+        </button>
       {{else}}
         <button class="btn btn-default btn-xs" {{action "delete" certificate}}>Delete</button>
       {{/if}}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.15",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-aptible-shared": "0.0.104",
+    "ember-cli-aptible-shared": "0.0.105",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",

--- a/tests/acceptance/apps/vhost-new-test.js
+++ b/tests/acceptance/apps/vhost-new-test.js
@@ -424,10 +424,10 @@ test(`visit ${appVhostsNewUrl} and create default endpoint`, function(assert) {
 });
 
 test(`visit ${appVhostsNewUrl} and create managed endpoint`, function(assert) {
-  assert.expect(9);
+  assert.expect(11);
 
-  const acmeDomainInputSelector = "input[type=text]";
-  const acmeDomain = "some.domain.com";
+  const userDomainInputSelector = "input[type=text]";
+  const userDomain = "some.domain.com";
   const vhostId = "new-vhost-id";
 
   setupStubs();
@@ -440,7 +440,9 @@ test(`visit ${appVhostsNewUrl} and create managed endpoint`, function(assert) {
     assert.equal(json.certificate_body, null, "Certificate body is NULL");
     assert.equal(json.private_key, null, "Certificate key is NULL");
     assert.equal(json.type, "http_proxy_protocol", "Proxy protocol is set");
-    assert.equal(json.acme_domain, acmeDomain, "ACME domain is set");
+    assert.equal(json.user_domain, userDomain, "User domain is set");
+    assert.equal(json.acme, true, "ACME is set");
+    assert.equal(json.default, false, "Default is not set");
 
     return this.success({id:vhostId});
   });
@@ -461,13 +463,13 @@ test(`visit ${appVhostsNewUrl} and create managed endpoint`, function(assert) {
     const saveButton = findWithAssert("button:contains(Save Endpoint)");
     assert.ok(saveButton.attr("disabled"), "Save button is disabled");
 
-    const acmeDomainInput = findWithAssert(acmeDomainInputSelector);
-    const acmeDomainInputhasError = acmeDomainInput.parent(".form-group").attr("class").indexOf("has-error") > 0;
-    assert.ok(acmeDomainInputhasError, "ACME Domain input has error");
+    const userDomainInput = findWithAssert(userDomainInputSelector);
+    const userDomainInputhasError = userDomainInput.parent(".form-group").attr("class").indexOf("has-error") > 0;
+    assert.ok(userDomainInputhasError, "User Domain input has error");
   });
 
   andThen(() => {
-    fillIn(findWithAssert(acmeDomainInputSelector), acmeDomain);
+    fillIn(findWithAssert(userDomainInputSelector), userDomain);
   });
 
   andThen(function(){

--- a/tests/acceptance/apps/vhost-new-test.js
+++ b/tests/acceptance/apps/vhost-new-test.js
@@ -128,7 +128,7 @@ test(`visit ${appVhostsNewUrl} shows creation form`, function(assert) {
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
+    assert.ok(find('.panel-heading:contains(Create a New Endpoint)').length,
        'has header');
     expectInput('service', {input:'select'});
     expectFocusedInput('service', {input:'select'});
@@ -149,11 +149,11 @@ test(`visit ${appVhostsNewUrl} shows creation form with existing certificates`, 
   });
 
   andThen(() => {
-    click(findWithAssert('label:contains(custom SSL)'));
+    click(findWithAssert('label:contains(custom certificate)'));
   });
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
+    assert.ok(find('.panel-heading:contains(Create a New Endpoint)').length,
        'has header');
     expectInput('domain-type', {input:'radio'});
     expectInput('service', {input:'select'});
@@ -188,11 +188,11 @@ test(`visit ${appVhostsNewUrl} shows creation form without certificates`, functi
   });
 
   andThen(() => {
-    click(findWithAssert('label:contains(custom SSL)'));
+    click(findWithAssert('label:contains(custom certificate)'));
   });
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
+    assert.ok(find('.panel-heading:contains(Create a New Endpoint)').length,
        'has header');
     expectInput('domain-type', {input:'radio'});
     expectInput('service', {input:'select'});
@@ -213,12 +213,12 @@ test(`visit ${appVhostsNewUrl} should remove certificate form if default endpoin
   });
 
   andThen(() => {
-    click(findWithAssert('label:contains(custom SSL)'));
+    click(findWithAssert('label:contains(custom certificate)'));
   });
 
   Error.stackTraceLimit = 1000;
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
+    assert.ok(find('.panel-heading:contains(Create a New Endpoint)').length,
       'has header');
 
     expectInput('domain-type', {input:'radio'});
@@ -245,7 +245,7 @@ test(`visit ${appVhostsNewUrl} shows creation form for app with existing default
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
+    assert.ok(find('.panel-heading:contains(Create a New Endpoint)').length,
       'has header');
 
     findWithAssert('label:contains(Default endpoint unavailable)');
@@ -264,7 +264,7 @@ test(`visit ${appVhostsNewUrl} shows creation form for app with existing default
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
+    assert.ok(find('.panel-heading:contains(Create a New Endpoint)').length,
       'has header');
 
     findWithAssert('label:contains(Default endpoint unavailable)');
@@ -283,10 +283,10 @@ test(`visit ${appVhostsNewUrl} shows creation form for app on v1 stack`, functio
   signInAndVisit(appVhostsNewUrl);
 
   andThen(function(){
-    assert.ok(find('.panel-heading:contains(Create a new endpoint)').length,
+    assert.ok(find('.panel-heading:contains(Create a New Endpoint)').length,
       'has header');
 
-    findWithAssert('label:contains(Managed SSL unavailable)');
+    findWithAssert('label:contains(Managed HTTPS unavailable)');
     expectInput('service', {input:'select'});
     expectFocusedInput('service', {input:'select'});
     expectInput('domain-type', {input:'radio'});
@@ -332,7 +332,7 @@ test(`visit ${appVhostsNewUrl} and create vhost with existing certificates`, fun
   signInAndVisit(appVhostsNewUrl);
 
   andThen(() => {
-    click(findWithAssert('label:contains(custom SSL)'));
+    click(findWithAssert('label:contains(custom certificate)'));
   });
 
   andThen(function(){
@@ -378,7 +378,7 @@ test(`visit ${appVhostsNewUrl} and create vhost with new certificate`, function(
   signInAndVisit(appVhostsNewUrl);
 
   andThen(() => {
-    click(findWithAssert('label:contains(custom SSL)'));
+    click(findWithAssert('label:contains(custom certificate)'));
   });
 
   andThen(function(){
@@ -461,7 +461,7 @@ test(`visit ${appVhostsNewUrl} and create managed endpoint`, function(assert) {
   signInAndVisit(appVhostsNewUrl);
 
   andThen(() => {
-    click(findWithAssert("label:contains(managed SSL)"));
+    click(findWithAssert("label:contains(Managed HTTPS)"));
   });
 
   andThen(() => {
@@ -519,7 +519,7 @@ test(`visit ${appVhostsNewUrl} and create a new transitonal managed endpoint`, f
   signInAndVisit(appVhostsNewUrl);
 
   andThen(() => {
-    click(findWithAssert("label:contains(managed SSL)"));
+    click(findWithAssert("label:contains(Managed HTTPS)"));
   });
 
   andThen(() => {

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -137,13 +137,15 @@ test(`visit ${appVhostsUrl} lists active endpoints`, function(assert) {
   });
 });
 
-test(`visit ${appVhostsUrl} lists endpoints with action required`, function(assert) {
+test(`visit ${appVhostsUrl} lists endpoints with action required with tips`, function(assert) {
+  assert.expect(15);
+
   var vhosts = [{
     id: 1,
     virtual_domain: 'www.health1.io',
     user_domain: 'www.health1.io',
     acme: true,
-    acme_status: 'transitional',
+    acme_status: 'transitioning',
     external_host: 'www.host1.com',
     status: 'provisioned',
   },{
@@ -168,7 +170,7 @@ test(`visit ${appVhostsUrl} lists endpoints with action required`, function(asse
 
   signInAndVisit(appVhostsUrl);
 
-  andThen(function(){
+  andThen(() => {
     assert.equal(find('.vhost').length, vhosts.length);
 
     vhosts.forEach(function(vhost, index){
@@ -185,6 +187,15 @@ test(`visit ${appVhostsUrl} lists endpoints with action required`, function(asse
       assert.ok(vhostEl.find(":contains(Action Required)").length,
          "has Action Required label");
 
+      if (vhost.acme_status === 'pending') {
+        assert.ok(vhostEl.find(":contains(temporarily unavailable)").length,
+                  "has temporarily unavailable tip");
+      } else {
+        assert.ok(vhostEl.find(":contains(in the background)").length,
+                  "has background tip");
+      }
+
+      // Note: those count in assert.expect
       expectNoButton('Edit', {context:vhostEl});
       expectButton('Delete', {context:vhostEl});
     });

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -137,6 +137,56 @@ test(`visit ${appVhostsUrl} lists active endpoints`, function(assert) {
   });
 });
 
+test(`visit ${appVhostsUrl} lists endpoints with action required`, function(assert) {
+  var vhosts = [{
+    id: 1,
+    virtual_domain: 'www.health1.io',
+    acme_domain: 'www.health1.io',
+    external_host: 'www.host1.com',
+    status: 'provisioned',
+  },{
+    id: 2,
+    virtual_domain: 'www.health2.io',
+    acme_domain: 'www.health2.io',
+    external_host: 'www.host2.com',
+    status: 'provisioned'
+  }];
+
+  stubApp({
+    id: appId,
+    _embedded: { services: [] },
+    _links: { vhosts: { href: appVhostsApiUrl } }
+  });
+
+  stubRequest('get', appVhostsApiUrl, function(){
+    return this.success({ _embedded: { vhosts: vhosts } });
+  });
+
+  signInAndVisit(appVhostsUrl);
+
+  andThen(function(){
+    assert.equal(find('.vhost').length, vhosts.length);
+
+    vhosts.forEach(function(vhost, index){
+      let vhostEl = find(`.vhost:eq(${index})`);
+      assert.ok(vhostEl.find(`:contains(${vhost.virtual_domain})`).length,
+         `has endpoint "${vhost.virtual_domain}"`);
+
+      assert.ok(vhostEl.find(`:contains(${vhost.external_host})`).length,
+         `has external host "${vhost.external_host}"`);
+
+      assert.ok(vhostEl.find("button:contains(I Created The CNAME)").length,
+         "has I Created The CNAME button");
+
+      assert.ok(vhostEl.find(":contains(Action Required)").length,
+         "has Action Required label");
+
+      expectNoButton('Edit', {context:vhostEl});
+      expectButton('Delete', {context:vhostEl});
+    });
+  });
+});
+
 test(`visit ${appVhostsUrl} lists pending vhosts`, function(assert) {
   var vhosts = [{
     id: 0,
@@ -281,9 +331,7 @@ test(`visit ${appVhostsUrl} and delete endpoint has error`, function(assert) {
 
   stubRequest('get', appVhostsApiUrl, function(){
     return this.success({ _embedded: { vhosts: vhosts } });
-  });
-
-  stubRequest('post', `/vhosts/${vhostId}/operations`, function(request){
+  }); stubRequest('post', `/vhosts/${vhostId}/operations`, function(request){
     this.json(request);
     return this.error(401, {});
   });
@@ -298,5 +346,221 @@ test(`visit ${appVhostsUrl} and delete endpoint has error`, function(assert) {
     assert.ok(alert.length, 'displays error div');
     assert.ok(alert.text().indexOf(errorMessage) > -1,
        `Displays error message "${errorMessage}"`);
+  });
+});
+
+function setupAcmeStubs(assert, options) {
+  options = options || {};
+  const renewFinalStatus = options.renewSucceeds ? 'succeeded' : 'failed';
+  const provisionFinalStatus = options.provisionSucceeds ? 'succeeded' : 'failed';
+
+  const vhostId = "vhost-1";
+
+  const vhost = {
+    id: vhostId,
+    acme_domain: "www.health.io",
+    status: "provisioned",
+    _links: {
+      self: { href: `/vhosts/${vhostId}` },
+      operations: { href: `/vhosts/${vhostId}/operations` }
+    }
+  };
+
+  const certificate = { id: 'cert-1', _links: { self: { href: "/certificates/cert-1" } } };
+
+  const operations = [];
+  const renewOperation = { id: "operation-123", type: "renew" };
+  const provisionOperation = { id: "operation-456", type: "provision" };
+
+  const createRenew = () => {
+    if (options.renewStartsQueued) {
+      renewOperation.status = "queued";
+    } else {
+      completeRenew();
+    }
+    operations.unshift(renewOperation);
+  };
+
+  const completeRenew = () => {
+    renewOperation.status = renewFinalStatus;
+    if (options.renewTriggersProvision) {
+      createProvision();
+    }
+  };
+
+  const createProvision = () => {
+    if (options.provisionStartsQueued) {
+      provisionOperation.status = "queued";
+    } else {
+      completeProvision();
+    }
+    operations.unshift(provisionOperation);
+  };
+
+  const completeProvision = () => {
+    provisionOperation.status = provisionFinalStatus;
+    if (provisionFinalStatus === "succeeded") {
+      vhost._links.certificate = certificate._links.self;
+    }
+  };
+
+  stubApp({
+    id: appId,
+    _embedded: { services: [] },
+    _links: { vhosts: { href: appVhostsApiUrl } }
+  });
+
+  stubRequest("get", appVhostsApiUrl, function(){
+    return this.success({ _embedded: { vhosts: [vhost] } });
+  });
+
+  stubRequest("post", `/vhosts/${vhostId}/operations`, function(request){
+    const json = this.json(request);
+    assert.equal(json.type, "renew", "creates renew operation");
+    createRenew();
+    return this.success(renewOperation);
+  });
+
+  stubRequest("get", `/vhosts/${vhostId}/operations`, function() {
+    return this.success({ _embedded: { operations: operations }});
+  });
+
+  stubRequest("get", `/vhosts/${vhostId}`, function() {
+    return this.success(vhost);
+  });
+
+  stubRequest("get", `/operations/${renewOperation.id}`, function() {
+    completeRenew();
+    return this.success(renewOperation);
+  });
+
+  stubRequest("get", `/operations/${provisionOperation.id}`, function() {
+    completeProvision();
+    return this.success(provisionOperation);
+  });
+
+  stubRequest("get", certificate._links.self.href, function() {
+    return this.success(certificate);
+  });
+}
+
+test(`visit ${appVhostsUrl} allows renewing an unitialized ACME cert (delayed success)`, function(assert) {
+  assert.expect(3);
+
+  setupAcmeStubs(assert, {
+    renewStartsQueued: true,
+    renewSucceeds: true,
+
+    provisionStartsQueued: true,
+    provisionSucceeds: true,
+
+    renewTriggersProvision: true
+  });
+
+  const buttonLabel = "I Created The CNAME";
+
+  signInAndVisit(appVhostsUrl);
+
+  andThen(() => {
+    click(findButton(buttonLabel));
+  });
+
+  andThen(() => {
+    assert.ok(!findButton(buttonLabel).length, "CNAME button is no longer shown");
+    assert.ok(find("div:contains(endpoint is ready)").length, "Success notification is shown");
+  });
+});
+
+test(`visit ${appVhostsUrl} allows renewing an unitialized ACME cert (instant success)`, function(assert) {
+  assert.expect(3);
+
+  setupAcmeStubs(assert, {
+    renewStartsQueued: true,
+    renewSucceeds: true,
+
+    provisionStartsQueued: false,
+    provisionSucceeds: true,
+
+    renewTriggersProvision: true
+  });
+
+  const buttonLabel = "I Created The CNAME";
+
+  signInAndVisit(appVhostsUrl);
+
+  andThen(() => {
+    click(findButton(buttonLabel));
+  });
+
+  andThen(() => {
+    assert.ok(find("div:contains(endpoint is ready)").length, "Success notification is shown");
+    assert.ok(!findButton(buttonLabel).length, "CNAME button is no longer shown");
+  });
+});
+
+test(`visit ${appVhostsUrl} allows renewing an unitialized ACME cert (renewal fails)`, function(assert) {
+  assert.expect(2);
+
+  setupAcmeStubs(assert, {
+    renewStartsQueued: true,
+    renewSucceeds: false,
+    renewTriggersProvision: false
+  });
+
+  signInAndVisit(appVhostsUrl);
+
+  andThen(function(){
+    click(findButton("I Created The CNAME"));
+  });
+
+  andThen(function(){
+    assert.ok(find("div:contains(Failed to generate certificate)").length,
+              "Failure notification is shown");
+  });
+});
+
+test(`visit ${appVhostsUrl} allows renewing an unitialized ACME cert (provision fails)`, function(assert) {
+  assert.expect(2);
+
+  setupAcmeStubs(assert, {
+    renewStartsQueued: true,
+    renewSucceeds: true,
+
+    provisionStartsQueued: true,
+    provisionSucceeds: false,
+
+    renewTriggersProvision: true
+  });
+
+  signInAndVisit(appVhostsUrl);
+
+  andThen(function(){
+    click(findButton("I Created The CNAME"));
+  });
+
+  andThen(function(){
+    assert.ok(find("div:contains(Failed to install certificate)").length,
+              "Failure notification is shown");
+  });
+});
+
+test(`visit ${appVhostsUrl} allows renewing an unitialized ACME cert (renewal does not trigger provision)`, function(assert) {
+  assert.expect(2);
+
+  setupAcmeStubs(assert, {
+    renewStartsQueued: true,
+    renewSucceeds: true,
+    renewTriggersProvision: false
+  });
+
+  signInAndVisit(appVhostsUrl);
+
+  andThen(function(){
+    click(findButton("I Created The CNAME"));
+  });
+
+  andThen(function(){
+    assert.ok(find("div:contains(unexpected error)").length,
+              "Failure notification is shown");
   });
 });

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -141,13 +141,17 @@ test(`visit ${appVhostsUrl} lists endpoints with action required`, function(asse
   var vhosts = [{
     id: 1,
     virtual_domain: 'www.health1.io',
-    acme_domain: 'www.health1.io',
+    user_domain: 'www.health1.io',
+    acme: true,
+    acme_status: 'transitional',
     external_host: 'www.host1.com',
     status: 'provisioned',
   },{
     id: 2,
     virtual_domain: 'www.health2.io',
-    acme_domain: 'www.health2.io',
+    user_domain: 'www.health2.io',
+    acme: true,
+    acme_status: 'pending',
     external_host: 'www.host2.com',
     status: 'provisioned'
   }];
@@ -358,8 +362,10 @@ function setupAcmeStubs(assert, options) {
 
   const vhost = {
     id: vhostId,
-    acme_domain: "www.health.io",
-    status: "provisioned",
+    user_domain: "www.health.io",
+    acme: true,
+    acme_status: 'pending',
+    status: 'provisioned',
     _links: {
       self: { href: `/vhosts/${vhostId}` },
       operations: { href: `/vhosts/${vhostId}/operations` }
@@ -382,6 +388,8 @@ function setupAcmeStubs(assert, options) {
   };
 
   const completeRenew = () => {
+    vhost.acme_status = 'ready';
+    vhost._links.certificate = certificate._links.self;
     renewOperation.status = renewFinalStatus;
     if (options.renewTriggersProvision) {
       createProvision();
@@ -399,9 +407,6 @@ function setupAcmeStubs(assert, options) {
 
   const completeProvision = () => {
     provisionOperation.status = provisionFinalStatus;
-    if (provisionFinalStatus === "succeeded") {
-      vhost._links.certificate = certificate._links.self;
-    }
   };
 
   stubApp({

--- a/tests/unit/components/domain-input/component-test.js
+++ b/tests/unit/components/domain-input/component-test.js
@@ -1,0 +1,65 @@
+import {
+  moduleForComponent,
+  test
+} from "ember-qunit";
+import { BASIC_DOMAIN_REGEXP } from "diesel/components/domain-input/component";
+import hbs from "htmlbars-inline-precompile";
+
+
+moduleForComponent("domain-input", {
+  integration: true
+});
+
+
+test("invalid domain is invalid", function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{domain-input domain=domainValue valid=validValue}}`);
+
+  const input = this.$("input");
+  input.val("some val");
+  input.trigger("input");
+
+  assert.equal(this.get("domainValue"), "some val");
+  assert.equal(this.get("validValue"), false);
+  assert.ok(this.$("div.form-group.has-error").length);
+});
+
+test("valid domain is valid", function(assert) {
+  assert.expect(3);
+
+  this.render(hbs`{{domain-input domain=domainValue valid=validValue}}`);
+
+  const input = this.$("input");
+  input.val("domain.com");
+  input.trigger("input");
+
+  assert.equal(this.get("domainValue"), "domain.com");
+  assert.equal(this.get("validValue"), true);
+  assert.ok(!this.$("div.form-group.has-error").length);
+});
+
+test("tip is shown", function(assert) {
+  assert.expect(1);
+  this.render(hbs`{{domain-input domain=domainValue valid=validValue tip="hello tip"}}`);
+  assert.ok(this.$("p:contains(hello tip)").length);
+});
+
+[
+  "http://test.com", "some", "1.1", "foo.bar.3", "!://abc.com", "❤️.com",
+  "foo bar"
+].forEach((domain) => {
+  test(`it does not accept ${domain}`, function(assert) {
+    assert.ok(!BASIC_DOMAIN_REGEXP.test(domain));
+  });
+});
+
+
+[
+  "test.com", "abc.com", "some.foo", "11.bar", "foo.bar", "SOME.Foo",
+  "ab.cd.ef", "te-st.com", "xn--qei.com", "test.unreasonabletld"
+].forEach((domain) => {
+  test(`it accepts ${domain}`, function(assert) {
+    assert.ok(BASIC_DOMAIN_REGEXP.test(domain));
+  });
+});


### PR DESCRIPTION
This is what I demo'ed last week. This lets customers provision Endpoints via ACME. In the Dashboard, those are branded as "Managed SSL".

There are a few changes here:

- First, I've made a bunch of tweaks to the new VHOST UI:
  - Replaced helper popovers on labels with a "?" popover (consistent with e.g. metrics). In practice, I couldn't get the helper popovers to show otherwise (IOW: the current popovers weren't working AFAICT). Accordingly, I showed disabled inputs when a given type is unavailable (we used to not show anything, which would have made the "?" popover confusing). I had to add them manually since our dependency that provides radio buttons doesn't support disabled inputs in the version we have (and upgrading seemed to be a little complex).
  - Added the new type to the input. It's only shown on v2 stacks. It does some very light validation that the input remotely looks like a domain, but is intentionally lax so as to not accidentally refuse domains that don't work.
  - I refactored most of the logic of the create VHOST component. Mainly: moved all data access to the route (this eliminates flicker when the form loads), replaced most implicit conditionals (e.g. if the VHOST is non-default, then it needs a cert) with more explicit ones (i.e. computeds like `certificateNeeded`). These changes were mainly needed to keep the component readable despite the addition of new logic.
- Second, I've added a new (somewhat extensible) "Action Needed" status to VHOSTs. This allows a component to be loaded for each Action Needed status. Right now, the only such status is an ACME VHOST that needs to be initialized (that's what provides the "I Created The CNAME" button).

A few screenshots:

![image](https://cloud.githubusercontent.com/assets/1737686/16566662/d73ddc96-4216-11e6-9cb2-ed157a515c4c.png)![image](https://cloud.githubusercontent.com/assets/1737686/16566666/df880bd8-4216-11e6-945b-eb9939fc92d7.png)

![image](https://cloud.githubusercontent.com/assets/1737686/16566716/4b8b494e-4217-11e6-96f0-8fddb9982baf.png)

![image](https://cloud.githubusercontent.com/assets/1737686/16566720/517bda44-4217-11e6-9022-5e2bc60365dc.png)

![image](https://cloud.githubusercontent.com/assets/1737686/16566793/15ae0f4a-4218-11e6-95a3-b2085a94abe5.png)

![image](https://cloud.githubusercontent.com/assets/1737686/16566737/7b8e01f4-4217-11e6-8007-b227009728fa.png)

---

cc @fancyremarker @sandersonet @gib 