### PR TITLE
Fix edit role member link

### DIFF
--- a/app/components/membership-table-row/template.hbs
+++ b/app/components/membership-table-row/template.hbs
@@ -38,7 +38,7 @@
 {{#if currentUserIsPrivileged}}
   {{#if isOnlyRole}}
     {{#if linkToEditMember}}
-      {{#link-to 'organization.members.edit' organization membership.user classNames='btn btn-default btn-xs'}}
+      {{#link-to 'organization.members.edit' organization.id membership.user.id classNames='btn btn-default btn-xs'}}
         {{#bs-tooltip title=removeTooltip}}
           <i class="glyphicon glyphicon-pencil"></i> Edit
         {{/bs-tooltip}}

--- a/tests/acceptance/role/members-test.js
+++ b/tests/acceptance/role/members-test.js
@@ -136,7 +136,6 @@ test(`visiting ${pageUrl} role members can be added by account owners`, (assert)
 
     clickButton('Add');
   });
-
   andThen(() => {
     findWithAssert('.aptable__member-row');
     assert.equal(find(`.profile--inline:contains(${memberUser.name})`).length,
@@ -178,6 +177,41 @@ test(`visiting ${pageUrl} role members can be removed by account owners`, (asser
   andThen(() => {
     assert.ok(find('.empty-row').text().match(/currently has no members/));
     window.confirm = _confirm;
+  });
+});
+
+test(`visiting ${pageUrl} account owners can get to the edit view for a role members`, (assert) => {
+  memberUser._embedded = { roles: [ nonOwnerRole ] }
+
+  const member1 = {
+    id: 'role-member-1',
+    _embedded: {
+      role: nonOwnerRole,
+      user: memberUser
+    }
+  };
+
+  setUp({
+    role: nonOwnerRole,
+    roleUsers: [ memberUser ],
+    roleMembers: [ member1 ],
+    roleMembersUrl: nonOwnerRole._links.memberships.href
+  });
+
+  signIn(null, ownerRole);
+  visit(`/organizations/${orgId}/roles/${nonOwnerRole.id}/members`);
+
+  pauseTest();
+  andThen(() => {
+    clickButton('Edit');
+  });
+  andThen(() => {
+    assert.equal(find(`.panel-heading:contains(${memberUser.name})`).length,
+      1, 'Renders edit member view.');
+    assert.equal(find(`input[type=checkbox]:checked`).length,
+      1, 'Current role is checked.');
+    assert.equal(find(`label:contains(${nonOwnerRole.name})`).length,
+      1, 'Current role is displayed.');
   });
 });
 

--- a/tests/acceptance/role/members-test.js
+++ b/tests/acceptance/role/members-test.js
@@ -181,7 +181,7 @@ test(`visiting ${pageUrl} role members can be removed by account owners`, (asser
 });
 
 test(`visiting ${pageUrl} account owners can get to the edit view for a role members`, (assert) => {
-  memberUser._embedded = { roles: [ nonOwnerRole ] }
+  memberUser._embedded = { roles: [ nonOwnerRole ] };
 
   const member1 = {
     id: 'role-member-1',
@@ -201,7 +201,6 @@ test(`visiting ${pageUrl} account owners can get to the edit view for a role mem
   signIn(null, ownerRole);
   visit(`/organizations/${orgId}/roles/${nonOwnerRole.id}/members`);
 
-  pauseTest();
   andThen(() => {
     clickButton('Edit');
   });


### PR DESCRIPTION
Red-green refactored, closes #778

This used to go to a blank view. Thanks @mitchlloyd for educating me on this issue earlier this week. Easy fix, test look a while to set up correctly.
![fix-role-member-edit](https://cloud.githubusercontent.com/assets/94830/20231557/ad6aa766-a817-11e6-8393-b2fe8ce4d889.gif)

@sandersonet 