### PR TITLE
Switch from IAM to ACM certificates

### DIFF
--- a/lib/create-website/templates/cloudfront-s3-website.json
+++ b/lib/create-website/templates/cloudfront-s3-website.json
@@ -101,7 +101,7 @@
               "Id": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] }
             }
           ],
-          "PriceClass": "PriceClass_100",
+          "PriceClass": { "Ref": "PriceClass" },
           "ViewerCertificate": {
             "IamCertificateId": { "Fn::FindInMap": [ "DomainAWSResourceIdMap", { "Ref": "Domain" }, "IamCertificateId" ] },
             "SslSupportMethod": "sni-only"

--- a/lib/create-website/templates/cloudfront-s3-website.json
+++ b/lib/create-website/templates/cloudfront-s3-website.json
@@ -50,19 +50,7 @@
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "Private",
-        "BucketName": {
-          "Fn::Join": [
-            ".",
-            [
-              {
-                "Ref": "Subdomain"
-              },
-              {
-                "Ref": "Domain"
-              }
-            ]
-          ]
-        },
+        "BucketName": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] },
         "WebsiteConfiguration": {
           "IndexDocument": "index.html",
           "RoutingRules": [
@@ -71,19 +59,7 @@
                 "HttpErrorCodeReturnedEquals": "403"
               },
               "RedirectRule": {
-                "HostName": {
-                  "Fn::Join": [
-                    ".",
-                    [
-                      {
-                        "Ref": "Subdomain"
-                      },
-                      {
-                        "Ref": "Domain"
-                      }
-                    ]
-                  ]
-                },
+                "HostName": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] },
                 "Protocol": "https",
                 "ReplaceKeyPrefixWith": "#/"
               }
@@ -97,19 +73,7 @@
       "Properties": {
         "DistributionConfig": {
           "Aliases": [
-            {
-              "Fn::Join": [
-                ".",
-                [
-                  {
-                    "Ref": "Subdomain"
-                  },
-                  {
-                    "Ref": "Domain"
-                  }
-                ]
-              ]
-            }
+            { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] }
           ],
           "DefaultCacheBehavior": {
             "ForwardedValues": {
@@ -117,40 +81,14 @@
             },
             "MinTTL": "0",
             "SmoothStreaming": false,
-            "TargetOriginId": {
-              "Fn::Join": [
-                ".",
-                [
-                  {
-                    "Ref": "Subdomain"
-                  },
-                  {
-                    "Ref": "Domain"
-                  }
-                ]
-              ]
-            },
+            "TargetOriginId": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] },
             "ViewerProtocolPolicy": "redirect-to-https"
           },
           "Enabled": true,
           "Logging": {
-            "Bucket": {
-              "Ref": "LogBucket"
-            },
+            "Bucket": { "Ref": "LogBucket" },
             "IncludeCookies": false,
-            "Prefix": {
-              "Fn::Join": [
-                ".",
-                [
-                  {
-                    "Ref": "Subdomain"
-                  },
-                  {
-                    "Ref": "Domain"
-                  }
-                ]
-              ]
-            }
+            "Prefix": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] }
           },
           "Origins": [
             {
@@ -159,52 +97,13 @@
                 "HTTPSPort": "443",
                 "OriginProtocolPolicy": "http-only"
               },
-              "DomainName": {
-                "Fn::Join": [
-                  "",
-                  [
-                    {
-                      "Ref": "Subdomain"
-                    },
-                    ".",
-                    {
-                      "Ref": "Domain"
-                    },
-                    ".",
-                    "s3-website-",
-                    {
-                      "Ref": "AWS::Region"
-                    },
-                    ".amazonaws.com"
-                  ]
-                ]
-              },
-              "Id": {
-                "Fn::Join": [
-                  ".",
-                  [
-                    {
-                      "Ref": "Subdomain"
-                    },
-                    {
-                      "Ref": "Domain"
-                    }
-                  ]
-                ]
-              }
+              "DomainName": { "Fn::Join": [ "", [ { "Ref": "Subdomain" }, ".", { "Ref": "Domain" }, ".", "s3-website-", { "Ref": "AWS::Region" }, ".amazonaws.com" ] ] },
+              "Id": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] }
             }
           ],
           "PriceClass": "PriceClass_100",
           "ViewerCertificate": {
-            "IamCertificateId": {
-              "Fn::FindInMap": [
-                "DomainAWSResourceIdMap",
-                {
-                  "Ref": "Domain"
-                },
-                "IamCertificateId"
-              ]
-            },
+            "IamCertificateId": { "Fn::FindInMap": [ "DomainAWSResourceIdMap", { "Ref": "Domain" }, "IamCertificateId" ] },
             "SslSupportMethod": "sni-only"
           }
         }
@@ -213,40 +112,10 @@
     "Route53RecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
