### PR TITLE
Parallelized Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember test"
+    "test": "ember exam --split=2 --parallel"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "ember-data": "1.0.0-beta.19.2",
     "ember-deploy-s3": "0.0.5",
     "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-exam": "0.4.6",
     "ember-export-application-global": "^1.0.4",
     "ember-feature-flags": "^1.0.0",
     "ember-json-schema-document": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-truth-helpers": "^1.2.0",
     "ember-validations": "2.0.0-alpha.3",
     "express": "^4.8.5",
+    "testem": "^1.8.1",
     "glob": "^4.0.5",
     "liquid-fire": "0.22.0",
     "silent-error": "^1.0.0",

--- a/testem.json
+++ b/testem.json
@@ -1,4 +1,5 @@
 {
+  "parallel": 8,
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,


### PR DESCRIPTION
This PR reduces the time to run `ember test` by about 75%(2:38 => 0:43 for me).

To run tests in parallel, use the `ember exam --split=[n] --parallel` command where `split` is the number of batches to divvy up the tests into.  I found the best performance with 8, but you may find more optimal number on your local machine. Use `time ember exam --split=n --parallel` to measure the time for your test suite to run.

Here are my local results:

**Without parallelization:**

<img width="317" alt="screenshot 2016-08-11 10 45 59" src="https://cloud.githubusercontent.com/assets/884151/17598912/8b6d0252-5fb1-11e6-97eb-c12a1873ded5.png">

**With split=3**

<img width="238" alt="screenshot 2016-08-11 10 49 00" src="https://cloud.githubusercontent.com/assets/884151/17598917/9597e026-5fb1-11e6-9033-06aea5388f9c.png">

**With split=8**

<img width="303" alt="screenshot 2016-08-11 10 46 56" src="https://cloud.githubusercontent.com/assets/884151/17598923/9b4b9bc0-5fb1-11e6-8eeb-90a8b30d5f8b.png">

