### PR TITLE
FTUX: Reload DBs after provisioning them

### DIFF
--- a/app/models/database.js
+++ b/app/models/database.js
@@ -51,7 +51,13 @@ export function provisionDatabases(user, store){
         diskSize: database.get('initialDiskSize') || '10',
         database: database
       });
-      return op.save();
+      return op.save().then((op) => {
+        // NOTE: We don't actually return this promise, because the UI should
+        // not block on the provisioning.
+        op.reloadUntilStatusChanged(1000 * 60 * 15 /* minutes */).then(() => {
+          return database.reload();
+        });
+      });
     });
 
     return Ember.RSVP.all(promises);


### PR DESCRIPTION
When a user provisions a DB during FTUX, the UI never reloads the DB
once it's done provisioning. There are presumably other places where
this particular defect exists, but this is one of them, and arguably
it's worth fixing since that's literally the first thing customers see.

I'm not sure if this is something that even has test coverage in here (I
haven't been able to find it), but if that's the case I'm happy to add
some tests. Otherwise, this now has test coverage here:
https://github.com/aptible/aptible-integration/pull/109

---

cc @sandersonet @gib @fancyremarker @blakepettersson