### PR TITLE
Remove commented-out bits in crossdomain.xml

### DIFF
--- a/public/crossdomain.xml
+++ b/public/crossdomain.xml
@@ -2,14 +2,5 @@
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
   <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
-
-  <!-- Most restrictive policy: -->
   <site-control permitted-cross-domain-policies="none"/>
-
-  <!-- Least restrictive policy: -->
-  <!--
-  <site-control permitted-cross-domain-policies="all"/>
-  <allow-access-from domain="*" to-ports="*" secure="false"/>
-  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-  -->
 </cross-domain-policy>


### PR DESCRIPTION
We've received two invalid reports on security@aptible.com about this
file.

In both cases, the reporter probably ran some form of basic automated
scanning (or manual review) and didn't realize the vulnerable bits of
the policy are commented out.

While it doesn't make any functional difference, we might as well remove
out the commented out bits here to avoid receiving further invalid
reports.

--

cc @fancyremarker @sandersonet 