### PR TITLE
Only allow ELBs on v2 😢

### DIFF
--- a/app/app/vhosts/new/route.js
+++ b/app/app/vhosts/new/route.js
@@ -7,8 +7,8 @@ export default Ember.Route.extend({
   },
 
   model() {
-    var app = this.modelFor('app');
-    var stack = app.get('stack');
+    const app = this.modelFor('app');
+    const stack = app.get('stack');
 
     return Ember.RSVP.hash({
       vhost: this.store.createRecord('vhost', { app }),

--- a/app/components/create-vhost/component.js
+++ b/app/components/create-vhost/component.js
@@ -65,6 +65,11 @@ export default Ember.Component.extend({
     if (this.get("defaultVhostAllowed")) { defaultVhostType = VHOST_TYPE_DEFAULT; }
     this.set('vhostType', defaultVhostType);
 
+    // Prefer ALBs
+    let defaultVhostPlatform = "elb";
+    if (this.get("albVhostAllowed")) { defaultVhostPlatform = "alb"; }
+    this.set("model.platform", defaultVhostPlatform);
+
     // The observer won't run automatically, so we force it now.
     this.vhostTypeObserver();
   },
@@ -82,7 +87,8 @@ export default Ember.Component.extend({
     }));
   }),
 
-  acmeVhostAllowed: Ember.computed.equal('vhostService.stack.sweetnessStackVersion', 'v2'),
+  acmeVhostAllowed: Ember.computed.alias('vhostService.stack.isV2'),
+  albVhostAllowed: Ember.computed.alias('vhostService.stack.isV2'),
 
   formValid: Ember.computed("vhostType", "userDomainValid", function() {
     if (this.get("isAcme")) {

--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -157,22 +157,26 @@
               Endpoint Platform:
               {{more-info-icon-endpoint-platform title="Choosing an Endpoint Platform"}}
             </label>
-            ALB is strongly recommended,
-            {{#link-to-aptible app="support" path="topics/paas/upgrading-to-alb-endpoints"}}
-              visit Aptible support for more information.
-            {{/link-to-aptible}}
-            <div class="radio">
-              <div>
-                {{#radio-button value='alb' groupValue=model.platform name="vhost-platform"}}
-                  ALB
-                {{/radio-button}}
+            {{#if albVhostAllowed}}
+              ALB is strongly recommended,
+              {{#link-to-aptible app="support" path="topics/paas/upgrading-to-alb-endpoints"}}
+                visit Aptible support for more information.
+              {{/link-to-aptible}}
+              <div class="radio">
+                <div>
+                  {{#radio-button value='alb' groupValue=model.platform name="vhost-platform"}}
+                    ALB
+                  {{/radio-button}}
+                </div>
+                <div>
+                  {{#radio-button value='elb' groupValue=model.platform name="vhost-platform" }}
+                    ELB <span class="text-muted">deprecated</span>
+                  {{/radio-button}}
+                </div>
               </div>
-              <div>
-                {{#radio-button value='elb' groupValue=model.platform name="vhost-platform" }}
-                  ELB <span class="text-muted">deprecated</span>
-                {{/radio-button}}
-              </div>
-            </div>
+            {{else}}
+                Only ELB Endpoints are available on Aptible legacy infrastructure.
+            {{/if}}
           </div>
         </div>
       </div>

--- a/app/components/modal-upgrade-to-alb/component.js
+++ b/app/components/modal-upgrade-to-alb/component.js
@@ -18,6 +18,10 @@ export default Ember.Component.extend({
       }
     },
 
+    onDismiss() {
+      this.sendAction('dismiss');
+    },
+
     outsideClick: Ember.K
   }
 });

--- a/app/components/more-info-icon-endpoint-platform/template.hbs
+++ b/app/components/more-info-icon-endpoint-platform/template.hbs
@@ -2,12 +2,13 @@
   title=title
   bs-html=true
   body="
-  The Endpoint Platform is the underlying AWS resource
-  Aptible uses to expose your Endpoint.
+  The Endpoint Platform is the underlying AWS resource Aptible uses to expose
+  your Endpoint.
   <br><br>
-  ALB Endpoints provide better guarantees that your App will
-  remain available if something goes wrong with a deployment,
-  whereas ELB Endpoints can occasionally cause downtime.
+  ALB Endpoints provide better guarantees that your App will remain available
+  if something goes wrong with a deployment, whereas ELB Endpoints can
+  occasionally cause downtime.
   <br><br>
-  ALBs are the default for new Endpoints. You can upgrade an
-  Endpoint from ELB to ALB without downtime."}}
+  Except on Aptible legacy infrastructure where they are not available, ALBs
+  are the default for new Endpoints, and you can upgrade an Endpoint from ELB
+  to ALB without downtime."}}

--- a/app/models/stack.js
+++ b/app/models/stack.js
@@ -52,6 +52,8 @@ export default DS.Model.extend({
   appUsage: Ember.computed.mapBy('apps', 'usage'),
   databaseUsage: Ember.computed.mapBy('databases', 'usage'),
   containerUsage: Ember.computed.sum('appUsage', 'databaseUsage'),
+  isV1: Ember.computed.equal('sweetnessStackVersion', 'v1'),
+  isV2: Ember.computed.equal('sweetnessStackVersion', 'v2'),
 
   getUsageByResourceType(type) {
     let usageAttr = { container: 'containerCount', disk: 'totalDiskSize',

--- a/app/models/vhost.js
+++ b/app/models/vhost.js
@@ -14,7 +14,7 @@ export default DS.Model.extend(ProvisionableMixin, {
   userDomain: DS.attr('string'),
   isAcme: DS.attr('boolean', { defaultValue: false }),
   acmeStatus: DS.attr('string'),
-  platform: DS.attr('string', { defaultValue: 'alb' }),
+  platform: DS.attr('string'),
 
   certificate: DS.belongsTo('certificate', { async: true }),
   service: DS.belongsTo('service', {async:true}),

--- a/app/templates/app/-domain.hbs
+++ b/app/templates/app/-domain.hbs
@@ -87,8 +87,10 @@
             <h3 class="resource-metadata-value endpoint-platform">
               {{ vhost.platform }}
 
-              {{#if vhost.isElb}}
-                - <a href="#" {{action "openUpgradeVhostModal" vhost}}>Upgrade</a>
+              {{#if vhost.service.app.stack.isV2}}
+                {{#if vhost.isElb}}
+                  - <a href="#" {{action "openUpgradeVhostModal" vhost}}>Upgrade</a>
+                {{/if}}
               {{/if}}
             </h3>
           </li>


### PR DESCRIPTION
Unfortunately, legacy stacks can't support ALBs unless we add a second
public subnet (without any instances in it). Considering these stacks
are in maintenance mode at this point, it's preferable to just disallow
this option rather than make last minute changes (also, in practice,
ELBs aren't as bad there as they are on v2).

---

(It's regrettable I didn't catch this before, but our only v1 test stack is a bastardized v2 turned v1 stack... which had multiple subnets 👎)

cc @fancyremarker @sandersonet 