### PR TITLE
Role styles / Compliance User Role permissions

### DIFF
--- a/app/styles/components/_aptables.scss
+++ b/app/styles/components/_aptables.scss
@@ -55,8 +55,8 @@
     border-bottom: 1px solid #e0e0e0;
     color: $color-light;
     font-size: 12px;
-    text-transform: uppercase;
     font-weight: $weight-semibold;
+    text-transform: uppercase;
   }
 
   tr:hover {

--- a/app/styles/components/_panel.scss
+++ b/app/styles/components/_panel.scss
@@ -51,6 +51,7 @@
   }
   .aptable__row-heading, .role-details__header {
     color: #4a4a4a;
+    font-weight: $weight-semibold;
   }
   .role-details__header {
     font-size: 14px;

--- a/app/styles/components/_typography.scss
+++ b/app/styles/components/_typography.scss
@@ -16,6 +16,7 @@
 .aptible-label {
   color: #4a4a4a;
   font-size: 12px;
+  font-weight: $weight-semibold;
   margin-top: 0;
   margin-bottom: 5px;
   text-transform: uppercase;

--- a/app/templates/organization/-compliance-role-details.hbs
+++ b/app/templates/organization/-compliance-role-details.hbs
@@ -7,31 +7,31 @@
     <tbody>
       <tr>
         <td class="aptable__row-heading">Risk Assessments</td>
-        <td class="aptable__capitalized-list">Manage</td>
+        <td class="aptable__capitalized-list">Read</td>
       </tr>
       <tr>
         <td class="aptable__row-heading">Policies & Procedures</td>
-        <td class="aptable__capitalized-list">Manage</td>
+        <td class="aptable__capitalized-list">Read</td>
       </tr>
       <tr>
         <td class="aptable__row-heading">Workforce Training</td>
-        <td class="aptable__capitalized-list">Manage</td>
+        <td class="aptable__capitalized-list">Read</td>
       </tr>
       <tr>
         <td class="aptable__row-heading">Application Security</td>
-        <td class="aptable__capitalized-list">Manage</td>
+        <td class="aptable__capitalized-list">Read</td>
       </tr>
       <tr>
         <td class="aptable__row-heading">Incident Response</td>
-        <td class="aptable__capitalized-list">Manage</td>
+        <td class="aptable__capitalized-list">Read</td>
       </tr>
       <tr>
         <td class="aptable__row-heading">Contract Management</td>
-        <td class="aptable__capitalized-list">Manage</td>
+        <td class="aptable__capitalized-list">Read</td>
       </tr>
       <tr>
         <td class="aptable__row-heading">Security Reviews</td>
-        <td class="aptable__capitalized-list">Manage</td>
+        <td class="aptable__capitalized-list">Read</td>
       </tr>
     </tbody>
   </table>

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.15",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-aptible-shared": "0.0.98",
+    "ember-cli-aptible-shared": "0.0.99",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",


### PR DESCRIPTION
Add SASS font-weight variable where needed.

Communicate compliance user roles are read-only. This is enforced by API and we do not provide a way of changing these yet.