### PR TITLE
Set referrer policy to origin-only

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="referrer" content="origin">
     <title>Aptible Dashboard</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
This ensures we don't leak referrers to e.g. analytics third parties,
which is particularly relevant for e.g. pages whose URL includes an
opaque token, such as password recovery pages.

cc @fancyremarker @sandersonet 