### PR TITLE
don't redirect account owners

### DIFF
--- a/app/gridiron-organization/index/route.js
+++ b/app/gridiron-organization/index/route.js
@@ -4,7 +4,7 @@ export default Ember.Route.extend({
   complianceStatus: Ember.inject.service(),
 
   redirect() {
-    if(this.get('complianceStatus.authorizationContext.userIsGridironAdmin')) {
+    if(this.get('complianceStatus.authorizationContext.userIsGridironOrOrganizationAdmin')) {
       this.transitionTo('gridiron-admin');
     } else {
       this.transitionTo('gridiron-user');

--- a/app/gridiron/index/route.js
+++ b/app/gridiron/index/route.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend({
     let context = authorization.get('contextsWithGridironProduct.firstObject');
     let organization = context.get('organization');
 
-    if (context.get('userIsGridironAdmin')) {
+    if (context.get('userIsGridironOrOrganizationAdmin')) {
       this.transitionTo('gridiron-admin', organization.get('id'));
     } else {
       this.transitionTo('gridiron-user', organization.get('id'));


### PR DESCRIPTION
This PR changes the default gridiron dashboard from `user` to `admin` for users that belong in the `owner` role.

The current redirect checks will redirect any compliance non-admin to the user dashboard. In an ideal world, where organizations actually have a proper distinction between a compliance owner and an account owner, that is probably the correct behavior.  However, the reality for most customers (at least while role types is such a new concept) is that account owners are also likely compliance owners in practice. 