### PR TITLE
Fix issue determining authorization context for new organization profiles

### DIFF
--- a/app/databases/controller.js
+++ b/app/databases/controller.js
@@ -8,7 +8,7 @@ export default Ember.Controller.extend({
   persistedDatabases: Ember.computed.filterBy('model', 'isNew', false),
   hasNoDatabases: Ember.computed.equal('persistedDatabases.length', 0),
   deployedDatabases: Ember.computed.filterBy('persistedDatabases', 'isProvisioned'),
-  pendingDatabases: Ember.computed.filterBy('persistedDatabases', 'isProvisioning'),
+  pendingDatabases: Ember.computed.filterBy('persistedDatabases', 'isProvisioningOrPending'),
   deprovisioningDatabases: Ember.computed.filterBy('persistedDatabases', 'isDeprovisioning'),
 
   deprovisionedDatabases: Ember.computed.filterBy('persistedDatabases', 'isDeprovisioned'),

--- a/app/models/database.js
+++ b/app/models/database.js
@@ -33,7 +33,8 @@ export default DS.Model.extend(ProvisionableMixin, {
   supportsClustering: Ember.computed.equal('type', 'mongodb'),
 
   serviceUsage: Ember.computed.mapBy('service', 'usage'),
-  usage: Ember.computed.sum('serviceUsage')
+  usage: Ember.computed.sum('serviceUsage'),
+  isProvisioningOrPending: Ember.computed.or('isPending', 'isProvisioning')
 });
 
 export function provisionDatabases(user, store){

--- a/app/services/authorization.js
+++ b/app/services/authorization.js
@@ -70,6 +70,11 @@ export default Ember.Service.extend({
       return context.hasOrganizationScope(scope);
     }
 
+    if(permittable instanceof OrganizationProfile) {
+      context = this.getContext(permittable.get('id'));
+      return context.hasGridironScope(scope);
+    }
+
     context = this.getContextByHref(permittable.get('data.links.organization'));
 
     if (permittable instanceof Stack) {
@@ -78,10 +83,6 @@ export default Ember.Service.extend({
 
     if(permittable instanceof Role) {
       return context.hasRoleScope(scope, permittable);
-    }
-
-    if(permittable instanceof OrganizationProfile) {
-      return context.hasGridironScope(scope);
     }
   },
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -170,7 +170,7 @@ module.exports = function(environment) {
     ENV.segmentioKey = '5aOlxMYapu6bQCQYFbDz7rhNvVV7B1A5';
     ENV.featureFlags['sheriff'] = true;
     ENV.featureFlags['spd'] = false;
-
+    ENV.featureFlags.engines.risk = false;
     ENV.sentry.whitelistUrls = ['dashboard.aptible.com'];
     ENV.sentry.development = false;
     ENV.sentry.dsn = 'https://2dc5b29fd35e408cbadf581f9a167074@app.getsentry.com/22629';


### PR DESCRIPTION
Unsaved organization profiles don't have a `data.links.organization` property, so use the ID instead to determine context.

This also fixes a very minor issue of `pending` databases not being visible.  