### PR TITLE
Prevent potential issue with account creation

### DIFF
--- a/app/components/handle-input/component.js
+++ b/app/components/handle-input/component.js
@@ -25,6 +25,6 @@ export default OneWayInput.extend(Autofocusable, {
       // FIXME: nonAlphaNumerics really should be replaced with an empty string,
       // however that breaks the `value` attr binding so that the first invalid
       // character is never actually stripped.
-      replace(nonAlphaNumerics, '-');
+      replace(nonAlphaNumerics, '');
   }
 });

--- a/app/components/handle-input/component.js
+++ b/app/components/handle-input/component.js
@@ -22,6 +22,9 @@ export default OneWayInput.extend(Autofocusable, {
     return truncate(input, maxChars).
       replace(capitalLetters, replaceWithLower).
       replace(spaces, '-').
-      replace(nonAlphaNumerics, '');
+      // FIXME: nonAlphaNumerics really should be replaced with an empty string,
+      // however that breaks the `value` attr binding so that the first invalid
+      // character is never actually stripped.
+      replace(nonAlphaNumerics, '-');
   }
 });

--- a/app/no-stack/route.js
+++ b/app/no-stack/route.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({});

--- a/app/no-stack/template.hbs
+++ b/app/no-stack/template.hbs
@@ -1,0 +1,11 @@
+{{#error-page
+  title="Your account doesn't have access to any environments!"
+  message="This is likely because of an error during your account's initial setup.  Please contact support using the link below."
+  actionName="Logout"
+  actionDestination="settings.logout"}}
+
+  <p>
+    Note: you're still logged in as {{session.currentUser.name}};
+    if you are on a shared computer, log out now:
+  </p>
+{{/error-page}}

--- a/app/router.js
+++ b/app/router.js
@@ -183,6 +183,8 @@ Router.map(function() {
   this.authenticatedRoute("trainee-dashboard", { resetNamespace: true });
   this.authenticatedRoute("elevate", { resetNamespace: true });
   this.authenticatedRoute("no-organization", { resetNamespace: true });
+  this.authenticatedRoute("no-stack", { resetNamespace: true });
+
 
   this.route("login");
   this.route("signup", {}, function(){

--- a/app/stacks/route.js
+++ b/app/stacks/route.js
@@ -18,7 +18,7 @@ export default Ember.Route.extend({
     }
     else {
       if (stacks.get('length') === 0) {
-        this.transitionTo('welcome.first-app');
+        this.transitionTo('no-stack');
       } else if (stack.get('activated')) {
         this.transitionTo('apps', stack);
       } else {

--- a/tests/acceptance/no-stack-test.js
+++ b/tests/acceptance/no-stack-test.js
@@ -1,0 +1,37 @@
+import Ember from "ember";
+import { stubRequest } from "ember-cli-fake-server";
+import {module, test} from "qunit";
+import startApp from "../helpers/start-app";
+
+let App;
+
+module("Acceptance: No Stacks Page", {
+  beforeEach: function() {
+    App = startApp();
+    stubOrganizations();
+
+    stubRequest("get", "/accounts", function() {
+      return this.success({
+        _embedded: {
+          accounts: []
+        }
+      });
+    });
+  },
+  afterEach: function() {
+    Ember.run(App, "destroy");
+  }
+});
+
+test("visiting / redirects to no stacks page", function(assert) {
+  signInAndVisit("/");
+
+  andThen(function() {
+    assert.equal(currentPath(), "no-stack");
+    expectLink("support.aptible.com");
+    expectLink("status.aptible.com");
+    expectLink("twitter.com/aptiblestatus");
+    assert.ok(find(`a[href="/settings/logout"]`).length,
+              "Has link to /settings/logout");
+  });
+});


### PR DESCRIPTION
This PR fixes two more bugs that came up today:

1) It's possible to inject blacklisted handle chars using our `handle-input` component. This is tricky, but, if you only ever input blacklisted characters, the sanitized value of the input is never persisted as the actual value.  This is because all of the sanitized characters are replaced with empty string and empty string == empty string. It's not immediately clear to me how to fix this, so I am temporarily replacing all blacklist chars with `-`.  This isn't ideal, but at least fixes the major issue of blacklisted characters hitting API and failing account creation. 

2) Users with 0 stacks (as in those affected by the above bug) are now redirected to a `no-stacks` error page.  This is a bad state that our UI can't gracefully handle without additional refactor. 
