### PR TITLE
Reload app on invitation accept

### DIFF
--- a/app/claim/route.js
+++ b/app/claim/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Location from "diesel/utils/location";
 
 export default Ember.Route.extend({
   model(params){
@@ -38,7 +39,7 @@ export default Ember.Route.extend({
       });
 
       verification.save().then( () => {
-        this.replaceWith('enclave.index');
+        return Location.replaceAndWait('/');
       }, () => {
         this.controllerFor('claim').set('error', `
           There was an error accepting this invitation. Perhaps

--- a/tests/acceptance/claim-test.js
+++ b/tests/acceptance/claim-test.js
@@ -105,7 +105,7 @@ test(`visiting ${url} as unauthenticated revisits after log in`, function(assert
   clickButton('Accept invitation');
 
   andThen(function(){
-    assert.equal(currentPath(), 'requires-authorization.enclave.stack.apps.index');
+    expectReplacedLocation('/');
   });
 });
 
@@ -147,7 +147,7 @@ test(`visiting ${url} as authenticated creates verification`, function(assert) {
   signInAndVisit(url);
   clickButton('Accept invitation');
   andThen(function(){
-    assert.equal(currentPath(), 'requires-authorization.enclave.stack.apps.index');
+    expectReplacedLocation('/');
   });
 });
 


### PR DESCRIPTION
We cache organization permissions when loading the authorization
service, but when accepting an invitation, the user's permissions are
going to change.

We'd need to either invalidate the cached permissions, or invalidate
everything. This patch does the latter in the interest of un-breaking
accepting invitations, but the former might be a much cleaner approach.

--

cc @sandersonet @fancyremarker - as explained in Slack, I'm going to roll this out to un-break accepting invitations. I'm totally fine with reverting this or replacing it with a better fix.