### PR TITLE
VHOST: Prompt users to restart app for debugging

### DIFF
--- a/app/templates/app/-domain.hbs
+++ b/app/templates/app/-domain.hbs
@@ -66,7 +66,9 @@
           {{#if vhost.failedToProvision}}
             <h3 class="resource-metadata-value">
               <span class="danger failed-warning-message">
-                {{vhost.commonName}} failed to provision, please{{#link-to-aptible app="contact"}}contact Support{{/link-to-aptible}}
+                {{vhost.commonName}} failed to provision,
+                please{{#link-to-aptible app="support" path="topics/cli/how-to-restart-app"}}restart your app via the CLI{{/link-to-aptible}}
+                to access debugging output.
               </span>
             </h3>
           {{else}}


### PR DESCRIPTION
When a VHOST fails to provision, it can be attempted again by running an
`aptible restart` (or re-deploying the app). Since there's a user behind
the screen in those cases, it's an occasion for us to show debugging
output and explain what went wrong.

As of https://github.com/aptible/sweetness/pull/648, we'll start doing
so for VHOSTs, by explaining the most common error case, i.e. the
container does not EXPOSE any ports. This patch updates the VHOST error
message accordingly and invites users to retry via a restart rather than
contact support directly (which should help resolve their issue faster).


---

cc @fancyremarker  @blakepettersson @sandersonet