### PR TITLE
fix log drain tests

### DIFF
--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -279,7 +279,7 @@ test(`visit ${addLogUrl} and cancel`, function(assert){
 });
 
 test(`visit ${addLogUrl} and create log success`, function(assert){
-  assert.expect(9);
+  assert.expect(8);
 
   this.prepareStubs();
 
@@ -351,7 +351,7 @@ test(`visit ${addLogUrl} without elasticsearch databases`, function(assert){
 });
 
 test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
-  assert.expect(9);
+  assert.expect(8);
 
   let drainUser = 'someUser',
       drainPassword = 'somePw',
@@ -388,6 +388,7 @@ test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
     assert.equal(json.drain_username, drainUser);
 
     json.id = logDrainId;
+    json.status = 'provisioning';
     return this.success(json);
   });
 
@@ -395,10 +396,12 @@ test(`visit ${addLogUrl} and create log to elasticsearch`, function(assert){
     return this.success();
   });
 
-  stubRequest('get', '/log_drains/:id', function(request){
+  stubRequest('get', `/log_drains/${logDrainId}`, function(request){
     assert.ok(true, 'polls for updates');
+
     return this.success({
-      id: request.params.id,
+      id: logDrainId,
+      status: 'provisioned',
       drainHost: drainHost,
       drainPort: drainPort,
       handle: logDrainId,


### PR DESCRIPTION
https://github.com/aptible/ember-cli-aptible-shared/pull/152 exposed some flakey tests in the log drain module.  These tests are particularly flakey because they are "guessing" at the number of assertions for a given test. It's not always guaranteed how many polling attempts will be hit for a given test.

This PR fixes that by limiting the polling attempt to 1, so the number of assertions can be guaranteed each test.

