### PR TITLE
Enclave and compliance admins should be able to create roles

### DIFF
--- a/app/components/modal-create-role/template.hbs
+++ b/app/components/modal-create-role/template.hbs
@@ -22,10 +22,12 @@
             </div>
         </div>
 
-        {{#if authorizationContext.organizationHasGridironProduct}}
-          <div class="form-group">
-            {{role-type-options role=newRole}}
-          </div>
+        {{#if authorizationContext.userIsOrganizationAdmin}}
+          {{#if authorizationContext.organizationHasGridironProduct}}
+            <div class="form-group">
+              {{role-type-options role=newRole}}
+            </div>
+          {{/if}}
         {{/if}}
 
         <button class="btn btn-primary create-role" type="submit" {{action "createRole"}} disabled={{disableSave}}>

--- a/app/organization/roles/controller.js
+++ b/app/organization/roles/controller.js
@@ -1,6 +1,3 @@
 import Ember from "ember";
 
-export default Ember.Controller.extend({
-  //newRole: null, // Setting this will open create role modal
-  //authorizationContext: null
-});
+export default Ember.Controller.extend({});

--- a/app/organization/roles/route.js
+++ b/app/organization/roles/route.js
@@ -13,7 +13,13 @@ export default Ember.Route.extend({
     openCreateRoleModal() {
       let authorizationContext = this.modelFor('organization');
       let { organization } = authorizationContext;
-      let role = this.store.createRecord('role', { organization });
+      let type = 'platform_user';
+
+      if (authorizationContext.get('userIsGridironAdmin') && authorizationContext.get('organizationHasGridironProduct')) {
+        type = 'compliance_user';
+      }
+
+      let role = this.store.createRecord('role', { organization, type });
 
       this.controller.set('newRole', role);
     },

--- a/app/organization/roles/template.hbs
+++ b/app/organization/roles/template.hbs
@@ -3,13 +3,11 @@
     <div class="resource-title">
       <h1>{{authorizationContext.organization.name}} Roles</h1>
       <div class="resource-actions pull-right">
-        {{#aptible-ability scope="manage" permittable=authorizationContext.organization as |hasAbility|}}
-          {{#if hasAbility}}
-            <a {{action "openCreateRoleModal"}} class="btn btn-primary open-role-modal">
-              Create Role
-            </a>
-          {{/if}}
-        {{/aptible-ability}}
+        {{#if authorizationContext.userCanCreateNewRoles}}
+          <a {{action "openCreateRoleModal"}} class="btn btn-primary open-role-modal">
+            Create Role
+          </a>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/app/utils/user-organization-context.js
+++ b/app/utils/user-organization-context.js
@@ -81,6 +81,8 @@ export default Ember.Object.extend({
   userIsGridironAdmin: Ember.computed.gt('userGridironAdminRoles.length', 0),
   userIsOrganizationAdmin: Ember.computed.gt('userOrganizationAdminRoles.length', 0),
 
+  userCanCreateNewRoles: Ember.computed.or('userIsOrganizationAdmin', 'userIsGridironAdmin', 'userIsEnclaveAdmin'),
+
   userIsEnclaveOrOrganizationAdmin: Ember.computed.or('userIsEnclaveAdmin', 'userIsOrganizationAdmin'),
   userIsGridironOrOrganizationAdmin: Ember.computed.or('userIsGridironAdmin', 'userIsOrganizationAdmin'),
   userHasEnclaveAccess: Ember.computed.or('userIsEnclaveAdmin', 'userIsEnclaveUser', 'userIsOrganizationAdmin'),


### PR DESCRIPTION
This fixes the missing "Create Role" button and sets an appropriate default role type depending on the user's role.

