### PR TITLE
Allow updating and deleting a failed Endpoint

### DIFF
--- a/app/app/vhosts/edit/template.hbs
+++ b/app/app/vhosts/edit/template.hbs
@@ -6,6 +6,17 @@
       </div>
       <div class="panel-body">
         <form role="form">
+          {{#unless model.isProvisioned}}
+            {{#bs-alert alert="info"}}
+              <p>
+                This Endpoint is not yet provisioned, <strong>your changes will
+                not be applied automatically</strong>.
+              </p>
+              <p>
+                Use aptible restart after saving to do so manually.
+              </p>
+            {{/bs-alert}}
+          {{/unless}}
           {{#unless model.isValid}}
             {{#bs-alert alert="warning" as |component|}}
              {{#bs-alert-dismiss target=component}}

--- a/app/mixins/models/provisionable.js
+++ b/app/mixins/models/provisionable.js
@@ -61,7 +61,8 @@ export const ProvisionableBaseMixin = Ember.Mixin.create({
   hasFailedDeprovision: computed.equal('status', STATUSES.DEPROVISION_FAILED),
   isPending: computed.equal('status', STATUSES.PENDING),
   hasBeenDeprovisioned: computed.or('isDeprovisioned', 'isDeprovisioning'),
-  hasBeenDeployed: computed.not('isPending')
+  hasBeenDeployed: computed.not('isPending'),
+  isSettled: computed.or("isDeprovisioned", "isProvisioned", "hasFailedProvision", "hasFailedDeprovision"),
 });
 
 export default Ember.Mixin.create({

--- a/app/templates/app/-domain.hbs
+++ b/app/templates/app/-domain.hbs
@@ -20,7 +20,7 @@
 
     <div class="panel-heading-actions">
       {{#if vhost.isGeneric}}
-        {{#if vhost.isProvisioned}}
+        {{#if vhost.isSettled}}
           {{link-to 'Edit' 'app.vhosts.edit' vhost.id class="btn btn-default btn-xs"}}
         {{/if}}
       {{/if}}
@@ -33,7 +33,7 @@
         <span class="label label-success">Managed HTTPS</span>
       {{/if}}
 
-      {{#if vhost.isProvisioned}}
+      {{#if vhost.isSettled}}
         {{delete-vhost vhost=vhost startDeletion="startDeletion"
                                    failDeletion="failDeletion"
                                    completeDeletion="completeDeletion"}}
@@ -49,9 +49,9 @@
         {{#if vhost.failedToProvision}}
           <h3 class="resource-metadata-value">
             <span class="danger failed-warning-message">
-              {{vhost.commonName}} failed to provision,
-              please{{#link-to-aptible app="support" path="topics/cli/how-to-restart-app"}}restart your app via the CLI{{/link-to-aptible}}
-                to access debugging output.
+              {{vhost.commonName}} failed to provision, please
+              {{#link-to-aptible app="support" path="topics/cli/how-to-restart-app"}}restart your app via the CLI{{/link-to-aptible}}
+              to access debugging output.
             </span>
           </h3>
         {{else}}

--- a/tests/acceptance/apps/vhosts-test.js
+++ b/tests/acceptance/apps/vhosts-test.js
@@ -349,8 +349,8 @@ test(`visit ${appVhostsUrl} lists deprovisioned`, function(assert) {
       assert.ok(vhostEl.find(`:contains(${vhost.external_host})`).length,
          `has external host "${vhost.external_host}"`);
 
-      expectNoButton('Edit', {context:vhostEl});
-      expectNoButton('Delete', {context:vhostEl});
+      expectButton('Edit', {context:vhostEl});
+      expectButton('Delete', {context:vhostEl});
     });
   });
 });


### PR DESCRIPTION
We need to allow updating failed Endpoints, because with ALBs customers
must provide a certificate that's within its validity period, or it'll
be rejected when we try to upload it into IAM.

It's probably also a good idea to let customers delete these Endpoints
if they realize they've made a mistake (right now, you can't delete the
Endpoint unless you first get it to succeed provisioning, which can be a
little hard since we now require that the health check passes when
provisioning the Endpoint).

---

cc @fancyremarker @sandersonet 