### PR TITLE
Show certificate fingerprint

### DIFF
--- a/app/models/certificate.js
+++ b/app/models/certificate.js
@@ -2,6 +2,8 @@ import DS from 'ember-data';
 import Ember from 'ember';
 import { formatUtcTimestamp } from '../helpers/format-utc-timestamp';
 
+const FINGERPRINT_DISPLAY_SIZE = 7;
+
 export default DS.Model.extend({
   // properties
   certificateBody: DS.attr('string'),
@@ -19,6 +21,7 @@ export default DS.Model.extend({
   notBefore: DS.attr('iso-8601-timestamp'),
   notAfter: DS.attr('iso-8601-timestamp'),
   isAcme: DS.attr('boolean'),
+  sha256Fingerprint: DS.attr('string'),
 
   // relationships
   stack: DS.belongsTo('stack', {async: true}),
@@ -27,12 +30,35 @@ export default DS.Model.extend({
   apps: DS.hasMany('app', {async:true}),
 
   inUse: Ember.computed.gt('vhosts.length', 0),
-  name: Ember.computed('commonName', 'notBefore', 'notAfter', 'issuerOrganization', function() {
-    const cn = this.get('commonName');
-    const startDate = formatUtcTimestamp(this.get('notBefore'), true);
-    const expiry = formatUtcTimestamp(this.get('notAfter'), true);
-    const organization = this.get('issuerOrganization');
 
-    return `${cn} - Valid: ${startDate}-${expiry} - Issued by: ${organization}`;
+  name: Ember.computed('commonName', 'notBefore', 'notAfter', 'issuerDisplayName', 'shortDisplayFingerprint', function() {
+    const bits = [this.get("commonName")];
+
+    const notBefore = this.get('notBefore');
+    const notAfter = this.get('notAfter');
+    if (notBefore && notAfter) {
+      bits.push(`Valid: ${formatUtcTimestamp(notBefore, true)} - ${formatUtcTimestamp(notAfter, true)}`);
+    }
+
+    const issuerDisplayName = this.get("issuerDisplayName");
+    if (issuerDisplayName) {
+      bits.push(issuerDisplayName);
+    }
+
+    const fingerprint = this.get("shortDisplayFingerprint");
+    if (fingerprint) {
+      bits.push(fingerprint);
+    }
+
+    return bits.join(" - ");
+  }),
+
+  issuerDisplayName: Ember.computed("issuerOrganization", "issuerCommonName", function() {
+    return this.get("issuerOrganization") || this.get("issuerCommonName");
+  }),
+
+  shortDisplayFingerprint: Ember.computed("sha256Fingerprint", function() {
+    const fingerprint = this.get("sha256Fingerprint");
+    return fingerprint && fingerprint.slice(0, FINGERPRINT_DISPLAY_SIZE);
   })
 });

--- a/app/templates/stack/-certificate.hbs
+++ b/app/templates/stack/-certificate.hbs
@@ -38,7 +38,7 @@
         </h3>
       </li>
 
-      <li class="resource-metadata-item vhosts-count">
+      <li class="resource-metadata-item">
         <h5 class="resource-metadata-title">
           Valid
         </h5>
@@ -48,17 +48,31 @@
         </h3>
       </li>
 
-      <li class="resource-metadata-item vhosts-count">
+      <li class="resource-metadata-item">
         <h5 class="resource-metadata-title">
           Issuer
         </h5>
 
         <h3 class="resource-metadata-value">
-          {{#if certificate.issuerWebsite}}
-            <a href="//{{certificate.issuerWebsite}}">{{certificate.issuerOrganization}}</a>
+          {{#if certificate.issuerDisplayName}}
+            {{#if certificate.issuerWebsite}}
+              <a href="//{{certificate.issuerWebsite}}">{{certificate.issuerDisplayName}}</a>
+            {{else}}
+              {{certificate.issuerDisplayName}}
+            {{/if}}
           {{else}}
-            {{certificate.issuerOrganization}}
+            Self-signed certificate
           {{/if}}
+        </h3>
+      </li>
+
+      <li class="resource-metadata-item">
+        <h5 class="resource-metadata-title">
+          Fingerprint
+        </h5>
+
+        <h3 class="resource-metadata-value">
+          {{ certificate.shortDisplayFingerprint }}
         </h3>
       </li>
     </ul>

--- a/tests/acceptance/apps/vhost-edit-test.js
+++ b/tests/acceptance/apps/vhost-edit-test.js
@@ -75,11 +75,11 @@ test(`visit ${url} shows form with certificates`, function(assert) {
           { id: 'cert-1', certificate_body: 'cert_body',
             private_key: 'private_key', common_name: '*.health.io',
             issuer_organization: 'DigiCert', not_before: '2014-10-29T00:00:00.000Z',
-            not_after: '2017-01-21T12:00:00.000Z' },
+            not_after: '2017-01-21T12:00:00.000Z', sha256_fingerprint: '1234567890' },
           { id: 'cert-2', certificate_body: 'cert_body2',
             private_key: 'private_key2', common_name: 'health.io',
             issuer_organization: 'DigiCert', not_before: '2014-10-29T00:00:00.000Z',
-            not_after: '2017-01-21T12:00:00.000Z' }
+            not_after: '2017-01-21T12:00:00.000Z', sha256_fingerprint: 'abcdefabcdef' }
         ]
       }
     });
@@ -103,7 +103,7 @@ test(`visit ${url} shows form with certificates`, function(assert) {
 
     let certificateInput = findInput('certificate');
     assert.ok(certificateInput.length, 'has certificate input');
-    assert.equal(certificateInput.find('option:first').text(), '*.health.io - Valid: October 29, 2014-January 21, 2017 - Issued by: DigiCert');
+    assert.equal(certificateInput.find('option:first').text(), '*.health.io - Valid: October 29, 2014 - January 21, 2017 - DigiCert - 1234567');
     assert.equal(certificateInput.find('option:first').val(), 'cert-1');
 
     assert.ok(!findInput('certificate-body').length, 'has no certificate body field');

--- a/tests/unit/models/certificate-test.js
+++ b/tests/unit/models/certificate-test.js
@@ -86,3 +86,100 @@ test('creating POSTs to correct url', function(assert) {
     }).finally(done);
   });
 });
+
+test("shortDisplayFingerprint truncates the fingerprint", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", {
+    id: 1, sha256Fingerprint: "01d259fa5742122d74ac7b6e48be32ef17ce2cc23abfb62bf02144959e52307f"
+  });
+
+  assert.equal(certificate.get("shortDisplayFingerprint"), "01d259f");
+});
+
+test("shortDisplayFingerprint does not crash if the fingerprint is missing", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", { id: 1 });
+
+  assert.equal(certificate.get("shortDisplayFingerprint"), certificate.get("sha256Fingerprint"));
+});
+
+test("issuerDisplayName defaults to the issuer organization", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", {
+    id: 1, issuerOrganization: "Foo Org", issuerCommonName: "Foo"
+  });
+
+  assert.equal(certificate.get("issuerDisplayName"), "Foo Org");
+});
+
+test("issuerDisplayName falls back to the issuer common name", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", {
+    id: 1, issuerCommonName: "Foo"
+  });
+
+  assert.equal(certificate.get("issuerDisplayName"), "Foo");
+});
+
+test("name shows the Common Name", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", {
+    id: 1, commonName: "foo.com"
+  });
+
+  assert.equal(certificate.get("name"), "foo.com");
+});
+
+test("name shows notBefore and notAfter", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", {
+    id: 1, commonName: "foo.com",
+    notBefore: new Date(Date.UTC(2016, 0, 1)),
+    notAfter: new Date(Date.UTC(2017, 1, 2))
+  });
+
+  assert.equal(certificate.get("name"), "foo.com - Valid: January 1, 2016 - February 2, 2017");
+});
+
+test("name shows issuerDisplayName", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", {
+    id: 1, commonName: "foo.com",
+    notBefore: new Date(Date.UTC(2016, 0, 1)),
+    notAfter: new Date(Date.UTC(2017, 1, 2)),
+    issuerOrganization: "Foo Org"
+  });
+
+  assert.equal(certificate.get("name"),
+    "foo.com - Valid: January 1, 2016 - February 2, 2017 - Foo Org");
+});
+
+test("name shows sha256Fingerprint", function(assert) {
+  assert.expect(1);
+
+  let store = this.store();
+  let certificate = Ember.run(store, "push", "certificate", {
+    id: 1, commonName: "foo.com",
+    notBefore: new Date(Date.UTC(2016, 0, 1)),
+    notAfter: new Date(Date.UTC(2017, 1, 2)),
+    issuerOrganization: "Foo Org",
+    sha256Fingerprint: "1234567890"
+  });
+
+  assert.equal(certificate.get("name"),
+    "foo.com - Valid: January 1, 2016 - February 2, 2017 - Foo Org - 1234567");
+});


### PR DESCRIPTION
If you have multiple certificates with the same hostname and issuer, it
becomes a little difficult to tell which one is which, especially if
they have issue dates that are close.

Fortunately, we do in fact extract the certificate fingerprint in API,
which can be used to easily tell two certificates apart. This change
adds a truncated fingerprint (7 characters, which is what git uses for
truncated fingerprints too - it's not like we're relying on this for
security, just convenience), which is shown on the certificates list
page and the selector.

I also updated the list page to explain why some certs have no issuer
(they're self-signed), and to fallback to issuerCommonName if
issuerOrganization is missing (the former is guaranteed to be present if
the cert was signed by a CA, the latter is not).

I did have to make the certificate name a little more succinct (remove
some labels), or Chrome wouldn't always show the fingerprint if the
option label was too large in the cert picker.
## 

Some screenshots:

![image](https://cloud.githubusercontent.com/assets/1737686/19724389/2a8e5066-9b80-11e6-8703-d9579299814e.png)

![image](https://cloud.githubusercontent.com/assets/1737686/19724421/50c6270e-9b80-11e6-998f-78bc16afb35e.png)

cc @fancyremarker @sandersonet @gib 