-        "HostedZoneName": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "Domain"
-              },
-              "."
-            ]
-          ]
-        },
-        "Name": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "Subdomain"
-              },
-              ".",
-              {
-                "Ref": "Domain"
-              },
-              "."
-            ]
-          ]
-
-        },
+        "HostedZoneName": { "Fn::Join": [ "", [ { "Ref": "Domain" }, "." ] ] },
+        "Name": { "Fn::Join": [ "", [ { "Ref": "Subdomain" }, ".", { "Ref": "Domain" }, "." ] ] },
         "ResourceRecords": [
-          {
-            "Fn::GetAtt": [
-              "CloudFrontDistribution",
-              "DomainName"
-            ]
-          }
+          { "Fn::GetAtt": [ "CloudFrontDistribution", "DomainName" ] }
         ],
         "TTL": "300",
         "Type": "CNAME"

--- a/lib/create-website/templates/cloudfront-s3-website.json
+++ b/lib/create-website/templates/cloudfront-s3-website.json
@@ -30,19 +30,10 @@
         "PriceClass_100"
       ],
       "Description": "Price class for CloudFront distribution. See http://amzn.to/1Rmjv32 for details."
-    }
-  },
-  "Mappings": {
-    "DomainAWSResourceIdMap": {
-      "aptible.com": {
-        "IamCertificateId": "ASCAIIHAG2U3A2CIAFOSU"
-      },
-      "aptible-staging.com": {
-        "IamCertificateId": "ASCAIWRPADW2NPHDICMCA"
-      },
-      "aptible-sandbox.com": {
-        "IamCertificateId": "ASCAJJHNGQXFAFJ77ANTO"
-      }
+    },
+    "AcmCertificateArn": {
+      "Type": "String",
+      "Default": "arn:aws:acm:us-east-1:916150859591:certificate/77bc3323-0f5d-4635-bc1f-8cbe1c4c4e36"
     }
   },
   "Resources": {
@@ -103,7 +94,7 @@
           ],
           "PriceClass": { "Ref": "PriceClass" },
           "ViewerCertificate": {
-            "IamCertificateId": { "Fn::FindInMap": [ "DomainAWSResourceIdMap", { "Ref": "Domain" }, "IamCertificateId" ] },
+            "AcmCertificateArn": { "Ref": "AcmCertificateArn" },
             "SslSupportMethod": "sni-only"
           }
         }

--- a/lib/create-website/templates/s3-website.json
+++ b/lib/create-website/templates/s3-website.json
@@ -21,19 +21,7 @@
       "Type": "AWS::S3::Bucket",
       "Properties": {
         "AccessControl": "Private",
-        "BucketName": {
-          "Fn::Join": [
-            ".",
-            [
-              {
-                "Ref": "Subdomain"
-              },
-              {
-                "Ref": "Domain"
-              }
-            ]
-          ]
-        },
+        "BucketName": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] },
         "WebsiteConfiguration": {
           "IndexDocument": "index.html",
           "RoutingRules": [
@@ -42,19 +30,7 @@
                 "HttpErrorCodeReturnedEquals": "403"
               },
               "RedirectRule": {
-                "HostName": {
-                  "Fn::Join": [
-                    ".",
-                    [
-                      {
-                        "Ref": "Subdomain"
-                      },
-                      {
-                        "Ref": "Domain"
-                      }
-                    ]
-                  ]
-                },
+                "HostName": { "Fn::Join": [ ".", [ { "Ref": "Subdomain" }, { "Ref": "Domain" } ] ] },
                 "Protocol": "http",
                 "ReplaceKeyPrefixWith": "#/"
               }
@@ -66,54 +42,10 @@
     "Route53RecordSet": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
-        "HostedZoneName": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "Domain"
-              },
-              "."
-            ]
-          ]
-        },
-        "Name": {
-          "Fn::Join": [
-            "",
-            [
-              {
-                "Ref": "Subdomain"
-              },
-              ".",
-              {
-                "Ref": "Domain"
-              },
-              "."
-            ]
-          ]
-
-        },
+        "HostedZoneName": { "Fn::Join": [ "", [ { "Ref": "Domain" }, "." ] ] },
+        "Name": { "Fn::Join": [ "", [ { "Ref": "Subdomain" }, ".", { "Ref": "Domain" }, "." ] ] },
         "ResourceRecords": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                {
-                  "Ref": "Subdomain"
-                },
-                ".",
-                {
-                  "Ref": "Domain"
-                },
-                ".",
-                "s3-website-",
-                {
-                  "Ref": "AWS::Region"
-                },
-                ".amazonaws.com"
-              ]
-            ]
-          }
+          { "Fn::Join": [ "", [ { "Ref": "Subdomain" }, ".", { "Ref": "Domain" }, ".", "s3-website-", { "Ref": "AWS::Region" }, ".amazonaws.com" ] ] }
         ],
         "TTL": "300",
         "Type": "CNAME"


### PR DESCRIPTION
This does for our CloudFront distributions what aptible/pancake#124 did for our ELB certificate configurations, moving from IAM to ACM so that we can deprecate all IAM certificates (except for our one production EV certificate). The first two commits are just cleanup; see 99b0fd7 for relevant changes.
