### PR TITLE
Fix minor typo on create certificate modal

### DIFF
--- a/app/components/modal-create-certificate/template.hbs
+++ b/app/components/modal-create-certificate/template.hbs
@@ -19,7 +19,7 @@
           </p>
           <p>
             If you have a bundled certificate chain, drag and drop all of the
-            certificate files or paste their contents in the textarea below.4
+            certificate files or paste their contents in the textarea below
           </p>
           {{file-textarea value=newCertificate.certificateBody name="body" rows=10 autofocus=true}}
         </div>


### PR DESCRIPTION
The certificate creation modal had a random `4` at the end of a sentence which has now been removed.