### PR TITLE
Pin liquid fire to 0.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ember-validations": "2.0.0-alpha.3",
     "express": "^4.8.5",
     "glob": "^4.0.5",
-    "liquid-fire": "ef4/liquid-fire#v0.23.0",
+    "liquid-fire": "0.22.0",
     "silent-error": "^1.0.0",
     "torii": "^0.6.0-beta.4"
   },


### PR DESCRIPTION
Fixes this issue plaguing travis


> Version "0.1.2" not compatible with "^0.1.3"
Error: Version "0.1.2" not compatible with "^0.1.3"
    at Object.<anonymous> (/home/travis/build/aptible/dashboard.aptible.com/node_modules/liquid-fire/node_modules/broccoli-merge-trees/node_modules/fs-tree-diff/node_modules/heimdalljs-logger/node_modules/heimdalljs/index.js:12:11)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/home/travis/build/aptible/dashboard.aptible.com/node_modules/liquid-fire/node_modules/broccoli-merge-trees/node_modules/fs-tree-diff/node_modules/heimdalljs-logger/dist/index.js:9:32)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
npm ERR! Test failed.  See above for more details.

cc @gib @fancyremarker 