### PR TITLE
Log exceptions to console

### DIFF
--- a/app/application/route.js
+++ b/app/application/route.js
@@ -9,7 +9,7 @@ export default Ember.Route.extend({
 
     error(err) {
       this.intermediateTransitionTo('error', err);
-      this.get('raven').captureException(err, { throwWhenNotUsable: false });
+      this.get('raven').captureException(err);
     }
   }
 });

--- a/app/services/raven.js
+++ b/app/services/raven.js
@@ -1,11 +1,12 @@
 import RavenService from 'ember-cli-sentry/services/raven';
+import Ember from 'ember';
 
 export default RavenService.extend({
-  captureException: function(error, options = { throwWhenNotUsable: true }) {
+  captureException: function(error) {
     if (this.get('isRavenUsable')) {
       window.Raven.captureException(...arguments);
-    } else if(options.throwWhenNotUsable){
-      throw error;
     }
+
+    Ember.Logger.error(error);
   }
 });


### PR DESCRIPTION
#653 created a regression where exceptions were swallowed and not actually rendered in browser console.  If exceptions are not swallowed, it would prevent the transition to the error pages and create an infinite loop.  This fixes that by explicitly logging the exception.

