### PR TITLE
Update ember-cli-aptible-shared to 0.0.93

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "aws-sdk": "^2.1.34",
     "broccoli-sass": "^0.6.6",
     "core-object": "^1.1.0",
-    "ember-cli-aptible-shared": "krallin/ember-cli-aptible-shared#revoke-tokens",
+    "ember-cli-aptible-shared": "0.0.93",
     "ember-cli-deploy": "^0.4.1",
     "ember-deploy-s3": "0.0.5",
     "ember-cli-deprecation-workflow": "^0.1.4",


### PR DESCRIPTION
Oops; this was missing in https://github.com/aptible/dashboard.aptible.com/pull/635 — sorry about that.