### PR TITLE
Membership Removal Updates

### DIFF
--- a/app/components/membership-table-row/component.js
+++ b/app/components/membership-table-row/component.js
@@ -49,7 +49,7 @@ export default Ember.Component.extend({
   isToggleDisabled: Ember.computed('memberUserRoles.[]', 'currentUserRoles.[]', function() {
     if (this.get('role.isOwner')) { return true; }
 
-    // Disable if current user is not a role owner
+    // Disable if current user is not a platform, compliance, or account owner
     if (!this.isRoleOwner(this.get('currentUser'), this.get('currentUserRoles'))) {
       return true;
     }
@@ -60,6 +60,9 @@ export default Ember.Component.extend({
 
   isRoleOwner(user, roles) {
     if (!this.get('user')) { return false; }
+    if (user.isAccountOwner(roles, this.get('organization'))) {
+      return true;
+    }
     if (this.get('role.isCompliance')) {
       return user.isComplianceOwner(roles, this.get('organization'));
     }

--- a/app/components/membership-table-row/template.hbs
+++ b/app/components/membership-table-row/template.hbs
@@ -14,13 +14,28 @@
       toggled=isToggled
       toggle='togglePrivileged'
       showLabels=false
-      disabled=isDisabled
+      disabled=isToggleDisabled
       size='small'}}
 </td>
 <td class="aptable__actions aptable__actions--skinny">
-  <a class="btn btn-default btn-xs" {{action 'destroyMembership' membership}} href="#">
-    {{#bs-tooltip title="Remove role membership"}}
+  {{#if isOnlyRole}}
+    {{#if linkToEditMember}}
+      {{#link-to 'organization.members.edit' organization membership.user classNames='btn btn-default btn-xs'}}
+        {{#bs-tooltip title=removeTooltip}}
+          <i class="glyphicon glyphicon-pencil"></i> Edit
+        {{/bs-tooltip}}
+      {{/link-to}}
+    {{else}}
+      <button class="btn btn-default btn-xs" disabled>
+        <i class="fa fa-times"></i> Remove
+      </button>
+      {{#bs-tooltip title=removeTooltip}}
+        <i class="fa fa-exclamation-triangle btn__tip">Remove</i>
+      {{/bs-tooltip}}
+    {{/if}}
+  {{else}}
+    <button class="btn btn-default btn-xs" {{action 'destroyMembership'}}>
       <i class="fa fa-times"></i> Remove
-    {{/bs-tooltip}}
-  </a>
+    </button>
+  {{/if}}
 </td>

--- a/app/organization/members/edit/controller.js
+++ b/app/organization/members/edit/controller.js
@@ -15,16 +15,25 @@ export default Ember.Controller.extend({
   isSecurityOfficer: Ember.computed('organization.securityOfficer.id', 'model.id', function() {
     return this.get('organization.securityOfficer.id') === this.get('model.id');
   }),
+
   isBillingContact: Ember.computed('organization.billingDetail.billingContact.id', 'model.id', function() {
     return this.get('organization.billingDetail.billingContact.id') === this.get('model.id');
   }),
-  disableRemoveMessage: Ember.computed('isSecurityOfficer', 'isBillingContact', function() {
-    if(this.get('isSecurityOfficer')) {
-      return `${this.get('model.name')} is this organization's Security Officer.`;
-    } else if(this.get('isBillingContact')) {
-      return `${this.get('model.name')} is this organization's Billing Contact.`;
-    }
 
+  removeMessage(userName, orgName, officer) {
+    return `${userName} is ${orgName}'s ${officer} and cannot be removed until
+            another user is assigned.`;
+  },
+
+  disableRemoveMessage: Ember.computed('isSecurityOfficer', 'isBillingContact', function() {
+    let userName = this.get('model.name');
+    let orgName = this.get('organization.name');
+    if (this.get('isSecurityOfficer')) {
+      return this.removeMessage(userName, orgName, 'Security Officer');
+    }
+    if (this.get('isBillingContact')) {
+      return this.removeMessage(userName, orgName, 'Billing Contact');
+    }
     return false;
   })
 });

--- a/app/organization/members/edit/route.js
+++ b/app/organization/members/edit/route.js
@@ -38,11 +38,25 @@ export default Ember.Route.extend({
 
     remove(user){
       let organization = this.modelFor('organization');
+      let billingDetail = organization.get('billingDetail');
+      let message = `${user.get('name')} removed from ${organization.get('name')}`;
+
+      if (user.get('id') === organization.get('securityOfficer.id')) {
+        message = `${user.get('name')} is ${organization.get('name')}'s Security
+                   Officer and cannot be removed until a new one is assigned.`;
+        Ember.get(this, 'flashMessages').failure(message);
+        return false;
+      }
+
+      if (user.get('id') === billingDetail.get('billingContact.id')) {
+        message = `${user.get('name')} is ${organization.get('name')}'s Billing
+                   Contact and cannot be removed until a new one is assigned.`;
+        Ember.get(this, 'flashMessages').failure(message);
+        return false;
+      }
 
       user.set('organizationId', organization.get('id'));
       user.destroyRecord().then(() => {
-        let message = `${user.get('name')} removed from ${organization.get('name')}`;
-
         this.transitionTo('organization.members');
         Ember.get(this, 'flashMessages').success(message);
       });

--- a/app/organization/members/edit/template.hbs
+++ b/app/organization/members/edit/template.hbs
@@ -25,15 +25,19 @@
             </div>
 
             {{#unless (eq session.currentUser model)}}
-              <div class="">
-                <label>Remove {{model.name}} from {{organization.name}}</label>
+              <div class="member-edit__remove">
+                <label>
+                  Remove {{model.name}} from {{organization.name}}
+                  {{#if disableRemoveMessage}}
+                    {{#bs-tooltip title=disableRemoveMessage placement="bottom" bs-contaner=false}}
+                      <i class="fa fa-exclamation-triangle"></i>
+                    {{/bs-tooltip}}
+                  {{/if}}
+                </label>
                 {{#if disableRemoveMessage}}
-                  {{#bs-tooltip title=disableRemoveMessage placement="bottom" bs-contaner=false}}
-                    <div>
-                      <button class='btn btn-danger btn-block' disabled>Remove from {{organization.name}}
-                      </button>
-                    </div>
-                  {{/bs-tooltip}}
+                    <button class='btn btn-danger btn-block' disabled>
+                      Remove from {{organization.name}}
+                    </button>
                 {{else}}
                   <button {{action 'remove' model}} class='btn btn-danger btn-block'>
                     Remove from {{organization.name}}

--- a/app/role/members/route.js
+++ b/app/role/members/route.js
@@ -20,6 +20,19 @@ export default Ember.Route.extend({
     controller.set('currentUserRoles', model.currentUserRoles);
   },
 
+  redirect(model) {
+    let org = model.role.get('organization');
+    let currentUser = this.session.get('currentUser');
+    let currentUserMembership = model.memberships.filterBy('user.id', currentUser.get('id'))[0];
+
+    if ((model.role.get('isPlatform') && currentUser.canManagePlatform(model.currentUserRoles, org)) ||
+        (model.role.get('isCompliance') && currentUser.canManageCompliance(model.currentUserRoles, org)) ||
+        (currentUserMembership && currentUserMembership.get('privileged'))) {
+      return;
+    }
+    return this.transitionTo('organization.roles', org);
+  },
+
   // Note: Memberships are removed by the membership table row component
   actions: {
     completedAction(message) {

--- a/app/role/members/route.js
+++ b/app/role/members/route.js
@@ -22,6 +22,14 @@ export default Ember.Route.extend({
 
   // Note: Memberships are removed by the membership table row component
   actions: {
+    completedAction(message) {
+      Ember.get(this, 'flashMessages').success(message);
+    },
+
+    failedAction(message) {
+      Ember.get(this, 'flashMessages').danger(message);
+    },
+
     addMember() {
       const user = this.controller.get('invitedUser');
       if (!user) { return; }

--- a/app/role/members/template.hbs
+++ b/app/role/members/template.hbs
@@ -61,6 +61,8 @@
               membership=membership
               organization=organization
               role=role
+              completedAction='completedAction'
+              failedAction='failedAction'
               currentUser=session.currentUser}}
         {{else}}
           <td class="aptable--empty" colspan="6">

--- a/app/styles/components/_aptables.scss
+++ b/app/styles/components/_aptables.scss
@@ -80,7 +80,7 @@
     color: #999;
   }
 
-  a.btn.btn-xs {
+  .btn.btn-xs.btn--link {
     padding: 1px 4px;
   }
   .x-toggle:checked + .x-toggle-light.x-toggle-btn {
@@ -88,6 +88,14 @@
   }
   .x-toggle-container-disabled {
     opacity: 0.6;
+  }
+  .btn__tip {
+    opacity: 0;
+    cursor: pointer;
+    height: 28px;
+    padding: 5px 8px 3px;
+    position: absolute;
+    transform: translate(25px, -28px);
   }
 }
 .aptable__actions--skinny {

--- a/app/styles/components/_aptables.scss
+++ b/app/styles/components/_aptables.scss
@@ -63,11 +63,6 @@
     td {
       background-color: #f7f8fb;
     }
-
-    .aptable__actions .btn {
-      visibility: visible;
-      opacity: 1;
-    }
   }
 }
 
@@ -83,13 +78,6 @@
 .aptable__actions {
   .btn {
     color: #999;
-    opacity: 0;
-    transition: opacity 0.25s ease-in-out;
-    visibility: hidden;
-
-    &:hover {
-      color: #999;
-    }
   }
 
   a.btn.btn-xs {

--- a/app/styles/components/role-members.scss
+++ b/app/styles/components/role-members.scss
@@ -62,3 +62,7 @@ ul.role-members {
     width: 90%;
   }
 }
+
+.member-edit__remove {
+  margin-top: 20px;
+}

--- a/app/templates/organization/-invited-user-table-row.hbs
+++ b/app/templates/organization/-invited-user-table-row.hbs
@@ -7,12 +7,12 @@
   {{#aptible-ability scope="manage" user=session.currentUser role=invitation.role permittable=organization as |hasAbility|}}
     {{#if hasAbility}}
       <td class="aptable__actions aptable__actions--skinny">
-        <a class="btn btn-default btn-xs" {{action 'destroyInvitation' invitation}} href="#">
+        <a class="btn btn-default btn-xs btn--link" {{action 'destroyInvitation' invitation}} href="#">
           {{#bs-tooltip title="Delete Invitation"}}
             <i class="fa fa-times"></i>
           {{/bs-tooltip}}
         </a>
-        <a class="btn btn-default btn-xs" {{action 'resendInvitation' invitation}} href="#">
+        <a class="btn btn-default btn-xs btn--link" {{action 'resendInvitation' invitation}} href="#">
           {{#bs-tooltip title="Resend Invitation"}}
           <i class="fa fa-undo"></i>
           {{/bs-tooltip}}

--- a/tests/acceptance/organization/members/edit-test.js
+++ b/tests/acceptance/organization/members/edit-test.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import {
   module,
-  test
+  test,
+  skip
 } from 'qunit';
 import startApp from 'diesel/tests/helpers/start-app';
 import { stubRequest } from 'diesel/tests/helpers/fake-server';
@@ -203,4 +204,12 @@ test(`visit ${url} allows removing user from organization`, function(assert){
   andThen(() => {
     assert.equal(currentPath(), 'dashboard.catch-redirects.organization.members.index');
   });
+});
+
+skip(`disables remove for the organization's security officer`, function(assert){
+  assert.expect(1);
+});
+
+skip(`disables remove for the organization's billing contact`, function(assert){
+  assert.expect(1);
 });

--- a/tests/acceptance/role/members-test.js
+++ b/tests/acceptance/role/members-test.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 import {
   module,
-  test
+  test,
+  skip
 } from 'qunit';
 import startApp from 'diesel/tests/helpers/start-app';
 import { stubRequest } from '../../helpers/fake-server';
@@ -114,6 +115,14 @@ test(`visiting ${pageUrl} role members can be added by account owners`, (assert)
   });
 });
 
-// TODO:
-//  - admin member toggle
-//  - remove
+skip(`visiting ${pageUrl} role members can be removed by account owners`, (assert) => {
+  assert.expect(1);
+});
+
+skip(`visiting ${pageUrl} role members' last role cannot be removed`, (assert) => {
+  assert.expect(1);
+});
+
+skip(`visiting ${pageUrl} role members can be made an admins`, (assert) => {
+  assert.expect(1);
+});


### PR DESCRIPTION
- should no longer be able to remove a user’s last role from the role members screen
- relies on the member edit to enforce protecting removal of the billing contact and security officer (logic already existed there)
- Always show actions in tables
- redirect unauthorized users from an individual role view back to the role list (or lists) they do have access to
![account-owner-remove](https://cloud.githubusercontent.com/assets/94830/17339648/0cb69094-58aa-11e6-9ce2-82d41e157056.gif)
