### PR TITLE
Fix CSP violations on sandboxes / staging

### DIFF
--- a/app/services/metrics-api.js
+++ b/app/services/metrics-api.js
@@ -24,7 +24,7 @@ export default Ember.Service.extend({
     let accessToken = this.get("session.token.accessToken");
     let containerIds = containers.map((container) => container.get("id"));
 
-    return ajax(`${config.metricsBaseuri}/proxy/${containerIds.join(":")}?horizon=${horizon}&metric=${metric}`, {
+    return ajax(`${config.metricsBaseUri}/proxy/${containerIds.join(":")}?horizon=${horizon}&metric=${metric}`, {
       headers: {
         "Authorization": `Bearer ${accessToken}`
       }

--- a/config/environment.js
+++ b/config/environment.js
@@ -3,23 +3,31 @@
 var detectEndpointUri = require('../lib/detect-endpoint-uri');
 
 module.exports = function(environment) {
+  var metricsBaseUri = detectEndpointUri('metrics', environment) || "http://localhost:3000";
+  var complianceBaseUri = detectEndpointUri('compliance', environment) || 'http://localhost:3001';
+  var authBaseUri = detectEndpointUri('auth', environment) || 'http://localhost:4000';
+  var apiBaseUri = detectEndpointUri('api', environment) || 'http://localhost:4001';
+  var gridironBaseUri = detectEndpointUri('gridiron', environment) || 'http://localhost:4002';
+  var billingBaseUri = detectEndpointUri('billing', environment) || 'http://localhost:4004';
+  var dashboardBaseUri = detectEndpointUri('dashboard', environment) || 'http://localhost:4200';
+
   var ENV = {
     modulePrefix: 'diesel',
     environment: environment,
     baseURL: '/',
     locationType: 'auto',
 
-    metricsBaseuri: detectEndpointUri('metrics', environment) || "http://localhost:3000",
-    complianceBaseUri: detectEndpointUri('compliance', environment) || 'http://localhost:3001',
-    authBaseUri: detectEndpointUri('auth', environment) || 'http://localhost:4000',
-    apiBaseUri: detectEndpointUri('api', environment) || 'http://localhost:4001',
-    gridironBaseUri: detectEndpointUri('gridiron', environment) || 'http://localhost:4002',
-    billingBaseUri: detectEndpointUri('billing', environment) || 'http://localhost:4004',
-    dashboardBaseUri: detectEndpointUri('dashboard', environment) || 'http://localhost:4200',
+    metricsBaseUri: metricsBaseUri,
+    complianceBaseUri: complianceBaseUri,
+    authBaseUri: authBaseUri,
+    apiBaseUri: apiBaseUri,
+    gridironBaseUri: gridironBaseUri,
+    billingBaseUri: billingBaseUri,
+    dashboardBaseUri: dashboardBaseUri,
 
     aptibleHosts: {
-      compliance: detectEndpointUri('compliance', environment) || 'http://localhost:3001',
-      dashboard: detectEndpointUri('dashboard', environment) || 'http://localhost:4200',
+      compliance: complianceBaseUri,
+      dashboard: dashboardBaseUri,
       support: 'https://support.aptible.com',
       contact: 'http://contact.aptible.com'
     },
@@ -97,7 +105,10 @@ module.exports = function(environment) {
     },
 
     contentSecurityPolicy: {
-      'connect-src': "'self' ws://aptible1.local:49152 http://aptible1.local:4200 http://aptible1.local:4000 http://aptible1.local:4001 http://aptible1.local:4002 http://aptible1.local:4004 http://localhost:4000 http://localhost:4001 http://localhost:4002 ws://localhost:35729 ws://0.0.0.0:35729 http://api.mixpanel.com http://api.segment.io https://auth.aptible-staging.com https://api.aptible-staging.com https://gridiron.aptible-staging.com https://api-ping.intercom.io wss://*.intercom.io https://*.intercom.io",
+      'connect-src': "'self' ws://aptible1.local:49152 http://aptible1.local:4200 http://aptible1.local:4000 http://aptible1.local:4001 http://aptible1.local:4002 http://aptible1.local:4004 http://localhost:4000 http://localhost:4001 http://localhost:4002 ws://localhost:35729 ws://0.0.0.0:35729 http://api.mixpanel.com http://api.segment.io https://auth.aptible-staging.com https://api.aptible-staging.com https://gridiron.aptible-staging.com https://api-ping.intercom.io wss://*.intercom.io https://*.intercom.io" + [
+        metricsBaseUri, complianceBaseUri, authBaseUri, apiBaseUri,
+        gridironBaseUri, billingBaseUri, dashboardBaseUri,
+      ].join(' '),
       'style-src': "'self' 'unsafe-inline' http://use.typekit.net",
       'img-src': "'self' http://www.gravatar.com https://secure.gravatar.com http://www.google-analytics.com http://p.typekit.net https://track.customer.io https://js.intercomcdn.com",
       'script-src': "'self' 'unsafe-inline' http://aptible1.local:49152 https://js.stripe.com https://api.stripe.com http://use.typekit.net http://cdn.segment.com https://assets.customer.io http://www.google-analytics.com http://cdn.mxpnl.com https://js.intercomcdn.com https://static.intercomcdn.com https://widget.intercom.io",


### PR DESCRIPTION
We're hardcoding a lit of allwoed connect-src in our CSP, but it's
incomplete and doesn't work for sandboxes. This updates our CSP
connect-src rules to be dynamically constructed using the endpoint URLs
we're already dynamically generating.

(It also fixes a typo in `metricsBaseuri`, which should be
`metricsBaseUri` for consistency with everything else)

---

cc @sandersonet @fancyremarker 

I didn't *remove* anything for the sake of safety.. but perhaps we should. Let me know. I reckon we don't enable this in prod (since e.g. api.aptible.com isn't in the list), so the impact should be pretty low. LMK if I'm missing something though.

Cheers,