### PR TITLE
Fix broken feature reference

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -160,9 +160,6 @@ module.exports = function(environment) {
 
   if (environment === 'staging') {
     ENV.segmentioKey = '6jZlAcweTojgXShBvn4B9Tvwr1IlqkEE';
-
-    ENV.featureFlags['spd'] = false;
-
     ENV.sentry.whitelistUrls = ['dashboard.aptible-staging.com'];
     ENV.sentry.development = false;
     var stagingHosts = ['api.aptible-staging.com', 'auth.aptible-staging.com',
@@ -174,9 +171,6 @@ module.exports = function(environment) {
   if (environment === 'production') {
     ENV.stripePublishableKey = 'pk_live_ujeTeUIMpUcvNsWwu7R9b3Zy';
     ENV.segmentioKey = '5aOlxMYapu6bQCQYFbDz7rhNvVV7B1A5';
-    ENV.featureFlags['sheriff'] = true;
-    ENV.featureFlags['spd'] = false;
-    ENV.featureFlags.engines.risk = false;
     ENV.sentry.whitelistUrls = ['dashboard.aptible.com'];
     ENV.sentry.development = false;
     ENV.sentry.dsn = 'https://2dc5b29fd35e408cbadf581f9a167074@app.getsentry.com/22629';


### PR DESCRIPTION
When adding organization-specific feature flags, I missed cleaning up other environment feature flags.  This caused the build to break for production.