### PR TITLE
Refactor service slider component

### DIFF
--- a/app/components/service-scaler/component.js
+++ b/app/components/service-scaler/component.js
@@ -8,50 +8,47 @@ export default Ember.Component.extend({
 
   isSliding: false,
 
-  shouldDisable: Ember.computed('isv1Stack', 'isSaving', function() {
-    return this.get('isv1Stack') || this.get('isSaving');
-  }),
+  init() {
+    this._super(...arguments);
+    this.set('containerSize', this.get('service.containerSize'));
+    this.set('containerCount', this.get('service.containerCount'));
+  },
 
   isv2Stack: Ember.computed.equal('service.stack.sweetnessStackVersion', 'v2'),
   isv1Stack: Ember.computed.not('isv2Stack'),
 
-  showActionButtons: function(){
-    if (this.get('isSliding')) { return false; }
+  shouldDisable: Ember.computed.or('isv1Stack', 'isSaving'),
+  hasCountChanged: Ember.computed('containerCount', 'service.containerCount', function() {
+    return this.get('containerCount') !== this.get('service.containerCount');
+  }),
 
-    return (this.get('containerCount') !==
-      this.get('service.containerCount')) || (this.get('containerSize') !==
-      this.get('service.containerSize'));
-  }.property('isSliding', 'containerSize', 'service.containerSize', 'containerCount', 'service.containerCount'),
+  hasSizeChanged: Ember.computed('containerSize', 'service.containerSize', function() {
+    return this.get('containerSize') !== this.get('service.containerSize');
+  }),
 
-  initializeContainerSize: function(){
-    this.set( 'containerSize', this.get('service.containerSize') );
-  }.on('init').observes('service.containerSize'),
+  showActionButtons: Ember.computed.or('hasCountChanged', 'hasSizeChanged'),
 
-  initializeContainerCount: function(){
-    this.set( 'containerCount', this.get('service.containerCount') );
-  }.on('init').observes('service.containerCount'),
-
-  unitOfMeasure: function() {
+  unitOfMeasure: Ember.computed('service.stack.type', function() {
     var type = this.get('service.stack.type');
     return type ? type.capitalize() + " App Container" : '';
-  }.property('service.stack.type'),
+  }),
 
   actions: {
-    setContainerSize: function(value){
+    setContainerSize(value){
       this.set('isSliding', true);
       this.set('containerSize', value);
     },
 
-    setContainerCount: function(value){
+    setContainerCount(value){
       this.set('isSliding', true);
       this.set('containerCount', value);
     },
 
-    finishSliding: function(){
+    finishSliding(){
       this.set('isSliding', false);
     },
 
-    cancel: function(){
+    cancel(){
       this.set('containerSize', this.get('service.containerSize'));
       this.set('containerCount', this.get('service.containerCount'));
 
@@ -60,14 +57,14 @@ export default Ember.Component.extend({
       this.rerender();
     },
 
-    scale: function(){
+    scale(){
       if (this.get('isSaving')) { return; }
 
-      var service = this.get('service');
-      var component = this;
+      let component = this;
 
-      var containerSize = this.get('containerSize');
-      var containerCount = this.get('containerCount');
+      let {
+        service, containerSize, containerCount
+      } = this.getProperties('service', 'containerSize', 'containerCount');
 
       this.set('isSaving', true);
 
@@ -89,7 +86,7 @@ export default Ember.Component.extend({
       });
     },
 
-    clearMessages: function() {
+    clearMessages() {
       this.set('error', false);
       this.set('success', false);
     }

--- a/app/components/service-scaler/template.hbs
+++ b/app/components/service-scaler/template.hbs
@@ -39,15 +39,17 @@
           </div>
         </div>
 
-        <div class="slider-actions" data-visible="{{showActionButtons}}">
-          <button {{action "cancel"}} class="btn btn-xs btn-default btn-cancel">Cancel</button>
-          <button {{action "scale"}} class="btn btn-xs btn-primary slider-confirm" disabled={{ isSaving }}>
-            {{#if isSaving}}
-              Scaling...
-            {{else}}
-              Scale
-            {{/if}}
-          </button>
+        <div class="slider-actions">
+          {{#if showActionButtons}}
+            <button {{action "cancel"}} class="btn btn-xs btn-default btn-cancel">Cancel</button>
+            <button {{action "scale"}} class="btn btn-xs btn-primary slider-confirm" disabled={{ isSaving }}>
+              {{#if isSaving}}
+                Scaling...
+              {{else}}
+                Scale
+              {{/if}}
+            </button>
+          {{/if}}
         </div>
       </div>
 

--- a/app/styles/components/slider.scss
+++ b/app/styles/components/slider.scss
@@ -110,12 +110,7 @@
 
   .slider-actions {
     text-align: right;
-    visibility: hidden;
     min-width: 64px;
-
-    &[data-visible='true'] {
-      visibility: visible;
-    }
 
     .btn {
       display: inline-block;

--- a/tests/acceptance/apps/services-test.js
+++ b/tests/acceptance/apps/services-test.js
@@ -139,12 +139,14 @@ test(`visit ${url} allows scaling of services`, function(assert) {
 
   signInAndVisit(url);
   andThen(() => {
-    assert.equal($('.btn:contains("Scale")').css('visibility'), 'hidden', 'Scale button is hidden');
+    let scaleButton = find($('.btn:contains("Scale")'));
+    assert.equal(scaleButton.length, 0, 'Scale button is not visible');
     triggerSlider('.slider', newContainerCount);
   });
 
   andThen(() => {
-    assert.equal($('.btn:contains("Scale")').css('visibility'), 'visible', 'Scale button is visible');
+    let scaleButton = find($('.btn:contains("Scale")'));
+    assert.equal(scaleButton.length, 1, 'Scale button is visible');
     clickButton('Scale');
   });
 });

--- a/tests/unit/components/service-scaler-test.js
+++ b/tests/unit/components/service-scaler-test.js
@@ -13,6 +13,13 @@ function buildFeaturesMock() {
   });
 }
 
+function scale(size) {
+  let slider = this.$().find('.slider');
+  slider.trigger('slide', size);
+  slider.trigger('set', size);
+  this.$().find("button:contains(Scale)").click();
+}
+
 moduleForComponent('service-scaler', 'ServiceScalerComponent', {
   unit: true,
   needs: ['component:no-ui-slider', 'component:estimated-cost'],
@@ -94,7 +101,7 @@ test('it should show a success message when it succeeds', function(assert) {
   const scaleServiceAction = function(_0, _1, _2, deferred) {
     return deferred.resolve();
   };
-
+  let newContainerCount = 2;
   this.subject({
     service: Ember.Object.create({
       containerSize: 1024,
@@ -103,15 +110,13 @@ test('it should show a success message when it succeeds', function(assert) {
         sweetnessStackVersion: 'v2'
       })
     }),
-    containerCount: 2,
     targetObject: { scaleServiceAction },
     scaleService: "scaleServiceAction"
   });
 
   this.render();
-
   Ember.run(() => {
-    this.$().find("button").click();
+    scale.call(this, newContainerCount);
   });
 
   assert.ok(!this.$().find("div:contains(Some error)").length, "Has no error");
@@ -122,6 +127,7 @@ test('it should not show a success message when it fails', function(assert) {
   const scaleServiceAction = function(_0, _1, _2, deferred) {
     return deferred.reject(new Error("Some error"));
   };
+  let newContainerCount = 2;
 
   this.subject({
     service: Ember.Object.create({
@@ -131,7 +137,6 @@ test('it should not show a success message when it fails', function(assert) {
         sweetnessStackVersion: 'v2'
       })
     }),
-    containerCount: 2,
     targetObject: { scaleServiceAction },
     scaleService: "scaleServiceAction"
   });
@@ -139,7 +144,7 @@ test('it should not show a success message when it fails', function(assert) {
   this.render();
 
   Ember.run(() => {
-    this.$().find("button").click();
+    scale.call(this, newContainerCount);
   });
 
   assert.ok(this.$().find("div:contains(Some error)").length, "Has error");


### PR DESCRIPTION
This purpose of this refactor was to fix the flakey app service scale acceptance test.  The cause of the intermittent failure is due to the race condition present in `showActionButtons` computed.  That computed attempted to verify that the slider has changed even though the `initializeContainerSize`computed actually updates the slider value to match--thus making `showActionButtons` extremely unreliable.  This PR removes the `initializeContainerSize` computed property and replaces many of the manual computeds with built-in macros.

This also removes all the `visibility` tricks and instead just doesn't render the buttons if they don't need to be there. 

--
cc @krallin 
