### PR TITLE
Fix broken test when creating a compliance user role

### DIFF
--- a/app/components/role-type-options/component.js
+++ b/app/components/role-type-options/component.js
@@ -1,14 +1,9 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  updateValue: Ember.computed('role.type', function() {
-    let roleType = this.get('role').get('type');
-    this.$('.role-type-select').data('role-type', roleType);
-  }),
-
-  click(jqEvent) {
-    let role = this.get('role');
-    let roleType = $(jqEvent.target.closest('.role-type-option')).data('option-value');
-    role.set('type', roleType);
+  actions: {
+    updateType(roleType) {
+      this.get('role').set('type', roleType);
+    }
   }
 });

--- a/app/components/role-type-options/template.hbs
+++ b/app/components/role-type-options/template.hbs
@@ -1,15 +1,15 @@
 <div class="form-group role-type-select" data-role-type="{{role.type}}">
   <label class="role-type-select__label">Type</label>
-  <div class="role-type-option" data-option-value="platform_user">
+  <button class="form-control role-type-option" {{action 'updateType' 'platform_user'}} data-option-value="platform_user">
     <h3 class="role-type-option__name">Platform</h3>
     <p class="role-type-option__info">
       For granting permission to Apps, Databases, and Environments
     </p>
-  </div>
-  <div class="role-type-option" data-option-value="compliance_user">
+  </button>
+  <button class="form-control role-type-option" {{action 'updateType' 'compliance_user'}} data-option-value="compliance_user">
     <h3 class="role-type-option__name">Compliance</h3>
     <p class="role-type-option__info">
       For granting permission to Compliance Products
     </p>
-  </div>
+  </button>
 </div>

--- a/app/organization/roles/new/route.js
+++ b/app/organization/roles/new/route.js
@@ -3,8 +3,6 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   model() {
     let organization = this.modelFor('organization');
-    
-    // Note: organization.get('billingDetail') works, but this is easier to test.
     let billingDetail = this.store.find('billing-detail', organization.get('id'));
 
     return Ember.RSVP.hash({
@@ -37,7 +35,7 @@ export default Ember.Route.extend({
       role.save().then(() => {
         let message = `${role.get('name')} created`;
 
-        this.transitionTo('role.environments', role);
+        this.transitionTo('role.members', role);
         Ember.get(this, 'flashMessages').success(message);
       });
     }


### PR DESCRIPTION
Updates the role type options component and fixes the test (thanks @sandersonet). The component now has a single action to update the role. A side benefit is the actions are tab key focus-able with button elements instead of divs.

Users are also directed to role members after creating instead of role environments which are not available for compliance roles.