### PR TITLE
Show provision_failed status for default VHOSTs

### DIFF
--- a/app/templates/app/-domain.hbs
+++ b/app/templates/app/-domain.hbs
@@ -46,38 +46,38 @@
       {{#if vhost.hasActionRequired}}
         {{vhost-action-required vhost=vhost}}
       {{else}}
-        {{#if vhost.displayHost}}
-          <h5 class="resource-metadata-title">
-            {{#if vhost.internal}}
-              Internal
-            {{else}}
-              External
-            {{/if}}
-
-            Hostname
-          </h5>
+        {{#if vhost.failedToProvision}}
           <h3 class="resource-metadata-value">
-            <div class="external-host">
-              {{vhost.displayHost}}
-              {{click-to-copy text=vhost.displayHost}}
-            </div>
+            <span class="danger failed-warning-message">
+              {{vhost.commonName}} failed to provision,
+              please{{#link-to-aptible app="support" path="topics/cli/how-to-restart-app"}}restart your app via the CLI{{/link-to-aptible}}
+                to access debugging output.
+            </span>
           </h3>
         {{else}}
-          {{#if vhost.failedToProvision}}
+          {{#if vhost.displayHost}}
+            <h5 class="resource-metadata-title">
+              {{#if vhost.internal}}
+                Internal
+              {{else}}
+                External
+              {{/if}}
+
+              Hostname
+            </h5>
             <h3 class="resource-metadata-value">
-              <span class="danger failed-warning-message">
-                {{vhost.commonName}} failed to provision,
-                please{{#link-to-aptible app="support" path="topics/cli/how-to-restart-app"}}restart your app via the CLI{{/link-to-aptible}}
-                to access debugging output.
-              </span>
+              <div class="external-host">
+                {{vhost.displayHost}}
+                {{click-to-copy text=vhost.displayHost}}
+              </div>
             </h3>
           {{else}}
-          <h3 class="resource-metadata-value">
-            {{vhost.commonName}} is {{vhost.status}}...
-          </h3>
+            <h3 class="resource-metadata-value">
+              {{vhost.commonName}} is {{vhost.status}}...
+            </h3>
           {{/if}}
         {{/if}}
       {{/if}}
     </div>
   </div>
-</div>
+ </div>

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -164,6 +164,33 @@ test(`visit ${appVhostsUrl}: failed endpoints should have warning message`, func
   });
 });
 
+test(`visit ${appVhostsUrl}: failed default endpoints should have warning message`, function(assert) {
+  var vhosts = [{
+    id: 1,
+    virtual_domain: 'www.health1.io',
+    default: true,
+    status: 'provision_failed'
+  }];
+
+  stubApp({
+    id: appId,
+    _embedded: { services: [] },
+    _links: { vhosts: { href: appVhostsApiUrl } }
+  });
+
+  stubRequest('get', appVhostsApiUrl, function(){
+    return this.success({ _embedded: { vhosts: vhosts } });
+  });
+
+  signInAndVisit(appVhostsUrl);
+  andThen(() => {
+    let vhosts = find('.vhost');
+    assert.equal(vhosts.length, 1, 'shows the failed vhost');
+    let vhost = vhosts.eq(0);
+    assert.equal(vhost.find('.failed-warning-message:contains(failed to provision)').length, 1, 'has failed warning message');
+  });
+});
+
 test(`visit ${appVhostsUrl} lists endpoints with action required with tips`, function(assert) {
   assert.expect(15);
 


### PR DESCRIPTION
Default VHOSTs can fail to provision too (!), and we'd want to show the
error message in this case.

cc @blakepettersson @fancyremarker @sandersonet 