### PR TITLE
Only show service scaler success on success

### DIFF
--- a/app/components/service-scaler/component.js
+++ b/app/components/service-scaler/component.js
@@ -74,7 +74,11 @@ export default Ember.Component.extend({
       var deferred = Ember.RSVP.defer();
       this.sendAction('scaleService', service, containerCount, containerSize, deferred);
 
-      deferred.promise.catch(function(e){
+      deferred.promise.then(() => {
+        if (component.isDestroyed) { return; }
+
+        component.set('success', service.get('processType') + ' scaled to ' + containerCount + ' ' + containerSize + 'MB' + ' containers');
+      }).catch(function(e){
         if (component.isDestroyed) { return; }
 
         component.set('error', e.message);
@@ -82,7 +86,6 @@ export default Ember.Component.extend({
         if (component.isDestroyed) { return; }
 
         component.set('isSaving', false);
-        component.set('success', service.get('processType') + ' scaled to ' + containerCount + ' ' + containerSize + 'MB' + ' containers');
       });
     },
 

--- a/tests/unit/components/service-scaler-test.js
+++ b/tests/unit/components/service-scaler-test.js
@@ -89,3 +89,59 @@ test('it should set shouldDisable to true when component is saving', function(as
 
   assert.equal(true, component.get('shouldDisable'));
 });
+
+test('it should show a success message when it succeeds', function(assert) {
+  const scaleServiceAction = function(_0, _1, _2, deferred) {
+    return deferred.resolve();
+  };
+
+  this.subject({
+    service: Ember.Object.create({
+      containerSize: 1024,
+      containerCount: 1,
+      stack: Ember.Object.create({
+        sweetnessStackVersion: 'v2'
+      })
+    }),
+    containerCount: 2,
+    targetObject: { scaleServiceAction },
+    scaleService: "scaleServiceAction"
+  });
+
+  this.render();
+
+  Ember.run(() => {
+    this.$().find("button").click();
+  });
+
+  assert.ok(!this.$().find("div:contains(Some error)").length, "Has no error");
+  assert.ok(this.$().find("div:contains(scaled to)").length, "Has success");
+});
+
+test('it should not show a success message when it fails', function(assert) {
+  const scaleServiceAction = function(_0, _1, _2, deferred) {
+    return deferred.reject(new Error("Some error"));
+  };
+
+  this.subject({
+    service: Ember.Object.create({
+      containerSize: 1024,
+      containerCount: 1,
+      stack: Ember.Object.create({
+        sweetnessStackVersion: 'v2'
+      })
+    }),
+    containerCount: 2,
+    targetObject: { scaleServiceAction },
+    scaleService: "scaleServiceAction"
+  });
+
+  this.render();
+
+  Ember.run(() => {
+    this.$().find("button").click();
+  });
+
+  assert.ok(this.$().find("div:contains(Some error)").length, "Has error");
+  assert.ok(!this.$().find("div:contains(scaled to)").length, "Has no success");
+});


### PR DESCRIPTION
The service scaler shows a success message in a `finally` block, which
means it may show a success and an error at the same time if an
operation fails, whereas it should only show an error.

cc @sandersonet @gib @blakepettersson 