### PR TITLE
Ignore expired_token on non-revoke logout

### DIFF
--- a/app/settings/logout/route.js
+++ b/app/settings/logout/route.js
@@ -26,6 +26,13 @@ export default Ember.Route.extend({
       } else {
         logoutPromise = this.session.close('application', {
           token: this.get('session.token')
+        }).catch((e) => {
+          if (e.responseJSON && e.responseJSON.error === 'expired_token') {
+            // If the user's token has expired, then we don't care to log them
+            // out "further".
+            return;
+          }
+          throw e;
         });
       }
 


### PR DESCRIPTION
When the user is attempting to logout, telling them their token expired
isn't particularly useful (after all; it's in the state they wanted it
to be...!). So, this patch ensures we don't throw an exception if the
user's token has expired.

However, we still throw one if the user was trying to revoke their
tokens. The assumption here is that silently failing might result in
them thinking their tokens were revoked when in fact they were not.

--

cc @sandersonet @gib 