### PR TITLE
New Endpoint: use service process type, not handle

### DIFF
--- a/app/components/create-vhost/template.hbs
+++ b/app/components/create-vhost/template.hbs
@@ -17,7 +17,7 @@
 
             <div class="form-group">
               <label>Service</label>
-              {{ ultimate-select items=services name="service" itemKey="id" itemValue="handle" update=(action (mut vhostService)) selected=vhostService autofocus=true }}
+              {{ ultimate-select items=services name="service" itemKey="id" itemValue="name" update=(action (mut vhostService)) selected=vhostService autofocus=true }}
             </div>
 
               <div class="form-group">

--- a/app/models/service.js
+++ b/app/models/service.js
@@ -25,5 +25,9 @@ export default DS.Model.extend({
 
   usage: Ember.computed('containerCount', 'containerSize', function() {
     return this.get('containerCount') * (this.get('containerSize') / 1024);
+  }),
+
+  name: Ember.computed('processType', 'command', function() {
+    return `${this.get('processType')} - ${this.get('command')}`;
   })
 });


### PR DESCRIPTION
The handle for a service isn't ideal to let users differentiate between
services, mainly because:

- It includes a lot of redundant or useless information (namely, it
  includes the app handle and a random string).
- It is truncated to 32 characters, so it might not even include the
  relevant information (the process type).

This is presumably why we don't use it anywhere in the UI (at least that
I know of), except on the New Endpoint page. This can be a problem,
because it means users sometimes can't tell which service is which.

This patch fixes the issue by instead using the process type and
appending the command (so that it's shown if there is room), which
should make it easier for users to interact with this.

I've also added tests to ensure this selector actually works (which was
a little more involved than I anticipated, since the mocks here were
being created in two different places).

---

cc @sandersonet, for review
cc @fancyremarker, we talked about this last week: https://aptible-support.slack.com/archives/general/p1478811311000983