### PR TITLE
Billing detail redirects

### DIFF
--- a/app/catch-redirects/route.js
+++ b/app/catch-redirects/route.js
@@ -2,6 +2,29 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
   redirect() {
+    return this.handleNoOrganizations() ||
+           this.handleMissingBillingDetail() ||
+           this.handleComplianceOnlyUsers() ||
+           true;
+  },
+
+  handleNoOrganizations() {
+    let organizations = this.modelFor('dashboard').organizations;
+
+    if(organizations.get('length') === 0) {
+      return this.transitionTo('no-organization');
+    }
+  },
+
+  handleMissingBillingDetail() {
+    let organizations = this.modelFor('dashboard').organizations;
+
+    if (organizations.get('length') === 1 && organizations.get('firstObject.billingDetail.isRejected')) {
+       return this.transitionTo('welcome.payment-info');
+    }
+  },
+
+  handleComplianceOnlyUsers() {
     if (!this.features.get('trainee-dashboard')) {
       return;
     }
@@ -21,7 +44,7 @@ export default Ember.Route.extend({
     });
 
     if(complianceOnlyUser) {
-      this.transitionTo('trainee-dashboard');
+      return this.transitionTo('trainee-dashboard');
     }
   }
 });

--- a/app/catch-redirects/route.js
+++ b/app/catch-redirects/route.js
@@ -20,7 +20,7 @@ export default Ember.Route.extend({
     let organizations = this.modelFor('dashboard').organizations;
 
     if (organizations.get('length') === 1 && organizations.get('firstObject.billingDetail.isRejected')) {
-       return this.transitionTo('welcome.payment-info');
+       return this.transitionTo('welcome.payment-info', organizations.get('firstObject.id'));
     }
   },
 
@@ -33,7 +33,7 @@ export default Ember.Route.extend({
     let userRoles = this.modelFor('dashboard').currentUserRoles;
 
     // Does the user have any roles for any organization that are not compliance user?
-    let complianceOnlyUser = !organizations.any((organization) => {
+    let complianceOnlyUser = userRoles.length > 0 && !organizations.any((organization) => {
       let organizationHref = organization.get('data.links.self');
       let userOrganizationRoles = userRoles.filterBy('data.links.organization', organizationHref);
 

--- a/app/components/stack-sidebar/template.hbs
+++ b/app/components/stack-sidebar/template.hbs
@@ -12,5 +12,9 @@
     {{#link-to 'stack' stack tagName="li"}}
       {{link-to stack.handle 'stack' stack bubbles=false}}
     {{/link-to}}
+  {{else}}
+    <li>
+      {{link-to 'Requires payment method →' 'welcome.payment-info' organization.id classNames="requires-payment-link"}}
+    </li>
   {{/each}}
 </ul>

--- a/app/dashboard/route.js
+++ b/app/dashboard/route.js
@@ -10,10 +10,15 @@ export default Ember.Route.extend({
   },
 
   afterModel(model) {
-    if(model.organizations.get('length') === 0) {
-      return this.transitionTo('no-organization');
-    }
+    // If at least one of the billing details failed to load:
+    // This happens when an organization has not completed payment setup
+    // If we don't catch this failed promise, it will bubble up and cause
+    // dashboard to redirect to a 404 error page.
 
-    return Ember.RSVP.all(model.organizations.map(o => o.get('billingDetail'))).catch(Ember.$.noop);
+    // We can't redirect here because that would cause an infinite redirect
+    // loop.  noop here but expect that the `catch-redirects` route will
+    // catch this error condition and redirect to collect payment info.
+    let billingDetailPromises = model.organizations.map(o => o.get('billingDetail'));
+    return Ember.RSVP.all(billingDetailPromises).catch(Ember.$.noop);
   }
 });

--- a/app/mixins/routes/signup.js
+++ b/app/mixins/routes/signup.js
@@ -5,18 +5,16 @@ export default Ember.Mixin.create({
   actions: {
     signup: function(user, organization){
       let {email, password} = user.getProperties('email', 'password');
-      let plan = this.get('controller.plan') || 'development';
       this.controller.set('isSaving', true);
 
       user.save().then(() => {
         let credentials = buildCredentials(email, password);
         return this.get('session').open('application', credentials);
       }).then(() => {
-
         if (organization) {
           // standard signup flow, create organization at the same time
           return organization.save().then(() => {
-            this.transitionTo('welcome.first-app', { queryParams: { plan: plan }});
+            this.transitionTo('welcome.first-app', organization.get('id'));
             this.controller.set('isSaving', false);
           });
         } else {

--- a/app/organization/template.hbs
+++ b/app/organization/template.hbs
@@ -1,2 +1,12 @@
+{{#if model.billingDetail.isRejected}}
+  <div style="margin: 30px 30px 0;">
+  {{#bs-alert alert="warning" as |component|}}
+    {{bs-alert-dismiss target=component}}
+    It looks like we're missing payment information for {{model.name}}.
+    {{link-to 'Add payment info now' 'welcome.payment-info' model.id class="btn btn-default btn-xs"}}
+  {{/bs-alert}}
+  </div>
+{{/if}}
+
 {{outlet}}
 

--- a/app/router.js
+++ b/app/router.js
@@ -173,6 +173,7 @@ Router.map(function() {
   });
 
   this.authenticatedRoute("welcome", {
+    path: '/welcome/:organization_id',
     resetNamespace: true
   }, function() {
     this.route("first-app");

--- a/app/router.js
+++ b/app/router.js
@@ -53,7 +53,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.authenticatedRoute("dashboard", { path: '/' }, function() {
-    this.route('requires-read-access', { path: '', resetNamespace: true }, function() {
+    this.route('catch-redirects', { path: '', resetNamespace: true }, function() {
       this.route("index", { path: '', resetNamespace: true });
 
       this.route("app", {

--- a/app/signup/index/controller.js
+++ b/app/signup/index/controller.js
@@ -2,6 +2,4 @@ import Ember from 'ember';
 import SignupControllerMixin from "diesel/mixins/controllers/signup";
 
 export default Ember.Controller.extend(SignupControllerMixin, {
-  queryParams: ['plan'],
-  plan: null
 });

--- a/app/signup/index/route.js
+++ b/app/signup/index/route.js
@@ -3,9 +3,6 @@ import DisallowAuthenticated from "diesel/mixins/routes/disallow-authenticated";
 import SignupRouteMixin from "diesel/mixins/routes/signup";
 
 export default Ember.Route.extend(DisallowAuthenticated, SignupRouteMixin, {
-  queryParams: {
-    plan: { }
-  },
   setupController: function(controller){
     let user = this.store.createRecord('user');
     let organization = this.store.createRecord('organization');

--- a/app/welcome/controller.js
+++ b/app/welcome/controller.js
@@ -1,8 +1,6 @@
 import Ember from "ember";
 
 export default Ember.Controller.extend({
-  queryParams: ['plan'],
-  plan: null,
-  planBinding: 'model.plan'
+
 });
 

--- a/app/welcome/first-app/controller.js
+++ b/app/welcome/first-app/controller.js
@@ -38,8 +38,7 @@ export default Ember.Controller.extend(EmberValidationsMixin, {
       this.validate().then(() => {
         // model data is already stored on the parent
         // route (welcome). Just move forward.
-
-        this.transitionToRoute('welcome.payment-info');
+        this.transitionTo('welcome.payment-info', this.get('model.organization.id'));
       }).catch(() => {
         // Silence the validation exception, display it in UI
       });

--- a/app/welcome/first-app/template.hbs
+++ b/app/welcome/first-app/template.hbs
@@ -103,7 +103,7 @@
       </div>
       {{#unless errors.model.stackHandle}}
         <div class="skip-link">
-          {{link-to 'Do this later →' 'welcome.payment-info'}}
+          {{link-to 'Do this later →' 'welcome.payment-info' model.organization.id}}
         </div>
       {{/unless}}
     </div>

--- a/app/welcome/route.js
+++ b/app/welcome/route.js
@@ -42,7 +42,7 @@ export default Ember.Route.extend({
         if(stacks.get('length') > 0) {
           this.transitionTo('stacks');
         }
-      })
+      });
     }).catch(Ember.$.noop);
   }
 });

--- a/app/welcome/route.js
+++ b/app/welcome/route.js
@@ -12,13 +12,7 @@ export default Ember.Route.extend({
   },
 
   beforeModel: function(){
-    if(this.session.get('isAuthenticated')) {
-      return this.store.find('stack').then((stacks) => {
-        if (stacks.get('length') !== 0) {
-          this.transitionTo('index');
-        }
-      });
-    } else {
+    if(!this.session.get('isAuthenticated')) {
       this.transitionTo('login');
     }
   },
@@ -47,6 +41,15 @@ export default Ember.Route.extend({
   afterModel: function(model) {
     if (!model.organization) {
       this.transitionTo('no-organization');
+    }
+
+    // If there is only one organization, double check that no stacks exist
+    if (model.organization.get('length') === 1) {
+      return this.store.find('stack').then((stacks) => {
+        if (stacks.get('length') !== 0) {
+          this.transitionTo('index');
+        }
+      });
     }
   }
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -132,6 +132,13 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
+
+
+    ENV.APP.LOG_RESOLVER = false;
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_TRANSITIONS = true;
+    ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
     // Testem prefers this...
     ENV.baseURL = '/';
     ENV.locationType = 'none';

--- a/config/environment.js
+++ b/config/environment.js
@@ -132,13 +132,6 @@ module.exports = function(environment) {
   }
 
   if (environment === 'test') {
-
-
-    ENV.APP.LOG_RESOLVER = false;
-    ENV.APP.LOG_ACTIVE_GENERATION = false;
-    ENV.APP.LOG_TRANSITIONS = true;
-    ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    ENV.APP.LOG_VIEW_LOOKUPS = false;
     // Testem prefers this...
     ENV.baseURL = '/';
     ENV.locationType = 'none';

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "core-object": "^1.1.0",
     "ember-cli": "1.13.15",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-aptible-shared": "0.0.102",
+    "ember-cli-aptible-shared": "0.0.103",
     "ember-cli-babel": "^5.1.5",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.1.0",

--- a/tests/acceptance/apps/basic-test.js
+++ b/tests/acceptance/apps/basic-test.js
@@ -36,7 +36,7 @@ test(`visiting ${url} with no apps redirects to apps new`, function(assert) {
 
   signInAndVisit(url);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
   });
 });
 
@@ -62,7 +62,7 @@ test(`visiting ${url}`, function(assert) {
   signInAndVisit(url);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
     expectTitle(`${stackHandle} Apps`);
   });
 });
@@ -272,7 +272,7 @@ test(`visiting ${url} then clicking on an app visits the app`, function(assert) 
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.services.index', 'app show page is visited');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.services.index', 'app show page is visited');
   });
 });
 

--- a/tests/acceptance/apps/create-test.js
+++ b/tests/acceptance/apps/create-test.js
@@ -51,7 +51,7 @@ test(`visiting /stacks/:stack_id/apps without any apps redirects to ${url}`, fun
   signInAndVisit(`/stacks/${stackId}/apps`);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
   });
 });
 
@@ -61,7 +61,7 @@ test(`visit ${url} shows basic info`, function(assert) {
   stubOrganizations();
   signInAndVisit(url);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
     expectInput('handle');
     expectButton('Save App');
     expectButton('Cancel');
@@ -85,7 +85,7 @@ test(`visit ${url} and cancel`, function(assert) {
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
 
     assert.ok( !findApp(appHandle).length,
         'does not show app');
@@ -107,7 +107,7 @@ test(`visit ${url} without apps show no cancel button`, function(assert) {
   signInAndVisit(url);
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
     let button = findButton('Cancel');
     assert.ok(!button.length, 'Cancel button is not present');
   });
@@ -125,7 +125,7 @@ test(`visit ${url} and transition away`, function(assert) {
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
 
     assert.ok( !findApp(appHandle).length,
         'does not show app');
@@ -162,7 +162,7 @@ test(`visit ${url} and create an app`, function(assert) {
 
   clickButton('Save App');
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.deploy');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.deploy');
 
     assert.ok( findApp(appHandle).length > 0,
         'lists new app on index' );
@@ -189,7 +189,7 @@ test(`visit ${url} and with duplicate handle`, function(assert) {
     assert.ok(submitButton.is(':disabled'), 'submit is disabled');
 
     clickButton('Save App');
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
   });
 });
 

--- a/tests/acceptance/apps/deprovision-test.js
+++ b/tests/acceptance/apps/deprovision-test.js
@@ -83,7 +83,7 @@ test('/apps/:id/deprovision will deprovision with confirmation', function(assert
   click('button:contains(Deprovision)');
   andThen(function(){
     assert.ok(didDeprovision, 'deprovisioned');
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -121,6 +121,6 @@ test('/apps/:id/deprovision will show deprovision error', function(assert) {
   andThen(function(){
     var error = findWithAssert('.alert');
     assert.ok(error.text().indexOf(errorMessage) > -1, 'error message shown');
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.deprovision');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.deprovision');
   });
 });

--- a/tests/acceptance/apps/show-empty-test.js
+++ b/tests/acceptance/apps/show-empty-test.js
@@ -81,7 +81,7 @@ test(`visit ${url} when app has not been deployed`, function(assert){
 
   signInAndVisit(url);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.deploy');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.deploy');
 
     assert.ok( find(`.first-time-app-deploy h2:contains(${appHandle})`).length,
         'display app handle');
@@ -164,7 +164,7 @@ test(`visit ${url} when app has not been deployed, click destroy link`, function
 
   click(`a:contains(Destroy ${appHandle})`);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new', 'redirected to apps');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new', 'redirected to apps');
   });
 });
 
@@ -206,6 +206,6 @@ test(`visit ${deployStepsUrl} with app services should redirect to services page
   signInAndVisit(deployStepsUrl);
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.services.index', 'redirected to app services');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.services.index', 'redirected to app services');
   });
 });

--- a/tests/acceptance/apps/show-test.js
+++ b/tests/acceptance/apps/show-test.js
@@ -66,7 +66,7 @@ test('visiting /apps/my-app-id shows basic app info', function(assert) {
   signInAndVisit('/apps/' + appId);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.services.index', 'show page is visited');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.services.index', 'show page is visited');
 
     let app = find('.resource-title:contains(my-app)');
     assert.ok(app.length, 'shows app handle');

--- a/tests/acceptance/apps/sidebar-test.js
+++ b/tests/acceptance/apps/sidebar-test.js
@@ -63,7 +63,7 @@ test('includes breadcrumb to parent stack', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/apps/vhost-edit-test.js
+++ b/tests/acceptance/apps/vhost-edit-test.js
@@ -92,7 +92,7 @@ test(`visit ${url} shows form with certificates`, function(assert) {
 
   signInAndVisit(url);
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.edit');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.vhosts.edit');
     expectTitle(`Edit ${virtualDomain} - ${appHandle}`);
     assert.equal(find('.panel-heading h3').text(), `Edit ${virtualDomain}`);
 
@@ -130,7 +130,7 @@ test(`visit ${url} shows form without certificates`, function(assert) {
 
   signInAndVisit(url);
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.edit');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.vhosts.edit');
     expectTitle(`Edit ${virtualDomain} - ${appHandle}`);
     assert.equal(find('.panel-heading h3').text(), `Edit ${virtualDomain}`);
 
@@ -206,7 +206,7 @@ test(`visit ${url} click save`, function(assert) {
   });
 
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.vhosts.index');
 
     assert.ok( find(`.vhost .vhost-virtualdomain:contains(health.io)`).length,
         'shows new endpoint health.io');
@@ -243,7 +243,7 @@ test(`visit ${url} click save and error`, function(assert) {
   });
 
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.edit');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.vhosts.edit');
 
     assert.ok(find('.alert').length, 'has error div');
     assert.ok(find('.alert').text().indexOf(errorMsg) > -1,
@@ -272,7 +272,7 @@ test(`visit ${url} and click cancel`, function(assert) {
   });
 
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.vhosts.index');
     assert.ok(!find(`.vhost .vhost-virtualdomain:contains(${newVirtualDomain})`).length,
        `does not show new virtual domain: "${newVirtualDomain}"`);
     assert.ok(find(`.vhost .vhost-virtualdomain:contains(${virtualDomain})`).length,
@@ -291,7 +291,7 @@ test(`visit ${url} and transition away`, function(assert) {
   });
 
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.vhosts.index');
 
     assert.ok(!find(`.vhost .vhost-virtualdomain:contains(${newVirtualDomain})`).length,
        `does not show new virtual domain: "${newVirtualDomain}"`);

--- a/tests/acceptance/apps/vhost-new-test.js
+++ b/tests/acceptance/apps/vhost-new-test.js
@@ -33,7 +33,7 @@ test(`visiting ${appVhostsUrl} without any endpoints redirects to ${appVhostsNew
   signInAndVisit(appVhostsUrl);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.app.vhosts.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.app.vhosts.new');
   });
 });
 

--- a/tests/acceptance/certificates/basic-test.js
+++ b/tests/acceptance/certificates/basic-test.js
@@ -57,7 +57,7 @@ test(`visiting ${url} with no certificates redirects to certificates new`, funct
 
   signInAndVisit(url);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.certificates.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.certificates.new');
   });
 });
 

--- a/tests/acceptance/certificates/create-test.js
+++ b/tests/acceptance/certificates/create-test.js
@@ -72,13 +72,13 @@ test(`visiting ${url} and creating new certificate`, function(assert) {
 
   signInAndVisit(url);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.certificates.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.certificates.new');
     fillInput('body', cert);
     fillInput('private-key', pKey);
     clickButton('Save Certificate');
   });
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.certificates.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.certificates.index');
   });
 });

--- a/tests/acceptance/certificates/delete-test.js
+++ b/tests/acceptance/certificates/delete-test.js
@@ -86,7 +86,7 @@ test(`visiting ${url} and deleting a certificate should delete the certificate`,
 
   andThen(function() {
     assert.ok(didDelete, 'certificate was deleted');
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.certificates.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.certificates.index');
   });
 
 });

--- a/tests/acceptance/claim-test.js
+++ b/tests/acceptance/claim-test.js
@@ -105,7 +105,7 @@ test(`visiting ${url} as unauthenticated revisits after log in`, function(assert
   clickButton('Accept invitation');
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -147,7 +147,7 @@ test(`visiting ${url} as authenticated creates verification`, function(assert) {
   signInAndVisit(url);
   clickButton('Accept invitation');
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/databases/basic-test.js
+++ b/tests/acceptance/databases/basic-test.js
@@ -36,7 +36,7 @@ test('visiting /stacks/:stack_id/databases', function(assert) {
   signInAndVisit('/stacks/my-stack-1/databases');
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.index');
     expectTitle('my-stack-1 Databases');
   });
 });
@@ -69,7 +69,7 @@ test('visiting /stacks/my-stack-1/databases then clicking on an database visits 
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.database.activity', 'show page is visited');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.database.activity', 'show page is visited');
   });
 });
 

--- a/tests/acceptance/databases/create-test.js
+++ b/tests/acceptance/databases/create-test.js
@@ -47,7 +47,7 @@ test(`visiting /stacks/:stack_id/databases without any databases redirects to ${
   signInAndVisit(`/stacks/${stackId}/databases`);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.new');
   });
 });
 
@@ -70,7 +70,7 @@ test(`visit ${url} when stack has no databases does not show cancel`, function(a
   signInAndVisit(url);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.new');
     let button = findButton('Cancel');
     assert.ok(!button.length, 'has no cancel button');
   });
@@ -88,7 +88,7 @@ test(`visit ${url} shows basic info`, function(assert) {
   signInAndVisit(url);
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.new');
 
     expectInput('handle');
     expectFocusedInput('handle');
@@ -199,7 +199,7 @@ test(`visit ${url} and create`, function(assert) {
   // TODO test that moving the slider changes the disk size
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.index');
 
     assert.ok( findDatabase(dbHandle).length,
         'db list shows new db' );
@@ -259,7 +259,7 @@ test(`visit ${url} with duplicate handle`, function(assert) {
     assert.ok(submitButton.is(':disabled'), 'submit button is disabled');
 
     submitButton.click();
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.new');
   });
 });
 
@@ -274,7 +274,7 @@ test(`visit ${url} and click cancel button`, function(assert) {
     clickButton('Cancel');
   });
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.index');
 
     assert.ok( !findDatabase(dbHandle).length,
         'does not show database in list' );
@@ -311,7 +311,7 @@ test(`visit ${url} and transition away`, function(assert) {
     visit(dbIndexUrl);
   });
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.index');
 
     assert.ok( !findDatabase(dbHandle).length,
         'does not show database in list' );

--- a/tests/acceptance/databases/deprovision-test.js
+++ b/tests/acceptance/databases/deprovision-test.js
@@ -85,7 +85,7 @@ test('/databases/:id/deprovision will deprovision with confirmation', function(a
   click('button:contains(Deprovision)');
   andThen(() => {
     assert.ok(didDeprovision, 'deprovisioned', 'received successful response');
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.databases.new',
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.databases.new',
       'with no dbs, user is routed to create one');
   });
 });
@@ -122,6 +122,6 @@ test('/databases/:id/deprovision will show deprovision error', function(assert) 
   andThen(function(){
     var error = findWithAssert('.alert');
     assert.ok(error.text().indexOf(errorMessage) > -1, 'error message shown');
-    assert.equal(currentPath(), 'dashboard.requires-read-access.database.deprovision');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.database.deprovision');
   });
 });

--- a/tests/acceptance/databases/show-test.js
+++ b/tests/acceptance/databases/show-test.js
@@ -42,7 +42,7 @@ test('visiting /databases/my-db-id shows the database', function(assert) {
 
   signInAndVisit('/databases/my-db-id');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.database.activity', 'show page is visited');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.database.activity', 'show page is visited');
     var contentNode = findWithAssert('*:contains(my-database)');
     assert.ok(contentNode.length > 0, 'my-database is on the page');
   });
@@ -83,7 +83,7 @@ test('visiting /databases/my-db-id with provisioned database and disk shows disk
 
   signInAndVisit('/databases/my-db-id');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.database.activity', 'show page is visited');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.database.activity', 'show page is visited');
     var sizeNode = findWithAssert('.db-size:contains(10 GB)');
     var urlNode = findWithAssert('.db-connection-url:contains(postgresql://me:pw@10.0.0.0/db)');
     assert.ok(sizeNode.length > 0, 'shows database size');
@@ -114,7 +114,7 @@ test('visiting /databases/my-db-id with provisioning database shows a spinner', 
 
   signInAndVisit('/databases/my-db-id');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.database.activity', 'show page is visited');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.database.activity', 'show page is visited');
     var contentNode = findWithAssert('.db-status:contains(Provisioning)');
     assert.ok(contentNode.length > 0, 'shows provisioning status');
   });
@@ -143,7 +143,7 @@ test('visiting /databases/my-db-id with provisioned database but no disk doesn\'
 
   signInAndVisit('/databases/my-db-id');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.database.activity', 'show page is visited');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.database.activity', 'show page is visited');
     var contentNode = find('.db-size');
     assert.ok(contentNode.length === 0, 'my-database is on the page');
   });

--- a/tests/acceptance/databases/sidebar-test.js
+++ b/tests/acceptance/databases/sidebar-test.js
@@ -57,7 +57,7 @@ test('includes breadcrumb to parent stack', function(assert) {
   });
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/landing-page-test.js
+++ b/tests/acceptance/landing-page-test.js
@@ -32,7 +32,7 @@ test('visiting / when logged in with more than one stacks redirects to stacks in
   signInAndVisit('/');
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -63,7 +63,7 @@ test('visiting / when logged in with only one stack redirects to first stack pag
 
   andThen(function() {
     assert.equal(currentURL(), `/stacks/${stackId}/apps`);
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
 
     expectLink(`stacks/${stackId}/databases`);
     expectLink(`stacks/${stackId}/logging`);

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -87,7 +87,7 @@ test(`visit ${url} shows basic info`, function(assert){
   signInAndVisit(url);
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.index');
 
     expectButton('Add Log');
 
@@ -134,7 +134,7 @@ test(`visit ${url} shows pending and provisioning`, function(assert){
   signInAndVisit(url);
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.index');
 
     expectButton('Add Log');
 
@@ -160,7 +160,7 @@ test(`visit ${url} shows log tail explanation`, function(assert) {
   signInAndVisit(url);
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.index');
     assert.ok(!find('h5:contains(Host)').length, 'has no host section');
     assert.ok(find('h3:contains(log drain was automatically provisioned)').length, 'has tail explanation');
   });
@@ -171,7 +171,7 @@ test(`visit ${url} with no log drains will redirect to new log drains`, function
   signInAndVisit(url);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.new');
   });
 });
 
@@ -184,7 +184,7 @@ test(`visit ${url} with log drains and click add log shows form`, function(asser
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.new');
     assert.equal(currentURL(), addLogUrl);
 
     let formEl = find('form.create-log');
@@ -269,12 +269,12 @@ test(`visit ${addLogUrl} and cancel`, function(assert){
   signInAndVisit(addLogUrl);
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.new');
     clickButton('Cancel');
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.index');
   });
 });
 
@@ -330,7 +330,7 @@ test(`visit ${addLogUrl} and create log success`, function(assert){
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.index');
   });
 });
 
@@ -419,7 +419,7 @@ test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.index');
   });
 });
 
@@ -474,7 +474,7 @@ test(`visit ${addLogUrl} and create log to HTTPS`, function(assert){
   });
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.index');
   });
 });
 
@@ -494,7 +494,7 @@ test(`visit ${addLogUrl} and create log failure`, function(assert){
     clickButton('Save Log', {context:formEl});
   });
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.log-drains.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.log-drains.new');
     let errorDiv = find('.alert');
     assert.ok( errorDiv.length, 'error div is shown');
     assert.ok( errorDiv.text().indexOf(errorMessage) > -1,

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -136,7 +136,7 @@ test('logging in with correct credentials', function(assert) {
   fillInput('password', password);
   clickButton('Log in');
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -176,7 +176,7 @@ test('logging in with a valid OTP token', function(assert) {
   fillInput('otp-token', otpToken);
   clickButton('Log in');
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -256,7 +256,7 @@ test('visit /login while already logged in redirects to stack', function(assert)
   signInAndVisit('/login');
 
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/missing-billing-detail-test.js
+++ b/tests/acceptance/missing-billing-detail-test.js
@@ -28,7 +28,7 @@ test('with only one organization', function(assert) {
   });
 });
 
-test('with more than one organization', function(assert) {
+test('with more than one organization shows link to payment page', function(assert) {
   let organizations = [
     {
       id: 1, name: 'sprocket co',
@@ -47,7 +47,7 @@ test('with more than one organization', function(assert) {
   ];
   stubBillingDetail({ id: 1 });
   stubRequest('get', '/billing_details/2', (request) => request.notFound());
-  stubRequest('get', '/organizations', function(request) {
+  stubRequest('get', '/organizations', function() {
     return this.success({
       _links: {},_embedded: { organizations }
     });
@@ -58,6 +58,16 @@ test('with more than one organization', function(assert) {
   signInAndVisit('/');
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index', 'was not redirected to payment info');
-  })
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index',
+                 'was not redirected to payment info');
+    let paymentLink = findWithAssert('.layout-sidebar .requires-payment-link');
+    assert.equal(paymentLink.length, 1, 'shows requires payment link in sidebar');
+    visit('/organizations/2');
+  });
+
+  andThen(function() {
+    assert.equal(find('.alert:contains(missing payment information)').length, 1,
+                'shows alert warning on organization section');
+  });
 });
+

--- a/tests/acceptance/missing-billing-detail-test.js
+++ b/tests/acceptance/missing-billing-detail-test.js
@@ -1,0 +1,63 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import { stubRequest } from "ember-cli-fake-server";
+import startApp from '../helpers/start-app';
+
+let application;
+
+module('Acceptance: Missing Billing Detail', {
+  beforeEach: function() {
+    application = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('with only one organization', function(assert) {
+  stubOrganizations();
+  stubStacks();
+  stubOrganization({ id: 1 });
+  stubRequest('get', '/billing_details/1', (request) => request.notFound());
+
+  signInAndVisit('/');
+
+  andThen(function() {
+    assert.equal(currentPath(), 'welcome.payment-info', 'redirected to payment info when all organizations lack billing detail');
+  });
+});
+
+test('with more than one organization', function(assert) {
+  let organizations = [
+    {
+      id: 1, name: 'sprocket co',
+      _links: {
+        self: { href: '/organizations/1' },
+        billing_detail: { href: '/billing_details/1' }
+      }
+    },
+    {
+      id: 2, name: 'sprocket co2',
+      _links: {
+        self: { href: '/organizations/2' },
+        billing_detail: { href: '/billing_details/2' }
+      }
+    }
+  ];
+  stubBillingDetail({ id: 1 });
+  stubRequest('get', '/billing_details/2', (request) => request.notFound());
+  stubRequest('get', '/organizations', function(request) {
+    return this.success({
+      _links: {},_embedded: { organizations }
+    });
+  });
+  stubOrganization({ id: 1 });
+
+  stubStacks();
+  signInAndVisit('/');
+
+  andThen(function() {
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index', 'was not redirected to payment info');
+  })
+});

--- a/tests/acceptance/organization-test.js
+++ b/tests/acceptance/organization-test.js
@@ -25,7 +25,7 @@ test('visiting /organization', function(assert) {
   setFeature('organization-settings', true);
   signInAndVisit('/organizations/1');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.members.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.members.index');
     expectLink('/organizations/1/members');
     expectLink('/organizations/1/roles');
   });

--- a/tests/acceptance/organization/contact-settings-test.js
+++ b/tests/acceptance/organization/contact-settings-test.js
@@ -92,7 +92,7 @@ test(`visiting ${url}`, function(assert) {
   signInAndVisit(url);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.contact-settings');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.contact-settings');
     expectInput('name', {value: organizationData.name});
     expectInput('primary-phone', {value: organizationData.primaryPhone});
     expectInput('emergency-phone', {value: organizationData.emergencyPhone});

--- a/tests/acceptance/organization/environments/create-test.js
+++ b/tests/acceptance/organization/environments/create-test.js
@@ -36,7 +36,7 @@ test(`visiting ${url} shows form to create new environment`, (assert) => {
   stubStacks();
   signInAndVisit(url);
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.environments.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.environments.new');
     expectButton('Save environment');
     expectButton('Cancel');
     expectFocusedInput('environment-handle');
@@ -77,7 +77,7 @@ test(`visiting ${url} and creating new environment`, (assert) => {
     clickButton('Save environment');
   });
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.environments.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.environments.index');
   });
 });
 
@@ -119,7 +119,7 @@ test(`visiting ${url} and with duplicate handle`, (assert) => {
   });
   andThen(() => {
     //Still on new page
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.environments.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.environments.new');
   });
 });
 
@@ -157,7 +157,7 @@ test(`visiting ${url} and creating new prod environment`, (assert) => {
     clickButton('Save environment');
   });
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.environments.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.environments.index');
   });
 });
 
@@ -195,6 +195,6 @@ test(`Creating a new environment with non-phi plan offers a link to upgrade`, (a
     clickButton('Save environment');
   });
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.environments.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.environments.index');
   });
 });

--- a/tests/acceptance/organization/invite-test.js
+++ b/tests/acceptance/organization/invite-test.js
@@ -55,7 +55,7 @@ test(`visiting ${url} shows form to invite`, function(assert) {
 
   signInAndVisit(url);
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.invite');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.invite');
     expectFocusedInput('email');
     expectInput('email');
     expectInput('role');
@@ -81,7 +81,7 @@ test(`visiting ${url} and clicking cancel`, function(assert) {
   clickButton('Cancel');
 
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.members.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.members.index');
   });
 });
 

--- a/tests/acceptance/organization/members-test.js
+++ b/tests/acceptance/organization/members-test.js
@@ -96,7 +96,7 @@ test(`visiting ${url} shows users`, function(assert) {
   signInAndVisit(url, {}, roleData);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.members.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.members.index');
     assert.ok(find(':contains(Mike)').length, 'Mike is on the page');
     assert.ok(find(':contains(bob@bob.com)').length, 'bob@bob.com is on the page');
     expectLink(`/organizations/${orgId}/invite`);

--- a/tests/acceptance/organization/members/edit-test.js
+++ b/tests/acceptance/organization/members/edit-test.js
@@ -91,7 +91,7 @@ test(`visiting ${url} shows user's info and all roles with checkboxes`, function
   signInAndVisit(url);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.members.edit');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.members.edit');
     assert.ok(find(`:contains(${user.name})`).length, `user name "${user.name} is on the page`);
 
     expectButton('Save');
@@ -201,6 +201,6 @@ test(`visit ${url} allows removing user from organization`, function(assert){
   signInAndVisit(url);
   clickButton(`Remove from ${orgName}`);
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.members.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.members.index');
   });
 });

--- a/tests/acceptance/organization/roles-test.js
+++ b/tests/acceptance/organization/roles-test.js
@@ -87,7 +87,7 @@ test(`visiting ${url} shows roles`, (assert) => {
   signInAndVisit(url, {}, roles[0]);
 
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.roles.platform');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.roles.platform');
 
     roles.forEach( (r) => {
       let roleDiv = find(`.role-details__heading:contains(${r.name})`);
@@ -127,6 +127,6 @@ test(`visit ${url} and click to show`, (assert) => {
   signInAndVisit(url);
   click(`a[title="Edit ${role.name} Permissions"]`);
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.role.members');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.role.members');
   });
 });

--- a/tests/acceptance/organization/roles/create-test.js
+++ b/tests/acceptance/organization/roles/create-test.js
@@ -59,7 +59,7 @@ test(`visiting ${url} shows form to create new role`, (assert) => {
   setup('dev');
   signInAndVisit(url);
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.roles.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.roles.new');
     expectButton('Save');
     expectButton('Cancel');
     expectFocusedInput('role-name');
@@ -85,7 +85,7 @@ test(`visiting ${url} and creating new platform_user role`, (assert) => {
     clickButton('Save');
   });
   andThen(() => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.role.members');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.role.members');
   });
 });
 
@@ -103,13 +103,13 @@ test(`visiting ${url} and creating new compliance_user role`, (assert) => {
 
   signInAndVisit(url);
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.organization.roles.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.organization.roles.new');
     fillInput('role-name', roleData.name);
     findWithAssert('.role-type-option[data-option-value=compliance_user]').click();
     clickButton('Save');
   });
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.role.members');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.role.members');
   });
 });
 

--- a/tests/acceptance/password/new-test.js
+++ b/tests/acceptance/password/new-test.js
@@ -29,7 +29,7 @@ test('visiting /password/new/:reset_code/:user_id signed in redirects to index',
   var resetCode = 'defResetCode';
   signInAndVisit(`/password/new/${resetCode}/${userId}`);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/password/reset-test.js
+++ b/tests/acceptance/password/reset-test.js
@@ -29,7 +29,7 @@ test('visiting /password/reset signed in redirects to index', function(assert) {
   stubStacks();
   signInAndVisit('/password/reset');
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/signup/index-test.js
+++ b/tests/acceptance/signup/index-test.js
@@ -68,31 +68,6 @@ test('Creating an account directs to welcome wizard', function(assert) {
   });
 });
 
-test('Signing up with a platform plan shows platform copy', function(assert) {
-  // for loading information on the welcome.first-app screen
-  stubStacks({}, []);
-  stubOrganizations();
-  url = `${url}?plan=platform`;
-
-  stubRequest('post', '/organizations', function(request){
-    let params = this.json(request);
-    assert.equal(params.name, userInput.organization, 'correct organization is passed');
-    return this.success({
-      id: 'my-organization',
-      name: userInput.organization
-    });
-  });
-
-  doSignupSteps(url, userInput, {clickButton:false});
-  fillInput('organization', userInput.organization);
-  clickButton('Create account');
-
-  andThen(function() {
-    assert.equal(currentPath(), 'welcome.first-app', 'directs to first app');
-    assert.ok(find(':contains(Create Your Aptible platform Environment)'));
-    assert.ok(find(':contains(Create a database to store PHI)'));
-  });
-});
 
 test('Signing up with no plan shows development copy', function(assert) {
   // for loading information on the welcome.first-app screen
@@ -114,8 +89,8 @@ test('Signing up with no plan shows development copy', function(assert) {
 
   andThen(function() {
     assert.equal(currentPath(), 'welcome.first-app', 'directs to first app');
-    assert.ok(find(':contains(Create Your Aptible development Environment)'));
-    assert.ok(find(':contains(Create a database for your app)'));
+    assert.ok(find(':contains(Create Your Aptible development Environment)'), 'has create environment');
+    assert.ok(find(':contains(Create a database for your app)'), 'has create database');
   });
 });
 

--- a/tests/acceptance/stack/show-test.js
+++ b/tests/acceptance/stack/show-test.js
@@ -68,7 +68,7 @@ test(`visit ${url} shows basic stack info`, function(assert) {
   signInAndVisit(url);
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
     assert.ok(find('ul.resource-navigation li.active a:contains(Apps)').length,
               'Has active apps link');
 

--- a/tests/acceptance/verification-test.js
+++ b/tests/acceptance/verification-test.js
@@ -37,7 +37,7 @@ test('visiting /verify/some-code creates verification', function(assert) {
   let userData = {verified: false};
   signInAndVisit(`/verify/${verificationCode}`, userData);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -78,7 +78,7 @@ test('after verification, pending databases are provisioned', function(assert) {
 
   signInAndVisit('/verify/'+verificationCode);
   andThen(function(){
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/welcome/first-app-test.js
+++ b/tests/acceptance/welcome/first-app-test.js
@@ -28,15 +28,27 @@ test('visiting /welcome/first-app when not logged in', function(assert) {
   });
 });
 
-test('visiting /welcome/first-app logged in with stacks', function(assert) {
+test('visiting /welcome/1/first-app logged in with no billing detail', function(assert) {
   stubStacks();
   stubRequest('get', '/billing_details/1', (request) => request.notFound());
   stubOrganizations();
   stubOrganization();
-  signInAndVisit('/welcome/first-app');
+  signInAndVisit('/welcome/1/first-app');
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
+    assert.equal(currentPath(), 'welcome.first-app', 'remain on welcome page');
+  });
+});
+
+test('visiting /welcome/1/first-app logged in with billing detail and stacks redirects to stacks', function(assert) {
+  stubStacks();
+  stubBillingDetail({ id: 1 });
+  stubOrganizations();
+  stubOrganization();
+  signInAndVisit('/welcome/1/first-app');
+
+  andThen(function() {
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index', 'remain on welcome page');
   });
 });
 

--- a/tests/acceptance/welcome/first-app-test.js
+++ b/tests/acceptance/welcome/first-app-test.js
@@ -21,7 +21,7 @@ module('Acceptance: WelcomeFirstApp', {
 });
 
 test('visiting /welcome/first-app when not logged in', function(assert) {
-  visit('/welcome/first-app');
+  visit('/welcome/1/first-app');
 
   andThen(function() {
     assert.equal(currentPath(), 'login');
@@ -30,6 +30,7 @@ test('visiting /welcome/first-app when not logged in', function(assert) {
 
 test('visiting /welcome/first-app logged in with stacks', function(assert) {
   stubStacks();
+  stubRequest('get', '/billing_details/1', (request) => request.notFound());
   stubOrganizations();
   stubOrganization();
   signInAndVisit('/welcome/first-app');
@@ -42,11 +43,13 @@ test('visiting /welcome/first-app logged in with stacks', function(assert) {
 test('submitting a first app directs to payment info', function(assert) {
   var appHandle = 'my-app';
 
+  stubRequest('get', '/billing_details/1', (request) => request.notFound());
   stubStacks({}, []);
   stubOrganizations();
-  signInAndVisit('/welcome/first-app');
+  signInAndVisit('/welcome/1/first-app');
 
   fillIn('input[name="app-handle"]', appHandle);
+
   click('button:contains(Get Started)');
   andThen(function() {
     assert.equal(currentPath(), 'welcome.payment-info', 'redirected to payment info');
@@ -56,7 +59,7 @@ test('submitting a first app directs to payment info', function(assert) {
 test('choosing a database type opens database pane, clicking it again closes', function(assert) {
   stubStacks({}, []);
   stubOrganizations();
-  signInAndVisit('/welcome/first-app');
+  signInAndVisit('/welcome/1/first-app');
 
   click('.select-option[title="Redis"]');
   andThen(() => {

--- a/tests/acceptance/welcome/first-app-test.js
+++ b/tests/acceptance/welcome/first-app-test.js
@@ -35,7 +35,7 @@ test('visiting /welcome/first-app logged in with stacks', function(assert) {
   signInAndVisit('/welcome/first-app');
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -304,7 +304,6 @@ test('submitting valid payment info should create app', function(assert) {
   stubOrganization();
 
   stubRequest('get', '/billing_details/1', function(){
-    console.log("CATCHING");
     return this.notFound();
   });
 

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -84,7 +84,7 @@ test('visiting /welcome/payment-info logged in with stacks', function(assert) {
   signInAndVisit('/welcome/payment-info');
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -186,7 +186,7 @@ test('payment info should be submitted to stripe to create stripeToken', functio
     clickButton('Save');
   });
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -229,7 +229,7 @@ test('submitting valid payment info for development plan should create dev stack
     clickButton('Save');
   });
   andThen( () => {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
   });
 });
 
@@ -281,7 +281,7 @@ test('submitting valid payment info on organization with existing stripe info sh
   clickButton('Save');
 
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
   });
 });
 
@@ -324,7 +324,7 @@ test('submitting valid payment info should create app', function(assert) {
   });
   clickButton('Save');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.index');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.index');
   });
 });
 
@@ -371,7 +371,7 @@ test('submitting valid payment info should create db', function(assert) {
   });
   clickButton('Save');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
   });
 });
 
@@ -426,7 +426,7 @@ test('submitting valid payment info when user is verified should provision db', 
   });
   clickButton('Save');
   andThen(function() {
-    assert.equal(currentPath(), 'dashboard.requires-read-access.stack.apps.new');
+    assert.equal(currentPath(), 'dashboard.catch-redirects.stack.apps.new');
 
     assert.equal(databaseParams.handle, dbHandle,
           'db params has handle');


### PR DESCRIPTION
This PR expands on #670 to fully fix #669.

* Any user who belongs only to one organization that lacks a billing detail will now automatically be redirected to complete payment setup.

* Any user who belongs to multiple organizations will have a new "Complete payment info" button next to each organization lacking a billing detail.

These somewhat minor fixes require a complete refactor of the payment-info screen as it previously just punted on multi-org setups by always using the first org found.   

This PR also renames the `requires-read-access` route to something more generic.  This is because that route is now used to filter and redirect on 3 possible bad/error states.
