### PR TITLE
Improved experience for unprivileged users + refactor aptible-ability

### DIFF
--- a/app/apps/template.hbs
+++ b/app/apps/template.hbs
@@ -5,7 +5,7 @@
       <div class="row">
         <div class="col-xs-8 col-xs-offset-2">
           <h2><strong>{{stack.handle}}</strong> has no apps yet.</h2>
-          {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+          {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
             {{#if hasAbility}}
               {{#if session.currentUser.verified}}
                 <div class="call-to-action">
@@ -85,7 +85,7 @@
 
   {{#unless hasNoApps}}
     <div class="resource-actions">
-      {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+      {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
         {{#if hasAbility}}
           {{#if session.currentUser.verified}}
             <a {{action 'openCreateAppModal'}} class="btn btn-primary open-app-modal">

--- a/app/certificates/template.hbs
+++ b/app/certificates/template.hbs
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-xs-8 col-xs-offset-2">
         <h2><strong>{{stack.handle}}</strong> has no certificates yet.</h2>
-        {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+        {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
           {{#if hasAbility}}
             {{#if session.currentUser.verified}}
               <div class="call-to-action">
@@ -38,7 +38,7 @@
 
 {{#unless hasNoCertificates}}
   <div class="resource-actions">
-    {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+    {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
       {{#if hasAbility}}
         {{#if session.currentUser.verified}}
           <a {{action 'openCreateCertificateModal'}} class="btn btn-primary open-certificate-modal">

--- a/app/claim/route.js
+++ b/app/claim/route.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  model: function(params){
+  model(params){
     let invitationId = params.invitation_id;
     let verificationCode = params.verification_code;
 
@@ -27,7 +27,7 @@ export default Ember.Route.extend({
   },
 
   actions: {
-    claim: function(){
+    claim() {
       let invitation = this.controller.get('model');
       let verificationCode = this.controller.get('verificationCode');
 

--- a/app/components/aptible-ability/component.js
+++ b/app/components/aptible-ability/component.js
@@ -1,41 +1,17 @@
 import Ember from 'ember';
 
 export default Ember.Component.extend({
-  hasAbility: false,
-  tagName: '', // tagName must be exactly '' to render this component with no surrounding tag
+  authorization: Ember.inject.service(),
+  tagName: '',
 
-  user: null,
   scope: null,
   permittable: null,
+  hasAbility: Ember.computed('scope', 'permittable', function(){
+    let { scope, permittable } = this.getProperties('scope', 'permittable');
 
-  checkAbility: Ember.on('willInsertElement', function(){
-    var user  = this.get('user'),
-        scope = this.get('scope'),
-        permittable = this.get('permittable'),
-        role = this.get('role'),
-        component = this;
+    Ember.debug("You must provide a scope to aptible-ability", !!scope);
+    Ember.debug("You must provide a permittable to aptible-ability", !!permittable);
 
-    Ember.assert("You must provide a user to aptible-ability", !!user);
-    Ember.assert("You must provide a scope to aptible-ability", !!scope);
-    Ember.assert("You must provide a permittable to aptible-ability", !!permittable);
-
-    user.can(scope, permittable).then((bool) => {
-      if (component.isDestroyed) { return; }
-
-      component.set('hasAbility', bool);
-
-      // Only check the membership of a role if the user does not have ability
-      // and the role exists
-      if (!bool && role && role.get('isUser')) {
-        role.get('memberships').then((memberships) => {
-          var membership = user.findMembership(memberships);
-
-          if (component.isDestroyed || !membership) { return; }
-
-          component.set('hasAbility', membership.get('privileged'));
-        });
-        return;
-      }
-    });
+    return this.get('authorization').checkAbility(scope, permittable);
   })
 });

--- a/app/components/membership-table-row/component.js
+++ b/app/components/membership-table-row/component.js
@@ -10,6 +10,8 @@ export default Ember.Component.extend({
   organization: Ember.computed.reads('authorizationContext.organization'),
   billingDetail: Ember.computed.reads('authorizationContext.billingDetail'),
 
+  privilegedMemberships: Ember.computed.filterBy('role.memberships', 'privileged', true),
+
   isOnlyRole: Ember.computed('membership.user', 'memberUserRoles.[]', function() {
     return this.get('memberUserRoles.length') === 1;
   }),
@@ -32,9 +34,9 @@ export default Ember.Component.extend({
 
   // Account | Platform | Compliance Owners effectively have admin privileges,
   // so it gets toggled and disabled.
-  isToggled: Ember.computed('membership.privileged', 'memberUserRoles.[]', function() {
-    return this.isRoleOwner(this.get('membership.user'), this.get('memberUserRoles')) ||
-      this.get('membership.privileged');
+  isPrivilegedMember: Ember.computed('membership.privileged', 'memberUserRoles.[]', function() {
+    //return this.isRoleOwner(this.get('membership.user'), this.get('memberUserRoles')) ||
+    return this.get('membership.privileged');
   }),
 
   isToggleDisabled: Ember.computed('memberUserRoles.[]', 'authorizationContext.currentUserRoles.[]', function() {

--- a/app/components/membership-table-row/template.hbs
+++ b/app/components/membership-table-row/template.hbs
@@ -13,18 +13,29 @@
   {{/if}}
 </td>
 
-<td class="aptable__actions aptable__actions--checkbox">
-  {{x-toggle
-    value=isToggled
-    onToggle=(action 'togglePrivileged')
-    showLabels=false
-    onLabel=true
-    offLabel=false
-    disabled=isToggleDisabled
-    size='medium'}}
-</td>
+{{#unless role.isOwner}}
+  <td class="aptable__actions aptable__actions--checkbox">
+    {{#if currentUserIsPrivileged}}
+      {{x-toggle
+        value=isPrivilegedMember
+        onToggle=(action 'togglePrivileged')
+        showLabels=false
+        onLabel=true
+        offLabel=false
+        disabled=isToggleDisabled
+        size='medium'}}
+    {{else}}
+      {{#if isPrivilegedMember}}
+        <i class="fa fa-check success"></i>
+      {{/if}}
+    {{/if}}
+  </td>
+{{/unless}}
 
 <td class="aptable__actions aptable__actions--skinny">
+
+
+{{#if currentUserIsPrivileged}}
   {{#if isOnlyRole}}
     {{#if linkToEditMember}}
       {{#link-to 'organization.members.edit' organization membership.user classNames='btn btn-default btn-xs'}}
@@ -45,4 +56,8 @@
       <i class="fa fa-times"></i> Remove
     </button>
   {{/if}}
+{{/if}}
+
+
+
 </td>

--- a/app/components/permission-toggle/component.js
+++ b/app/components/permission-toggle/component.js
@@ -19,8 +19,8 @@ export default Ember.Component.extend({
   ownerTooltipTitle: Ember.computed('role.name', 'stack.handle', function() {
     return `${this.get('role.name')} is granted all permissions for ${this.get('stack.handle')}`;
   }),
-  userIsAuthorized: Ember.computed.equal('authorizationContext.userIsEnclaveOrOrganizationAdmin'),
-  userIsUnauthorized: Ember.computed.not('userIsUnauthorized'),
+  userIsAuthorized: Ember.computed.reads('authorizationContext.userIsEnclaveOrOrganizationAdmin'),
+  userIsUnauthorized: Ember.computed.not('userIsAuthorized'),
 
   actions: {
     onToggle(valueOptions) {

--- a/app/components/permission-toggle/template.hbs
+++ b/app/components/permission-toggle/template.hbs
@@ -1,14 +1,19 @@
 {{#if roleIsOwner}}
   {{#bs-tooltip title=ownerTooltipTitle}}
-  <i class="fa fa-check success"></i>
+    <i class="fa fa-check success"></i>
   {{/bs-tooltip}}
 {{else}}
-  {{x-toggle
-    disabled=userIsUnauthorizedß
-    value=isChecked
-    onToggle=(action 'onToggle')
-    onLabel=true
-    offLabel=false
-    showLabels=false
-    size='medium'}}
+  {{#if userIsAuthorized}}
+    {{x-toggle
+      value=isChecked
+      onToggle=(action 'onToggle')
+      onLabel=true
+      offLabel=false
+      showLabels=false
+      size='medium'}}
+  {{else}}
+    {{#if isChecked}}
+      <i class="fa fa-check success"></i>
+    {{/if}}
+  {{/if}}
 {{/if}}

--- a/app/components/stack-sidebar/template.hbs
+++ b/app/components/stack-sidebar/template.hbs
@@ -9,9 +9,11 @@
   </li>
 
   {{#each sortedStacks as |stack|}}
-    {{#link-to 'stack' stack tagName="li" class="sidebar-stack-item"}}
-      {{link-to stack.handle 'stack' stack bubbles=false}}
-    {{/link-to}}
+
+        {{#link-to 'stack' stack.id tagName="li" class="sidebar-stack-item"}}
+          {{link-to stack.handle 'stack' stack.id bubbles=false}}
+        {{/link-to}}
+
   {{/each}}
 
   {{#if authorizationContext.hasNoBillingDetail}}

--- a/app/databases/template.hbs
+++ b/app/databases/template.hbs
@@ -5,7 +5,7 @@
       <div class="row">
         <div class="col-xs-8 col-xs-offset-2">
           <h2><strong>{{stack.handle}}</strong> has no databases yet.</h2>
-          {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+          {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
             {{#if hasAbility}}
               {{#if session.currentUser.verified}}
                 <div class="call-to-action">
@@ -110,7 +110,7 @@
 
   {{#unless hasNoDatabases}}
     <div class="resource-list-actions">
-      {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+      {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
         {{#if hasAbility}}
           {{#if session.currentUser.verified}}
             <a {{action 'openCreateDbModal'}} class="btn btn-primary open-db-modal">

--- a/app/enclave/index/route.js
+++ b/app/enclave/index/route.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  authorization: Ember.inject.service(),
-
   redirect() {
     this.transitionTo('stacks');
   },

--- a/app/log-drains/template.hbs
+++ b/app/log-drains/template.hbs
@@ -3,7 +3,7 @@
       <div class="row">
         <div class="col-xs-8 col-xs-offset-2">
           <h2><strong>{{stack.handle}}</strong> has no log drains yet.</h2>
-          {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+          {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
             {{#if hasAbility}}
               {{#if session.currentUser.verified}}
                 <div class="call-to-action">
@@ -95,7 +95,7 @@
 
 {{#unless hasNoLogDrains}}
    <div class="resource-list-actions">
-      {{#aptible-ability scope="manage" user=session.currentUser permittable=stack as |hasAbility|}}
+      {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
         {{#if hasAbility}}
           {{#if session.currentUser.verified}}
             <a {{action 'openCreateLogDrainModal'}} class="btn btn-primary open-log-drain-modal">

--- a/app/models/role.js
+++ b/app/models/role.js
@@ -9,6 +9,9 @@ let Role = DS.Model.extend({
   invitations: DS.hasMany('invitations', {async:true}),
   users: DS.hasMany('users', {async:true}),
 
+  isComplianceRole: Ember.computed.match('type', /compliance/),
+  isPlatformRole: Ember.computed.match('type', /platform/),
+
   isAccountOwner: Ember.computed.equal('type', 'owner'),
   isComplianceOwner: Ember.computed.equal('type', 'compliance_owner'),
   isPlatformOwner: Ember.computed.equal('type', 'platform_owner'),

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,5 +1,4 @@
 import DS from 'ember-data';
-import can from "../utils/can";
 import Ember from 'ember';
 
 export default DS.Model.extend({
@@ -26,12 +25,6 @@ export default DS.Model.extend({
   otpConfigurations: DS.hasMany('otp-configuration', { async: true }),
 
   currentOtpConfiguration: DS.belongsTo('otp-configuration', { async: true }),
-
-  // check ability, returns a promise
-  // e.g.: user.can('manage', stack).then(function(boolean){ ... });
-  can(scope, stack){
-    return can(this, scope, stack);
-  },
 
   isRoleType(types, roles, organization) {
     Ember.assert('You must pass types to check against', !!types);

--- a/app/organization/admin/environments/index/template.hbs
+++ b/app/organization/admin/environments/index/template.hbs
@@ -58,7 +58,7 @@
     {{/if}}
 
     <div class="resource-actions">
-      {{#aptible-ability scope="manage" user=session.currentUser permittable=organization as |hasAbility|}}
+      {{#aptible-ability scope="manage" permittable=organization as |hasAbility|}}
         {{#if hasAbility}}
           {{#link-to 'organization.admin.environments.new' class="btn btn-primary"}}
             Create New Environment

--- a/app/organization/pending-invitations/template.hbs
+++ b/app/organization/pending-invitations/template.hbs
@@ -21,7 +21,11 @@
           <th>Role</th>
           <th>Invited By</th>
           <th>Invited On</th>
-          <th class="aptable__actions">Actions</th>
+          {{#aptible-ability scope="manage" permittable=role as |hasAbility|}}
+            {{#if hasAbility}}
+              <th class="aptable__actions">Actions</th>
+            {{/if}}
+          {{/aptible-ability}}
         </tr>
       </thead>
 

--- a/app/organization/roles/index/route.js
+++ b/app/organization/roles/index/route.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend({
   },
 
   redirect(model) {
-    if (model.get('hasEnclaveAccess')) {
+    if (model.get('userHasEnclaveAccess')) {
       this.transitionTo('organization.roles.type', 'platform');
     } else {
       this.transitionTo('organization.roles.type', 'compliance');

--- a/app/organization/roles/template.hbs
+++ b/app/organization/roles/template.hbs
@@ -3,7 +3,7 @@
     <div class="resource-title">
       <h1>{{authorizationContext.organization.name}} Roles</h1>
       <div class="resource-actions pull-right">
-        {{#aptible-ability scope="manage" user=session.currentUser permittable=authorizationContext.organization as |hasAbility|}}
+        {{#aptible-ability scope="manage" permittable=authorizationContext.organization as |hasAbility|}}
           {{#if hasAbility}}
             <a {{action "openCreateRoleModal"}} class="btn btn-primary open-role-modal">
               Create Role

--- a/app/requires-authorization/index/route.js
+++ b/app/requires-authorization/index/route.js
@@ -5,7 +5,7 @@ export default Ember.Route.extend({
     let authorization = this.get('authorization');
     let context = authorization.get('organizationContexts.firstObject');
 
-    if(context.get('organizationHasEnclaveProduct') && context.get('hasEnclaveAccess')) {
+    if(context.get('organizationHasEnclaveProduct') && context.get('userHasEnclaveAccess')) {
       return this.transitionTo('enclave');
     }
 

--- a/app/role/environments/route.js
+++ b/app/role/environments/route.js
@@ -8,13 +8,11 @@ export default Ember.Route.extend({
   setupController(controller, model) {
     let contextHref = model.get('data.links.organization');
     let context = this.get('authorization').getContextByHref(contextHref);
-    let canManageRole = context.hasRoleScope('manage', model);
 
     controller.set('model', model);
     controller.set('stacks', context.get('stacks'));
     controller.set('organization', context.get('organization'));
     controller.set('currentUserRoles', context.get('currentUserRoles'));
-    controller.set('canManagePermissions', canManageRole);
     controller.set('authorizationContext', context);
   }
 });

--- a/app/role/environments/route.js
+++ b/app/role/environments/route.js
@@ -8,11 +8,13 @@ export default Ember.Route.extend({
   setupController(controller, model) {
     let contextHref = model.get('data.links.organization');
     let context = this.get('authorization').getContextByHref(contextHref);
+    let canManageRole = context.hasRoleScope('manage', model);
 
     controller.set('model', model);
     controller.set('stacks', context.get('stacks'));
     controller.set('organization', context.get('organization'));
     controller.set('currentUserRoles', context.get('currentUserRoles'));
+    controller.set('canManagePermissions', canManageRole);
     controller.set('authorizationContext', context);
   }
 });

--- a/app/role/environments/template.hbs
+++ b/app/role/environments/template.hbs
@@ -44,6 +44,7 @@
                   <td class="aptable__actions aptable__actions--skinny">
                     {{permission-toggle
                         authorizationContext=authorizationContext
+                        currentUserCanManagePermissions=canManagePermissions
                         role=model
                         scope="read"
                         stack=stack}}
@@ -54,6 +55,7 @@
                   <td class="aptable__actions">
                     {{permission-toggle
                         authorizationContext=authorizationContext
+                        currentUserCanManagePermissions=canManagePermissions
                         role=model
                         scope="manage"
                         stack=stack}}

--- a/app/role/environments/template.hbs
+++ b/app/role/environments/template.hbs
@@ -42,23 +42,27 @@
                 <tr>
                   <td class="aptable__row-heading">Read</td>
                   <td class="aptable__actions aptable__actions--skinny">
-                    {{permission-toggle
+                    {{#aptible-ability scope="manage" permittable=model as |hasAbility|}}
+                      {{permission-toggle
                         authorizationContext=authorizationContext
-                        currentUserCanManagePermissions=canManagePermissions
+                        currentUserCanManagePermissions=hasAbility
                         role=model
                         scope="read"
                         stack=stack}}
+                    {{/aptible-ability}}
                   </td>
                 </tr>
                 <tr>
                   <td class="aptable__row-heading">Manage</td>
                   <td class="aptable__actions">
-                    {{permission-toggle
+                    {{#aptible-ability scope="manage" permittable=model as |hasAbility|}}
+                      {{permission-toggle
                         authorizationContext=authorizationContext
-                        currentUserCanManagePermissions=canManagePermissions
+                        currentUserCanManagePermissions=hasAbility
                         role=model
                         scope="manage"
                         stack=stack}}
+                    {{/aptible-ability}}
                   </td>
                 </tr>
               </tbody>

--- a/app/role/members/route.js
+++ b/app/role/members/route.js
@@ -5,16 +5,23 @@ export default Ember.Route.extend({
     return this.modelFor('role');
   },
 
+  afterModel(model) {
+    return model.get('memberships');
+  },
+
   setupController(controller, model) {
     let contextHref = model.get('data.links.organization');
     let authorizationContext = this.get('authorization').getContextByHref(contextHref);
     let { organization, currentUserRoles } = authorizationContext;
-    let canManageMemberships = authorizationContext.canUserInviteIntoRole(model);
+    let canManageMemberships = authorizationContext.hasRoleScope('invite', model);
+    let canManageRole = authorizationContext.hasRoleScope('manage', model);
 
     controller.set('role', model);
     controller.set('memberships', model.get('memberships'));
     controller.set('invitations', model.get('invitations'));
-    controller.setProperties({ authorizationContext, organization, currentUserRoles, canManageMemberships });
+    controller.setProperties({ authorizationContext, organization,
+                               currentUserRoles, canManageMemberships,
+                               canManageRole });
   },
 
   actions: {

--- a/app/role/members/route.js
+++ b/app/role/members/route.js
@@ -13,15 +13,11 @@ export default Ember.Route.extend({
     let contextHref = model.get('data.links.organization');
     let authorizationContext = this.get('authorization').getContextByHref(contextHref);
     let { organization, currentUserRoles } = authorizationContext;
-    let canManageMemberships = authorizationContext.hasRoleScope('invite', model);
-    let canManageRole = authorizationContext.hasRoleScope('manage', model);
 
     controller.set('role', model);
     controller.set('memberships', model.get('memberships'));
     controller.set('invitations', model.get('invitations'));
-    controller.setProperties({ authorizationContext, organization,
-                               currentUserRoles, canManageMemberships,
-                               canManageRole });
+    controller.setProperties({ authorizationContext, organization, currentUserRoles});
   },
 
   actions: {

--- a/app/role/members/template.hbs
+++ b/app/role/members/template.hbs
@@ -1,44 +1,46 @@
-{{#if canManageMemberships}}
-  <div class="row invite-new-members-to-role">
-    <div class="col-xs-12 flex-row">
-      <form class="flex-row-item role__add-user">
-        <h3 class="heading--caps heading--sm">Add Existing User</h3>
-        <div class="invite-user">
-          <button class="btn btn-primary" {{action "addMember" invitedUser}} type="submit">
-            Add
-          </button>
-          <div class="user-select-container">
-            {{ultimate-select
-                class="user-select"
-                name="invited-user"
-                prompt="Select..."
-                items=nonmembers
-                itemKey="id"
-                itemValue="name"
-                update=(action (mut invitedUser))
-                selected=invitedUser}}
+{{#aptible-ability scope="invite" permittable=role as |hasAbility|}}
+  {{#if hasAbility}}
+    <div class="row invite-new-members-to-role">
+      <div class="col-xs-12 flex-row">
+        <form class="flex-row-item role__add-user">
+          <h3 class="heading--caps heading--sm">Add Existing User</h3>
+          <div class="invite-user">
+            <button class="btn btn-primary" {{action "addMember" invitedUser}} type="submit">
+              Add
+            </button>
+            <div class="user-select-container">
+              {{ultimate-select
+                  class="user-select"
+                  name="invited-user"
+                  prompt="Select..."
+                  items=nonmembers
+                  itemKey="id"
+                  itemValue="name"
+                  update=(action (mut invitedUser))
+                  selected=invitedUser}}
+            </div>
+
           </div>
+        </form>
 
-        </div>
-      </form>
+        <h3 class="flex-row-item heading--caps heading--sm">OR</h3>
 
-      <h3 class="flex-row-item heading--caps heading--sm">OR</h3>
-
-      <form class="role__invite-user flex-row-item" role='form' {{action "inviteByEmail" inviteByEmail on="submit"}}>
-        {{server-validation-errors model=invitation}}
-        <h3 class="heading--caps heading--sm">Invite By Email</h3>
-        <div class="invite-user">
-          <button class="btn btn-primary" {{action "inviteByEmail" invitedEmail}} type="submit">Send Invite</button>
-          <div class="invite-user-container">
-            {{input name='invite-by-email' value=invitedEmail classNames="form-control" placeholder="Email Address"}}
+        <form class="role__invite-user flex-row-item" role='form' {{action "inviteByEmail" inviteByEmail on="submit"}}>
+          {{server-validation-errors model=invitation}}
+          <h3 class="heading--caps heading--sm">Invite By Email</h3>
+          <div class="invite-user">
+            <button class="btn btn-primary" {{action "inviteByEmail" invitedEmail}} type="submit">Send Invite</button>
+            <div class="invite-user-container">
+              {{input name='invite-by-email' value=invitedEmail classNames="form-control" placeholder="Email Address"}}
+            </div>
           </div>
-        </div>
-      </form>
+        </form>
+      </div>
     </div>
-  </div>
 
-  <hr>
-{{/if}}
+    <hr>
+  {{/if}}
+{{/aptible-ability}}
 
 <div class="row">
   <div class="col-xs-12">
@@ -65,19 +67,21 @@
       </thead>
 
       <tbody>
-        {{#each memberships as |membership|}}
-          {{membership-table-row
-              membership=membership
-              authorizationContext=authorizationContext
-              currentUserIsPrivileged=canManageMemberships
-              role=role
-              completedAction='completedAction'
-              failedAction='failedAction'}}
-        {{else}}
-          <td class="empty-row" colspan="6">
-            {{role.name}} currently has no members.
-          </td>
-        {{/each}}
+        {{#aptible-ability scope="invite" permittable=role as |hasAbility|}}
+          {{#each memberships as |membership|}}
+            {{membership-table-row
+                membership=membership
+                authorizationContext=authorizationContext
+                currentUserIsPrivileged=hasAbility
+                role=role
+                completedAction='completedAction'
+                failedAction='failedAction'}}
+          {{else}}
+            <td class="empty-row" colspan="6">
+              {{role.name}} currently has no members.
+            </td>
+          {{/each}}
+        {{/aptible-ability}}
       </tbody>
     </table>
   </div>
@@ -95,7 +99,7 @@
             <th>Role</th>
             <th>Invited By</th>
             <th>Invited On</th>
-            {{#aptible-ability scope="manage" role=role as |hasAbility|}}
+            {{#aptible-ability scope="invite" permittable=role as |hasAbility|}}
               {{#if hasAbility}}
                 <th>Actions</th>
               {{/if}}

--- a/app/role/members/template.hbs
+++ b/app/role/members/template.hbs
@@ -51,13 +51,15 @@
           <th>Email</th>
           <th>Date Added</th>
           <th>Owner</th>
-          <th>
-            Role Admins
-            {{#bs-tooltip placement="bottom" bs-container=false
-                title="Owners and Role Admins can manage members."}}
-              <i class='fa fa-question-circle icon--highlight'></i>
-            {{/bs-tooltip}}
-          </th>
+          {{#unless role.isOwner}}
+            <th>
+              Role Admins
+              {{#bs-tooltip placement="bottom" bs-container=false
+                  title="Owners and Role Admins can manage members."}}
+                <i class='fa fa-question-circle icon--highlight'></i>
+              {{/bs-tooltip}}
+            </th>
+          {{/unless}}
           <th>Actions</th>
         </tr>
       </thead>
@@ -67,6 +69,7 @@
           {{membership-table-row
               membership=membership
               authorizationContext=authorizationContext
+              currentUserIsPrivileged=canManageMemberships
               role=role
               completedAction='completedAction'
               failedAction='failedAction'}}
@@ -92,7 +95,11 @@
             <th>Role</th>
             <th>Invited By</th>
             <th>Invited On</th>
-            <th>Actions</th>
+            {{#aptible-ability scope="manage" role=role as |hasAbility|}}
+              {{#if hasAbility}}
+                <th>Actions</th>
+              {{/if}}
+            {{/aptible-ability}}
           </tr>
         </thead>
 

--- a/app/role/settings/route.js
+++ b/app/role/settings/route.js
@@ -1,6 +1,17 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  redirect() {
+    let role = this.modelFor('role');
+    let contextHref = role.get('data.links.organization');
+    let authorizationContext = this.get('authorization').getContextByHref(contextHref);
+    let canManageRole = authorizationContext.hasRoleScope('manage', role);
+
+    if (!canManageRole) {
+      this.transitionTo('role.members');
+    }
+  },
+
   actions: {
     save() {
       let role = this.currentModel;

--- a/app/role/template.hbs
+++ b/app/role/template.hbs
@@ -15,7 +15,6 @@
   </header>
 
   <div class="layout-container">
-    <h1>{{platformRole}}</h1>
     <ul class='nav nav-pills resource-navigation'>
 
       {{#link-to 'role.members' model.id tagName="li"}}

--- a/app/services/authorization.js
+++ b/app/services/authorization.js
@@ -82,7 +82,7 @@ export default Ember.Service.extend({
   hasSingleOrganization: Ember.computed.equal('organizationContexts.length', 1),
   hasNoOrganizations: Ember.computed.equal('organizationContexts.length', 0),
   hasNoStacks: Ember.computed.equal('stacks.length', 0),
-  contextsWithEnclaveAccess: Ember.computed.filterBy('organizationContexts', 'hasEnclaveAccess', true),
+  contextsWithEnclaveAccess: Ember.computed.filterBy('organizationContexts', 'userHasEnclaveAccess', true),
   hasAnyEnclaveAccess: Ember.computed.gt('contextsWithEnclaveAccess.length', 0),
 
   contextsWithEnclaveProduct: Ember.computed.filterBy('organizationContexts', 'organizationHasEnclaveProduct', true),

--- a/app/stack/controller.js
+++ b/app/stack/controller.js
@@ -1,9 +1,5 @@
 import Ember from "ember";
 
 export default Ember.Controller.extend({
-  // FIXME: app and database creation pages are dependent on these
-  // CPs being defined.
-  persistedApps: Ember.computed.filterBy('model.apps', 'isNew', false),
-  persistedCertificates: Ember.computed.filterBy('model.certificates', 'isNew', false),
-  persistedDatabases: Ember.computed.filterBy('model.databases', 'isNew', false)
+
 });

--- a/app/stack/index/route.js
+++ b/app/stack/index/route.js
@@ -8,10 +8,8 @@ export default Ember.Route.extend({
       return this.transitionTo('stack.activate');
     }
 
-    return this.get('session.currentUser').can('read', stack).then((permitted) => {
-      if(permitted) {
-        this.transitionTo('apps');
-      }
-    });
+    if(this.get('authorization').checkAbility('read', stack)) {
+      this.transitionTo('apps');
+    }
   }
 });

--- a/app/stack/index/route.js
+++ b/app/stack/index/route.js
@@ -4,10 +4,14 @@ export default Ember.Route.extend({
   redirect() {
     let stack = this.modelFor('stack');
 
-    if(stack.get('activated')) {
-      this.transitionTo('apps');
-    } else {
-      this.transitionTo('stack.activate');
+    if (!stack.get('activated')) {
+      return this.transitionTo('stack.activate');
     }
+
+    return this.get('session.currentUser').can('read', stack).then((permitted) => {
+      if(permitted) {
+        this.transitionTo('apps');
+      }
+    });
   }
 });

--- a/app/stack/template.hbs
+++ b/app/stack/template.hbs
@@ -1,8 +1,21 @@
 {{partial "stack/header"}}
 <div class="layout-container">
-  {{#if model.activated}}
-    {{partial "stack/nav"}}
-  {{/if}}
+  {{#aptible-ability scope="read" user=session.currentUser permittable=model as |hasAbility|}}
+    {{#if hasAbility}}
+      {{#if model.activated}}
+        {{partial "stack/nav"}}
+      {{/if}}
+      {{liquid-outlet}}
+    {{else}}
 
-  {{liquid-outlet}}
+     <div class="activate-notice activate-notice--micro">
+      <div class="row">
+        <div class="col-xs-8 col-xs-offset-2">
+          <h2>You do not have permission to view <strong>{{model.handle}}</strong> resources.</h2>
+        </div>
+      </div>
+    </div>
+
+    {{/if}}
+  {{/aptible-ability}}
 </div>

--- a/app/stack/template.hbs
+++ b/app/stack/template.hbs
@@ -1,6 +1,7 @@
 {{partial "stack/header"}}
+
 <div class="layout-container">
-  {{#aptible-ability scope="read" user=session.currentUser permittable=model as |hasAbility|}}
+  {{#aptible-ability scope="read" permittable=model as |hasAbility|}}
     {{#if hasAbility}}
       {{#if model.activated}}
         {{partial "stack/nav"}}

--- a/app/styles/components/_x-toggle.scss
+++ b/app/styles/components/_x-toggle.scss
@@ -16,6 +16,7 @@
 
 .x-toggle-container-disabled {
   opacity: 0.4;
+  pointer-events: none;
 }
 
 .x-toggle-component {

--- a/app/templates/organization/-invited-user-table-row.hbs
+++ b/app/templates/organization/-invited-user-table-row.hbs
@@ -4,7 +4,7 @@
   <td>{{invitation.inviterName}}</td>
   <td>{{format-date invitation.createdAt}}</td>
   <!-- Actions -->
-  {{#aptible-ability scope="manage" user=session.currentUser role=invitation.role permittable=authorizationContext.organization as |hasAbility|}}
+  {{#aptible-ability scope="manage" permittable=role as |hasAbility|}}
     {{#if hasAbility}}
       <td class="aptable__actions aptable__actions--skinny">
         <a class="btn btn-default btn-xs btn--link" {{action 'destroyInvitation' invitation}} href="#">

--- a/app/templates/organization/-invited-user-table-row.hbs
+++ b/app/templates/organization/-invited-user-table-row.hbs
@@ -4,7 +4,7 @@
   <td>{{invitation.inviterName}}</td>
   <td>{{format-date invitation.createdAt}}</td>
   <!-- Actions -->
-  {{#aptible-ability scope="manage" permittable=role as |hasAbility|}}
+  {{#aptible-ability scope="invite" permittable=role as |hasAbility|}}
     {{#if hasAbility}}
       <td class="aptable__actions aptable__actions--skinny">
         <a class="btn btn-default btn-xs btn--link" {{action 'destroyInvitation' invitation}} href="#">

--- a/app/templates/organization/-members-header.hbs
+++ b/app/templates/organization/-members-header.hbs
@@ -6,7 +6,7 @@
     </div>
 
     <ul class="resource-metadata resource-metadata">
-      {{#aptible-ability scope="manage" user=session.currentUser permittable=organization as |hasAbility|}}
+      {{#aptible-ability scope="manage" permittable=organization as |hasAbility|}}
         {{#if hasAbility}}
           {{#link-to 'organization.admin.contact-settings' tagName='li' classNames='resource-metadata-item resource-metadata-button'}}
             {{#bs-tooltip title="Edit Contact Settings"}}

--- a/app/templates/sidebars/settings.hbs
+++ b/app/templates/sidebars/settings.hbs
@@ -16,7 +16,7 @@
       {{link-to "Roles" "organization.roles" organization.id bubbles=false class="role-index" bubbles=false}}
     {{/link-to}}
 
-    {{#aptible-ability scope="manage" user=session.currentUser permittable=organization as |hasAbility|}}
+    {{#aptible-ability scope="manage" permittable=organization as |hasAbility|}}
       {{#if hasAbility}}
 
         {{#link-to 'organization.admin.environments' organization.id tagName="li"}}

--- a/app/utils/user-organization-context.js
+++ b/app/utils/user-organization-context.js
@@ -83,11 +83,7 @@ export default Ember.Object.extend({
 
   userIsEnclaveOrOrganizationAdmin: Ember.computed.or('userIsEnclaveAdmin', 'userIsOrganizationAdmin'),
   userIsGridironOrOrganizationAdmin: Ember.computed.or('userIsGridironAdmin', 'userIsOrganizationAdmin'),
-
-  // Can the user use enclave? TODO revisit these two:
-  userHasEnclaveAccess: Ember.computed.or('userIsEnclaveAdmin', 'userIsEnclaveUser'),
-  hasEnclaveAccess: Ember.computed.or('userHasEnclaveAccess', 'userIsOrganizationAdmin'),
-  // End
+  userHasEnclaveAccess: Ember.computed.or('userIsEnclaveAdmin', 'userIsEnclaveUser', 'userIsOrganizationAdmin'),
 
   doesUserHavePrivilegedMembershipForRole(role) {
     // This method is dumb and counts on memberhsips being loaded on the role

--- a/app/utils/user-organization-context.js
+++ b/app/utils/user-organization-context.js
@@ -70,6 +70,7 @@ export default Ember.Object.extend({
   hasBillingDetail: Ember.computed.not('hasNoBillingDetail'),
 
   // Computeds related to user's roles in organization
+  hasVerifiedEmail: Ember.computed.reads('currentUser.verified'),
   userPlatformUserRoles: Ember.computed.filterBy('currentUserRoles', 'type', 'platform_user'),
   userPlatformAdminRoles: Ember.computed.filterBy('currentUserRoles', 'type', 'platform_owner'),
   userGridironUserRoles: Ember.computed.filterBy('currentUserRoles', 'type', 'compliance_user'),
@@ -83,37 +84,68 @@ export default Ember.Object.extend({
   userIsEnclaveOrOrganizationAdmin: Ember.computed.or('userIsEnclaveAdmin', 'userIsOrganizationAdmin'),
   userIsGridironOrOrganizationAdmin: Ember.computed.or('userIsGridironAdmin', 'userIsOrganizationAdmin'),
 
+  // Can the user use enclave? TODO revisit these two:
   userHasEnclaveAccess: Ember.computed.or('userIsEnclaveAdmin', 'userIsEnclaveUser'),
   hasEnclaveAccess: Ember.computed.or('userHasEnclaveAccess', 'userIsOrganizationAdmin'),
+  // End
 
-  canUserManageRolePermissions(role) {
+  doesUserHavePrivilegedMembershipForRole(role) {
+    // This method is dumb and counts on memberhsips being loaded on the role
+    // FIXME: Load memberships from users and cache them in this context
+    let privilegedMemberships = role.get('memberships').filterBy('privileged', true);
+    return !!privilegedMemberships.findBy('user.id', this.get('currentUser.id'));
+  },
+
+  hasStackScope(scope, stack) {
+    // Scopes: read, manage
+    if(scope === 'manage' && !this.get('hasVerifiedEmail')) {
+      return false;
+    }
+
+    return this.get('currentUserRoles').any((role) => {
+      return stack.permitsRole(role, scope);
+    });
+  },
+
+  hasOrganizationScope(scope) {
+    // Scopes: read, manage
+    if(scope === 'read') {
+      return true;
+    }
+
+    if(scope === 'manage' && !this.get('hasVerifiedEmail')) {
+      return false;
+    }
+
+    return this.get('userIsOrganizationAdmin');
+  },
+
+  hasRoleScope(scope, role) {
+    // Scopes: read, manage, invite
+    if(scope === 'read') {
+      return true;
+    }
+
+    if(scope === 'manage' && !this.get('hasVerifiedEmail')) {
+      return false;
+    }
+
     if(this.get('userIsOrganizationAdmin')) {
       return true;
     }
 
-    if(role.get('type').match(/platform/) && this.get('userIsEnclaveAdmin')) {
+    if(role.get('isPlatform') && this.get('userIsEnclaveAdmin')) {
       return true;
     }
 
-    if(role.get('type').match(/compliance/) && this.get('userIsGridironAdmin')) {
+    if(role.get('isComplianceRole') && this.get('userIsGridironAdmin')) {
+      return true;
+    }
+
+    if(scope === 'invite' && this.doesUserHavePrivilegedMembershipForRole(role)) {
       return true;
     }
 
     return false;
-  },
-
-  canUserInviteIntoRole(role) {
-    if(this.doesUserHavePrivilegedMembershipForRole(role)) {
-      return true;
-    }
-
-    return this.canUserManageRolePermissions(role);
-  },
-
-  doesUserHavePrivilegedMembershipForRole(role) {
-    let roleHref = role.get('data.links.self');
-    let roleMembership = this.get('currentUserMemberships').findBy('data.links.role', roleHref);
-
-    return !!roleMembership && roleMembership.get('privileged');
   }
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -135,9 +135,10 @@ module.exports = function(environment) {
     ENV.locationType = 'none';
 
     // keep test console output quieter
-    ENV.APP.LOG_ACTIVE_GENERATION = false;
-    ENV.APP.LOG_VIEW_LOOKUPS = false;
-
+    ENV.APP.LOG_ACTIVE_GENERATION = true;
+    ENV.APP.LOG_VIEW_LOOKUPS = true;
+    ENV.APP.LOG_TRANSITIONS = true;
+    ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     ENV.APP.rootElement = '#ember-testing';
     ENV.replaceLocation = false;
     ENV.replaceTitle = false;

--- a/config/environment.js
+++ b/config/environment.js
@@ -135,10 +135,10 @@ module.exports = function(environment) {
     ENV.locationType = 'none';
 
     // keep test console output quieter
-    ENV.APP.LOG_ACTIVE_GENERATION = true;
-    ENV.APP.LOG_VIEW_LOOKUPS = true;
-    ENV.APP.LOG_TRANSITIONS = true;
-    ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+    ENV.APP.LOG_TRANSITIONS = false;
+    ENV.APP.LOG_TRANSITIONS_INTERNAL = false;
     ENV.APP.rootElement = '#ember-testing';
     ENV.replaceLocation = false;
     ENV.replaceTitle = false;

--- a/tests/acceptance/elevation-test.js
+++ b/tests/acceptance/elevation-test.js
@@ -12,7 +12,7 @@ module('Acceptance: Elevation', {
     user = createStubUser();
     stubUser(user);
     stubStacks();
-    stubOrganization({ id: 'o1'});
+    stubOrganization({ id: '1'});
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/log-drains/basic-test.js
+++ b/tests/acceptance/log-drains/basic-test.js
@@ -8,7 +8,7 @@ let App;
 let stackHandle = 'my-stack-handle',
     stackId = 'my-stack-id',
     orgName = 'my org',
-    orgId = 'org-1',
+    orgId = '1',
     url = `stacks/${stackId}/logging`;
 
 module('Acceptance: Log Drains', {

--- a/tests/acceptance/organization/contact-settings-test.js
+++ b/tests/acceptance/organization/contact-settings-test.js
@@ -8,9 +8,7 @@ import { stubRequest } from '../../helpers/fake-server';
 
 let application;
 
-// FIXME this is hardcoded to match the value for signIn in
-// aptible-helpers
-const organizationId = 'o1';
+const organizationId = '1';
 const contactSettingsUrl = `/organizations/${organizationId}/admin/contact-settings`;
 const url = contactSettingsUrl;
 const organizationApiUrl = `/organizations/${organizationId}`;

--- a/tests/acceptance/settings/settings-admin-test.js
+++ b/tests/acceptance/settings/settings-admin-test.js
@@ -151,7 +151,7 @@ module('Acceptance: User Settings: Account', {
     App = startApp();
     showedOtpUri = false;
     stubStacks();
-    stubOrganization({ id: 'o1'});
+    stubOrganization({ id: '1'});
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/settings/settings-logout-test.js
+++ b/tests/acceptance/settings/settings-logout-test.js
@@ -10,7 +10,7 @@ module("Acceptance: User Settings: Logout", {
   beforeEach() {
     App = startApp();
     stubStacks();
-    stubOrganization({ id: 'o1'});
+    stubOrganization({ id: '1'});
   },
 
   afterEach() {

--- a/tests/acceptance/settings/settings-profile-test.js
+++ b/tests/acceptance/settings/settings-profile-test.js
@@ -20,7 +20,7 @@ module('Acceptance: User Settings: Profile', {
   beforeEach: function() {
     App = startApp();
     stubStacks();
-    stubOrganization({ id: 'o1'});
+    stubOrganization({ id: '1'});
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/settings/settings-ssh-test.js
+++ b/tests/acceptance/settings/settings-ssh-test.js
@@ -12,7 +12,7 @@ module('Acceptance: User Settings: Ssh', {
   beforeEach: function() {
     App = startApp();
     stubStacks();
-    stubOrganization({ id: 'o1'});
+    stubOrganization({ id: '1'});
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/welcome/payment-info-test.js
+++ b/tests/acceptance/welcome/payment-info-test.js
@@ -176,7 +176,11 @@ test('payment info should be submitted to stripe to create stripeToken', functio
       id: stackHandle,
       handle: stackHandle,
       type: 'development',
-      activated: true
+      activated: true,
+      _links: {
+        self: { href: `/accounts/${stackHandle}` },
+        organization: { href: '/organizations/1' }
+      }
     });
   });
 
@@ -240,6 +244,10 @@ test('submitting valid payment info for development plan should create dev stack
     var params = this.json(request);
     stackAssertions[params.handle](params);
     params.activated = true;
+    params._links = {
+      self: { href: `/accounts/${params.handle}` },
+      organization: { href: '/organizations/1' }
+    };
     return this.success(Ember.merge({id:params.handle }, params));
   });
 
@@ -263,6 +271,10 @@ test('submitting valid payment info on organization with existing stripe info sh
   stubRequest('post', '/accounts', function(request) {
     var params = this.json(request);
     params.activated = true;
+    params._links = {
+      self: { href: `/accounts/${params.handle}` },
+      organization: { href: '/organizations/1' }
+    };
     return this.success(Ember.merge({id:params.handle }, params));
   });
 
@@ -325,6 +337,10 @@ test('submitting valid payment info should create app', function(assert) {
   stubRequest('post', '/accounts', function(request){
     var params = this.json(request);
     params.activated = true;
+    params._links = {
+      self: { href: `/accounts/${params.handle}` },
+      organization: { href: '/organizations/1' }
+    };
     return this.success(Ember.merge({id:params.handle}, params));
   });
 
@@ -385,6 +401,10 @@ test('submitting valid payment info should create db', function(assert) {
   stubRequest('post', '/accounts', function(request){
     var params = this.json(request);
     params.activated = true;
+    params._links = {
+      self: { href: `/accounts/${params.handle}` },
+      organization: { href: '/organizations/1' }
+    };
     return this.success(Ember.merge({id:params.handle}, params));
   });
 
@@ -437,6 +457,10 @@ test('submitting valid payment info when user is verified should provision db', 
   stubRequest('post', '/accounts', function(request){
     let params = this.json(request);
     params.activated = true;
+    params._links = {
+      self: { href: `/accounts/${params.handle}` },
+      organization: { href: '/organizations/1' }
+    };
     return this.success(Ember.merge({id:params.handle},params));
   });
 


### PR DESCRIPTION
This PR improves the UX for users with less than `owner` or `manage` permission. While testing the simple UX changes, I uncovered a few scenarios where `aptible-ability` failed to reload state and render the proper UI.  So, this PR also refactors `aptible-ability` and makes it much nicer to use.

To start, `aptible-ability` is no longer async/promise based.  Instead, the `authorization` service is used to proxy authorization checks to the relevant organization context.  This also slims up `aptible-ability`'s argument list with the caveat that it's always assumed the user you are checking is the current user.

`aptible-ability` also supports 2 new permittables:  role and organization. Role checks include the following scopes: `invite`, `read`, and `manage`.  The new `invite` scope will pass if the user can `manage` or if their membership to the role is privileged.

Also, because `aptible-ability` is now synchronous, you can use it to make authorization requests anywhere, even outside of templates:

```javascript

let stack = this.modelFor('stack');
this.get('authorization').checkAbility('manage', stack); // true if can manage

let role = this.modelFor('role');
this.get('authorization').checkAbility('invite', role); // true if can invite into role
```

The same checks from a template:
```hbs
{{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
  {{#if hasAbility}}
    You can create apps
  {{else}}
    You can't create apps
{{/aptible-ability}}

{{#aptible-ability scope="invite" permittable=role as |hasAbility|}}
  {{#if hasAbility}}
    You can invite users
  {{else}}
    You can't invite users
{{/aptible-ability}}
```

