### PR TITLE
Move role route from enclave to organization

### DIFF
--- a/app/enclave/route.js
+++ b/app/enclave/route.js
@@ -36,10 +36,13 @@ export default Ember.Route.extend({
   handleComplianceOnlyUsers() {
     // If no organization context has any enclave access, get out of here
     if (!this.get('authorization.hasAnyEnclaveAccess')) {
-      let message = `You do not have access to view Enclave resources. If this
-                     is a mistake, please contact either your account owner or
-                     support@aptible.com`;
-      Ember.get(this, 'flashMessages').danger(message);
+      // REVIEW:  Don't warn until we update to have a more intelligent default
+      // route
+      // let message = `You do not have access to view Enclave resources. If this
+      //                is a mistake, please contact either your account owner or
+      //                support@aptible.com`;
+
+      // Ember.get(this, 'flashMessages').danger(message);
       let context = this.get('authorization.organizationContexts.firstObject');
       let organization = context.get('organization.id');
 

--- a/app/role/route.js
+++ b/app/role/route.js
@@ -12,7 +12,7 @@ export default Ember.Route.extend({
   renderTemplate() {
     this._super.apply(this, arguments);
     this.render('sidebars/settings', {
-      into: 'enclave',
+      into: 'organization',
       outlet: 'sidebar'
     });
   }

--- a/app/router.js
+++ b/app/router.js
@@ -70,6 +70,11 @@ Router.map(function() {
         this.route("edit", {path: ":user_id/edit"});
       });
       this.route('pending-invitations');
+      this.route("role", { resetNamespace: true, path: "/roles/:role_id" }, function() {
+        this.route('members');
+        this.route('environments');
+        this.route('settings');
+      });
       this.route("roles", {}, function() {
         this.route("type", { path: ':type' });
         this.modal('modal-create-role', {
@@ -186,15 +191,6 @@ Router.map(function() {
       });
 
       this.route("stacks", { resetNamespace: true });
-
-      this.route("role", {
-        resetNamespace: true,
-        path: "roles/:role_id"
-      }, function() {
-        this.route('members');
-        this.route('environments');
-        this.route('settings');
-      });
     });
 
     this.route('gridiron', { path: 'gridiron', resetNamespace: true }, function() {

--- a/tests/acceptance/organization/roles-test.js
+++ b/tests/acceptance/organization/roles-test.js
@@ -134,6 +134,6 @@ test(`visit ${url} and click to show`, (assert) => {
   });
 
   andThen(() => {
-    assert.equal(currentPath(), 'requires-authorization.enclave.role.members');
+    assert.equal(currentPath(), 'requires-authorization.organization.role.members');
   });
 });

--- a/tests/acceptance/organization/roles/create-test.js
+++ b/tests/acceptance/organization/roles/create-test.js
@@ -106,7 +106,7 @@ test(`visiting ${url} and creating new platform_user role`, (assert) => {
   });
 
   andThen(() => {
-    assert.equal(currentPath(), 'requires-authorization.enclave.role.members');
+    assert.equal(currentPath(), 'requires-authorization.organization.role.members');
   });
 });
 
@@ -130,7 +130,7 @@ test(`visiting ${url} and creating new compliance_user role`, (assert) => {
     clickButton('Save');
   });
   andThen(function() {
-    assert.equal(currentPath(), 'requires-authorization.enclave.role.members');
+    assert.equal(currentPath(), 'requires-authorization.organization.role.members');
   });
 });
 

--- a/tests/acceptance/role/environments-test.js
+++ b/tests/acceptance/role/environments-test.js
@@ -10,7 +10,7 @@ let application;
 // let orgId = 'o1'; // FIXME this is hardcoded to match the value for signIn in aptible-helpers
 let roleId = 'r1';
 // let roleName = 'the-role';
-let url = `/roles/${roleId}/members`;
+let url = `/organizations/o1/roles/${roleId}/members`;
 // let apiRoleUrl = `/roles/${roleId}`;
 // let apiRoleUsersUrl = `/roles/${roleId}/users`;
 // let apiUsersUrl = `/organizations/${orgId}/users`;

--- a/tests/acceptance/role/members-test.js
+++ b/tests/acceptance/role/members-test.js
@@ -11,7 +11,7 @@ let orgId = '1';
 let roleId = 'r1';
 let roleMembersUrl = `/roles/${roleId}/memberships`;
 let orgUsersUrl = `/organizations/${orgId}/users`;
-let pageUrl = `/roles/${roleId}/members`;
+let pageUrl = `/organizations/${orgId}/roles/${roleId}/members`;
 
 const ownerRole = {
   id: roleId,
@@ -242,7 +242,7 @@ test(`role members can be made role admins`, (assert) => {
   });
 
   signIn(memberUser, ownerRole);
-  visit(`/roles/${nonOwnerRole.id}/members`);
+  visit(`/organizations/${orgId}/roles/${nonOwnerRole.id}/members`);
 
   andThen(() => {
     assert.equal(member1.privileged, false, 'member is not privileged');
@@ -277,11 +277,11 @@ test(`visiting ${pageUrl} as an unauthorized user to roles does not redirect, bu
   });
 
   signIn(cannotDeleteThis, nonOwnerRole);
-  visit(`/roles/${nonOwnerRole.id}/members`);
+  visit(`/organizations/${orgId}/roles/${nonOwnerRole.id}/members`);
   andThen(() => {
     assert.equal(
       currentPath(),
-      'requires-authorization.enclave.role.members',
+      'requires-authorization.organization.role.members',
       'remains on current path'
     );
 

--- a/tests/acceptance/role/settings-test.js
+++ b/tests/acceptance/role/settings-test.js
@@ -7,10 +7,10 @@ import startApp from '../../helpers/start-app';
 // import { stubRequest } from '../../helpers/fake-server';
 
 let application;
-// let orgId = 'o1';
+let orgId = 'o1';
 let roleId = 'r1';
 // let roleName = 'the-role';
-let url = `/roles/${roleId}/members`;
+let url = `/organizations/${orgId}/roles/${roleId}/members`;
 // let apiRoleUrl = `/roles/${roleId}`;
 // let apiRoleUsersUrl = `/roles/${roleId}/users`;
 // let apiUsersUrl = `/organizations/${orgId}/users`;


### PR DESCRIPTION
This PR moves the `role#show` route from being a child of `enclave` to that of `organization`.  The purpose of this is to prevent the `enclave` permission checks to prevent non-platform user's from being able to see the role show page (and invite users).
