### PR TITLE
Certificates: Create -> Upload

### DIFF
--- a/app/certificates/route.js
+++ b/app/certificates/route.js
@@ -17,7 +17,7 @@ export default Ember.Route.extend({
   },
 
   actions: {
-    openCreateCertificateModal() {
+    openUploadCertificateModal() {
       let stack = this.modelFor('stack');
       this.controller.set('newCertificate', this.store.createRecord('certificate', { stack }));
     },

--- a/app/certificates/template.hbs
+++ b/app/certificates/template.hbs
@@ -7,15 +7,15 @@
           {{#if hasAbility}}
             {{#if session.currentUser.verified}}
               <div class="call-to-action">
-                <a {{action 'openCreateCertificateModal'}} class="btn btn-primary open-certificate-modal">
-                  Create Certificate
+                <a {{action 'openUploadCertificateModal'}} class="btn btn-primary open-certificate-modal">
+                  Upload Certificate
                 </a>
               </div>
             {{/if}}
           {{else}}
             <div class="call-to-action">
-              <a disabled=true class="btn btn-primary disabled">Create Certificate</a>
-              {{#bs-tooltip title="You do not have permission to create certificates for this environment"}}
+              <a disabled=true class="btn btn-primary disabled">Upload Certificate</a>
+              {{#bs-tooltip title="You do not have permission to upload certificates for this environment"}}
                 <i class="fa fa-question-circle"></i>
               {{/bs-tooltip}}
             </div>
@@ -41,13 +41,13 @@
     {{#aptible-ability scope="manage" permittable=stack as |hasAbility|}}
       {{#if hasAbility}}
         {{#if session.currentUser.verified}}
-          <a {{action 'openCreateCertificateModal'}} class="btn btn-primary open-certificate-modal">
-            Create Certificate
+          <a {{action 'openUploadCertificateModal'}} class="btn btn-primary open-certificate-modal">
+            Upload Certificate
           </a>
         {{/if}}
       {{else}}
-        <a disabled=true class="btn btn-primary">Create Certificate</a>
-        {{#bs-tooltip title="You do not have permission to create certificates for this environment"}}
+        <a disabled=true class="btn btn-primary">Upload Certificate</a>
+        {{#bs-tooltip title="You do not have permission to upload certificates for this environment"}}
           <i class="fa fa-question-circle"></i>
         {{/bs-tooltip}}
       {{/if}}

--- a/tests/acceptance/certificates/basic-test.js
+++ b/tests/acceptance/certificates/basic-test.js
@@ -31,7 +31,7 @@ test(`visiting ${url} requires authentication`, function() {
   expectRequiresAuthentication(url);
 });
 
-test(`visiting ${url} with no certificates shows create message`, function(assert) {
+test(`visiting ${url} with no certificates shows upload message`, function(assert) {
   stubRequest('get', '/accounts/my-stack-1/certificates', function(){
     return this.success({
       _links: {},
@@ -56,7 +56,7 @@ test(`visiting ${url} with no certificates shows create message`, function(asser
   andThen(function(){
     assert.equal(currentPath(), 'requires-authorization.enclave.stack.certificates.index');
     assert.equal(find('.activate-notice:contains(has no certificates)').length, 1, 'shows notice of no certificates');
-    assert.equal(find('.open-certificate-modal:contains(Create Certificate)').length, 1, 'Shows create certificate button');
+    assert.equal(find('.open-certificate-modal:contains(Upload Certificate)').length, 1, 'Shows upload certificate button');
   });
 });
 


### PR DESCRIPTION
The copy for uploading a certificate suggests you can create a new
certificate via Aptible, which could be misunderstood as signing a CSR
and returning a Certificate.

While the copy is technically accurate (we create a certificate record
in API), it's a little confusing, since you need to already have created
the certificate somewhere else to be able to use in on Aptible.

--

cc @sandersonet @fancyremarker 