### PR TITLE
Add no organization error page

### DIFF
--- a/app/error/controller.js
+++ b/app/error/controller.js
@@ -2,14 +2,14 @@ import Ember from "ember";
 
 export default Ember.Controller.extend({
 
-  title: function(){
+  errorCode: function(){
     return this.get('model.status') || this.get('model.name');
   }.property('model.status', 'model.name'),
 
-  subTitle: Ember.computed.alias('model.statusText'),
+  title: Ember.computed.alias('model.statusText'),
 
   message: function(){
-    return this.get('model.responseJSON.message')+'.' || 'Our JavaScript raised an exception.';
+    const errorLabel = this.get('model.responseJSON.message') || 'Our JavaScript raised an exception';
+    return `${errorLabel}. Maybe the URL you visited is no longer valid?`;
   }.property('model.responseJSON.message')
-
 });

--- a/app/error/template.hbs
+++ b/app/error/template.hbs
@@ -1,1 +1,1 @@
-{{partial 'not-found-error'}}
+{{error-page errorCode=errorCode title=title message=message}}

--- a/app/no-organization/template.hbs
+++ b/app/no-organization/template.hbs
@@ -1,0 +1,16 @@
+{{#error-page
+  title="You are not a member of any Organization on Aptible"
+  message="Here's what you can do:"
+  actionName="Logout"
+  actionDestination="settings.logout"}}
+  <ul>
+    <li>If a colleague invited you to Aptible, access their invitation via your inbox.</li>
+    <li>If the invitation has expired, ask them to send it again.</li>
+    <li>If that doesn't work, contact support via the link below.</li>
+  </ul>
+
+  <p>
+    Note: you're still logged in as {{session.currentUser.name}};
+    if you are on a shared computer, log out now:
+  </p>
+{{/error-page}}

--- a/app/not-found/template.hbs
+++ b/app/not-found/template.hbs
@@ -1,1 +1,3 @@
-{{partial 'not-found-error'}}
+{{error-page
+  title="Hmm... we can't find the page you're looking for."
+  message="Maybe you mistyped the address? If not, the page may have moved"}}

--- a/app/router.js
+++ b/app/router.js
@@ -171,6 +171,7 @@ Router.map(function() {
 
   this.authenticatedRoute("trainee-dashboard", { resetNamespace: true });
   this.authenticatedRoute("elevate", { resetNamespace: true });
+  this.authenticatedRoute("no-organization", { resetNamespace: true });
 
   this.route("login");
   this.route("signup", {}, function(){

--- a/app/welcome/route.js
+++ b/app/welcome/route.js
@@ -10,6 +10,7 @@ export default Ember.Route.extend({
   queryParams: {
     plan: { }
   },
+
   beforeModel: function(){
     if(this.session.get('isAuthenticated')) {
       return this.store.find('stack').then((stacks) => {
@@ -24,19 +25,28 @@ export default Ember.Route.extend({
 
   model: function(params){
     return this.store.find('organization').then((organizations) => {
-      let stackHandle = organizations.objectAt(0).get('name').dasherize();
-      let plan = params.plan || 'development';
+      const model = {
+        organization: organizations.objectAt(0)
+      };
 
-      if(plan === 'production') {
-        plan = 'platform';
+      if (model.organization) {
+        let plan = params.plan || 'development';
+        if(plan === 'production') {
+          plan = 'platform';
+        }
+
+        model.stackHandle = model.organization.get('name').dasherize();
+        model.plan = plan;
       }
 
-      let model = {
-        stackHandle,
-        plan
-      };
       resetDBData(model);
       return model;
     });
+  },
+
+  afterModel: function(model) {
+    if (!model.organization) {
+      this.transitionTo('no-organization');
+    }
   }
 });

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "krallin/ember-cli-aptible-shared#revoke-tokens",
+    "ember-cli-aptible-shared": "0.0.92",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "0.0.92",
+    "ember-cli-aptible-shared": "0.0.93",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",

--- a/tests/acceptance/error-test.js
+++ b/tests/acceptance/error-test.js
@@ -1,0 +1,55 @@
+import Ember from "ember";
+import { stubRequest } from "ember-cli-fake-server";
+import {module, test} from "qunit";
+import startApp from "../helpers/start-app";
+
+let App;
+
+module("Acceptance: Error Page", {
+  beforeEach: function() {
+    App = startApp();
+    stubOrganization();
+    stubOrganizations();
+  },
+  afterEach: function() {
+    Ember.run(App, "destroy");
+  }
+});
+
+const stubStacksWithError = function(code, error, message) {
+  stubRequest("get", "/accounts", function() {
+    return this.error(code, { code, error, message });
+  });
+};
+
+[
+  [404, "Not Found", "not_found", "Not Found"],
+  [403, "Forbidden", "access_denied", "Access Denied"],
+  [500, "Internal Server Error", "internal_server_error", "Internal Server Error"],
+].forEach((testCase) => {
+  const httpStatusCode = testCase[0];
+  const httpStatusLine = testCase[1];
+  const apiError = testCase[2];
+  const apiMessage = testCase[3];
+
+  test(`Getting a ${httpStatusCode} ${apiError} from the API shows error`, function(assert) {
+    stubStacksWithError(httpStatusCode, apiError, apiMessage);
+    signInAndVisit("/");
+
+    andThen(() => {
+      assert.equal(currentPath(), "error");
+      expectLink("support.aptible.com");
+      expectLink("status.aptible.com");
+      expectLink("twitter.com/aptiblestatus");
+
+      assert.ok(find(`a[href="/"]`).length, "Has link back to /");
+
+      assert.ok(find(`h1:contains("${httpStatusCode}")`).length,
+                `HTTP Status Code ${httpStatusCode} is shown in h1`);
+      assert.ok(find(`h1:contains("${httpStatusLine}")`).length,
+                `HTTP Status Line ${httpStatusLine} is shown in h3`);
+      assert.ok(find(`h3:contains("${apiMessage}")`).length,
+                `API Error message ${apiMessage} is shown in h3`);
+    });
+  });
+});

--- a/tests/acceptance/no-organization-test.js
+++ b/tests/acceptance/no-organization-test.js
@@ -1,0 +1,45 @@
+import Ember from "ember";
+import { stubRequest } from "ember-cli-fake-server";
+import {module, test} from "qunit";
+import startApp from "../helpers/start-app";
+
+let App;
+
+module("Acceptance: No Organization Page", {
+  beforeEach: function() {
+    App = startApp();
+
+    stubRequest("get", "/organizations", function() {
+      return this.success({
+        _embedded: {
+          organizations: []
+        }
+      });
+    });
+
+    stubRequest("get", "/accounts", function() {
+      return this.success({
+        _embedded: {
+          accounts: []
+        }
+      });
+    });
+  },
+  afterEach: function() {
+    Ember.run(App, "destroy");
+  }
+});
+
+test("visiting / redirects to no organization page", function(assert) {
+  signInAndVisit("/");
+
+  andThen(function() {
+    assert.equal(currentPath(), "no-organization");
+    expectLink("support.aptible.com");
+    expectLink("status.aptible.com");
+    expectLink("twitter.com/aptiblestatus");
+    assert.ok(find(`a[href="/settings/logout"]`).length,
+              "Has link to /settings/logout");
+  });
+});
+

--- a/tests/acceptance/not-found-test.js
+++ b/tests/acceptance/not-found-test.js
@@ -22,5 +22,7 @@ test(`visiting ${url} shows not-found message`, function(assert) {
     expectLink('support.aptible.com');
     expectLink('status.aptible.com');
     expectLink('twitter.com/aptiblestatus');
+
+    assert.ok(find(`a[href="/"]`).length, "Has link back to /");
   });
 });


### PR DESCRIPTION
When a user attempts to log in without being a member of an
organization, we currently throw a `TypeError`, which is problematic for
a few reasons:

- First, it doesn't let the user log out (without manually deleting
  cookies), which is bad from a security standpoint (they might not even
  realize they're still logged in).
- Second, it's very confusing: it's very unclear why they're receiving a
  `TypeError`. In practice this shouldn't happen very often, but it
  *can* happen if a user attempts to verify their email before accepting
  an invitation (aptible/auth.aptible.com#225 is
  evidence that some people do), in which case we should send them back
  on the happy path, i.e. tell them to accept the invitation.
- Third, it might start happening more often if / when we let users
  remove other users from their organization
  (#642,
  #641)

Obligatory screenshot: 

![image](https://cloud.githubusercontent.com/assets/1737686/16731523/d4c64022-4778-11e6-98fb-df48f964e056.png)

It's not *super* sexy, but I think it works. I'm a little bit concerned about that grey on grey being a little toned down (but that's arguably a problem for error pages?). Let me know what you think.


--

cc @fancyremarker @sandersonet @gib 
also, cc @wcpines, this should make the "accept-invitation" flow more foolproof. 